### PR TITLE
Serialization v2 with v1 backward compatibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Allors Documentation
+
+## Core Concepts
+
+- [Serialization Format](serialization.md) - XML serialization format specification
+
+## Platform Documentation
+
+- [.NET](dotnet/)

--- a/docs/dotnet/README.md
+++ b/docs/dotnet/README.md
@@ -1,0 +1,5 @@
+# .NET Documentation
+
+## Contents
+
+- [Serialization](serialization.md) - Database adapter serialization implementation

--- a/docs/dotnet/serialization.md
+++ b/docs/dotnet/serialization.md
@@ -1,0 +1,259 @@
+# .NET Serialization Implementation
+
+This document describes the .NET implementation of the [Allors serialization format](../serialization.md).
+
+## Overview
+
+The .NET implementation provides serialization support across multiple database adapters:
+
+- **Memory Adapter** (`Allors.Database.Adapters.Memory`): In-memory database storage
+- **SQL Adapters**:
+  - `Allors.Database.Adapters.Sql.SqlClient`: Microsoft SQL Server
+  - `Allors.Database.Adapters.Sql.Npgsql`: PostgreSQL
+  - `Allors.Database.Adapters.Sql`: Shared base implementation
+
+All adapters implement the `IDatabase` interface which defines the `Load(XmlReader)` and `Save(XmlWriter)` methods.
+
+## IDatabase Interface
+
+```csharp
+public interface IDatabase
+{
+    event ObjectNotLoadedEventHandler ObjectNotLoaded;
+    event RelationNotLoadedEventHandler RelationNotLoaded;
+
+    bool IsShared { get; }
+    string Id { get; }
+    IObjectFactory ObjectFactory { get; }
+    IMetaPopulation MetaPopulation { get; }
+    IDatabaseServices Services { get; }
+    ISink Sink { get; set; }
+
+    void Init();
+    ITransaction CreateTransaction();
+    void Load(XmlReader reader);
+    void Save(XmlWriter writer);
+}
+```
+
+## Memory Adapter
+
+**Location**: `System/Database/Adapters/Allors.Database.Adapters.Memory/`
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `Database.cs` | Entry point, implements `IDatabase.Load/Save` |
+| `Transaction.cs` | Manages in-memory object strategies |
+| `Load.cs` | XML deserialization |
+| `Save.cs` | XML serialization |
+| `Strategy.cs` | In-memory object state |
+
+### Save Flow
+
+```
+Transaction.Save(XmlWriter)
+  -> Save class initialization
+    -> SavePopulation()
+      -> SaveObjectType()     // Write objects grouped by type
+      -> SaveRelationType()   // Write relations by role type
+        -> SaveUnit()         // Scalar values
+        -> SaveComposite()    // One-to-one references
+        -> SaveComposites()   // One-to-many references
+```
+
+### Load Flow
+
+```
+Database.Load(XmlReader)
+  -> Load class initialization
+    -> Execute()
+      -> LoadPopulation()
+        -> LoadObjects()
+          -> LoadObjectTypes()
+            -> InsertStrategy()    // Create Strategy in Transaction
+        -> LoadRelations()
+          -> LoadUnitRelations()   -> SetUnitRole()
+          -> LoadCompositeRelations() -> SetCompositeRole()/SetCompositesRole()
+      -> Transaction.Commit()
+```
+
+### In-Memory Storage
+
+The `Strategy` class stores object state:
+
+```csharp
+// Object identity
+long ObjectId;
+long ObjectVersion;
+IClass Class;
+
+// Role storage
+Dictionary<IRoleType, object> unitRoleByRoleType;           // Scalar values
+Dictionary<IRoleType, Strategy> compositeRoleByRoleType;    // One-to-one refs
+Dictionary<IRoleType, HashSet<Strategy>> compositesRoleByRoleType;  // One-to-many refs
+```
+
+## SQL Adapters
+
+**Base**: `System/Database/Adapters/Allors.Database.Adapters.Sql/`
+**SqlClient**: `System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/`
+**Npgsql**: `System/Database/Adapters/Allors.Database.Adapters.Sql.Npgsql/`
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `Database.cs` | Database implementation, abstract in Sql/ |
+| `Serialization/Load.cs` | XML to SQL bulk insert |
+| `Serialization/Save.cs` | SQL query to XML |
+| `Serialization/RelationTypeOneXmlWriter.cs` | One-to-one relation writer |
+| `Serialization/RelationTypeManyXmlWriter.cs` | One-to-many relation writer |
+
+### Save Flow (SQL -> XML)
+
+```
+Database.Save(XmlWriter)
+  -> Save class initialization
+    -> Execute(ManagementTransaction)
+      -> SaveObjects()        // Query objects table, write XML
+      -> SaveRelations()      // Query relation tables, write XML
+        -> Unit roles: Query class tables
+        -> Composite one-to-one: Query using foreign keys
+        -> Composite many: Query dedicated relation tables
+```
+
+### Load Flow (XML -> SQL)
+
+```
+Database.Load(XmlReader)
+  -> Load class initialization
+    -> Execute(XmlReader)
+      -> LoadObjects()
+        -> Enumerate XML using Objects class
+        -> Format data using LoadObjectsReader
+        -> Bulk insert using SqlBulkCopy or Npgsql COPY
+      -> LoadRelations()
+        -> LoadUnitRelations()      // Insert into class tables
+        -> LoadCompositeRelations() // Insert into relation/FK columns
+```
+
+### Bulk Operations
+
+SQL adapters use database-specific bulk copy operations for performance:
+
+- **SqlClient**: `SqlBulkCopy`
+- **Npgsql**: PostgreSQL COPY protocol
+
+## Adapter Comparison
+
+| Aspect | Memory | SQL |
+|--------|--------|-----|
+| Storage | In-memory dictionaries | SQL database |
+| Load | Direct object instantiation | Bulk SQL insert |
+| Save | Iterate strategies | Query database |
+| Persistence | Only when saved to XML | Database persistent |
+| Best for | Testing, small datasets | Production, large datasets |
+| Concurrency | Single-threaded transactions | Database-level concurrency |
+
+## Error Handling
+
+Serialization uses event-based error handling for missing objects/relations:
+
+```csharp
+public event ObjectNotLoadedEventHandler ObjectNotLoaded;
+public event RelationNotLoadedEventHandler RelationNotLoaded;
+```
+
+Failure scenarios:
+- Unknown object type ID
+- Unknown relation type ID
+- Invalid object references
+- Type mismatches
+- Multiplicity violations
+
+If no handler is registered, an exception is thrown.
+
+## Backup and Restore
+
+### Backup (Save)
+
+```csharp
+using var stringWriter = new StringWriter();
+using var writer = XmlWriter.Create(stringWriter);
+database.Save(writer);
+var xml = stringWriter.ToString();
+```
+
+### Restore (Load)
+
+```csharp
+database.Init();  // Clear existing data
+using var reader = XmlReader.Create(new StringReader(xml));
+database.Load(reader);
+```
+
+## Version Handling
+
+Version checking is implemented in `Serialization.cs`:
+
+```csharp
+public static void CheckVersion(int version)
+{
+    if (version != 1 && version != 2)
+    {
+        throw new ArgumentException(
+            $"Database supports version 1 and 2 but found version {version}");
+    }
+}
+```
+
+## Schema Classes
+
+Located in `Allors.Database.Adapters/Schema/`:
+
+| Class | Purpose |
+|-------|---------|
+| `Xml.cs` | Root `<allors>` element |
+| `Population.cs` | `<population>` container |
+| `Objects.cs` | `<objects>` collection |
+| `ObjectType.cs` | `<ot>` element |
+| `Relations.cs` | `<relations>` collection |
+| `RelationTypeUnit.cs` | `<rtu>` element |
+| `RelationTypeComposite.cs` | `<rtc>` element |
+| `Relation.cs` | `<r>` element |
+
+These use .NET `[Xml*]` attributes for XML serialization structure definition.
+
+## Unit Type Mapping
+
+| Tag | Type | .NET Type | Encoding |
+|-----|------|-----------|----------|
+| `1` | Binary | `byte[]` | Base64 |
+| `2` | Boolean | `bool` | `true`/`false` |
+| `3` | DateTime | `DateTime` | ISO 8601 UTC via `XmlConvert` |
+| `4` | Decimal | `decimal` | XML decimal via `XmlConvert` |
+| `5` | Float | `double` | XML double via `XmlConvert` |
+| `6` | Integer | `int` | XML integer via `XmlConvert` |
+| `7` | String | `string` | v1: Plain text, v2: Base64 (UTF-8) |
+| `8` | Unique | `Guid` | Standard GUID string |
+
+## Upgrading from v1 to v2
+
+To upgrade a v1 backup to v2 format:
+
+```csharp
+// Load v1 backup (plain text strings)
+using var reader = XmlReader.Create("backup-v1.xml");
+database.Load(reader);
+
+// Save as v2 (base64 encoded strings)
+using var writer = XmlWriter.Create("backup-v2.xml");
+database.Save(writer);
+```
+
+This produces a v2 backup file that benefits from:
+- Consistent encoding for all string values
+- Safe handling of special XML characters
+- Binary-safe string representation

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,0 +1,185 @@
+# Allors Serialization Format
+
+This document describes the XML serialization format used by the Allors framework for database persistence.
+
+## Overview
+
+Allors uses an XML-based serialization format that enables:
+
+- Backup and restore of database state
+- Data migration between different storage adapters
+- Cross-platform data exchange
+- Version upgrades from older formats
+
+## XML Schema
+
+### Document Structure
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<allors version="2">
+  <population version="2">
+    <objects>
+      <database>
+        <ot i="[ObjectTypeId]">objectId1:version1,objectId2:version2</ot>
+      </database>
+    </objects>
+    <relations>
+      <database>
+        <rtu i="[RelationTypeId]">
+          <r a="[AssociationId]">[value]</r>
+        </rtu>
+        <rtc i="[RelationTypeId]">
+          <r a="[AssociationId]">[roleId1,roleId2]</r>
+        </rtc>
+      </database>
+    </relations>
+  </population>
+</allors>
+```
+
+### XML Elements
+
+| Element | Attribute | Description |
+|---------|-----------|-------------|
+| `allors` | `version` | Root element, schema version (1 or 2) |
+| `population` | `version` | Container for objects and relations |
+| `objects` | | Container for all object types |
+| `database` | | Database-scoped data (vs. workspace) |
+| `ot` | `i` (id) | ObjectType - groups objects of same type |
+| `relations` | | Container for all relations |
+| `rtu` | `i` (id) | RelationType Unit - scalar property values |
+| `rtc` | `i` (id) | RelationType Composite - object references |
+| `r` | `a` (association) | Individual relation value |
+| `x` | | No relation marker (empty composite) |
+
+### Object Format
+
+Objects are serialized within `<ot>` elements, grouped by ObjectType:
+
+```xml
+<ot i="a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6">1:1,2:1,3:2</ot>
+```
+
+- The `i` attribute is the ObjectType GUID
+- Content format: `objectId:objectVersion` pairs separated by commas
+- Object IDs are long integers
+- Object versions are long integers (for optimistic concurrency)
+
+### Relation Format
+
+**Unit Relations** (`<rtu>`) store scalar values:
+
+```xml
+<rtu i="12345678-1234-1234-1234-123456789abc">
+  <r a="1">SGVsbG8gV29ybGQ=</r>
+  <r a="2">42</r>
+</rtu>
+```
+
+**Composite Relations** (`<rtc>`) store object references:
+
+```xml
+<rtc i="87654321-4321-4321-4321-987654321fed">
+  <r a="1">10</r>
+  <r a="2">10,11,12</r>
+</rtc>
+```
+
+- The `i` attribute is the RelationType GUID
+- The `a` attribute is the association object ID
+- Content is the role value(s), comma-separated for many-to-many
+
+## Data Encoding
+
+### Unit Types
+
+| Tag | Type | Encoding |
+|-----|------|----------|
+| `1` | Binary | Base64 |
+| `2` | Boolean | `true`/`false` |
+| `3` | DateTime | ISO 8601 UTC |
+| `4` | Decimal | XML decimal |
+| `5` | Float | XML double |
+| `6` | Integer | XML integer |
+| `7` | String | v1: Plain text, v2: Base64 (UTF-8) |
+| `8` | Unique | Standard GUID string |
+
+### Delimiters
+
+| Delimiter | Purpose |
+|-----------|---------|
+| `:` | Separates objectId from objectVersion |
+| `,` | Separates multiple objects or role values |
+
+## Version Management
+
+### Schema Versions
+
+The serialization format supports two schema versions:
+
+| Version | String Encoding | Status |
+|---------|-----------------|--------|
+| 1 | Plain text | Legacy (load only) |
+| 2 | Base64 encoded (UTF-8) | Current (save/load) |
+
+- **Save** always outputs version 2
+- **Load** accepts both version 1 and version 2
+
+### String Encoding by Version
+
+**Version 1** (legacy):
+```xml
+<r a="1">Hello World</r>
+```
+
+**Version 2** (current):
+```xml
+<r a="1">SGVsbG8gV29ybGQ=</r>  <!-- "Hello World" base64 encoded -->
+```
+
+### Object Version
+
+Per-object version numbers are used for optimistic concurrency. These are separate from the schema version and are stored in the `objectId:objectVersion` format.
+
+## Example XML Output
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<allors version="2">
+  <population version="2">
+    <objects>
+      <database>
+        <ot i="a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6">1:1,2:1,3:1</ot>
+        <ot i="f1e2d3c4-b5a6-4978-a6b5-c4d3e2f1a0b9">10:1</ot>
+      </database>
+    </objects>
+    <relations>
+      <database>
+        <rtu i="12345678-1234-1234-1234-123456789abc">
+          <r a="1">SGVsbG8gV29ybGQ=</r>
+          <r a="2">VGVzdCBTdHJpbmc=</r>
+        </rtu>
+        <rtc i="87654321-4321-4321-4321-987654321fed">
+          <r a="1">10</r>
+          <r a="2">10,11</r>
+          <r a="3">11,12,13</r>
+        </rtc>
+      </database>
+    </relations>
+  </population>
+</allors>
+```
+
+## Use Cases
+
+- **Data Migration**: Move data between different storage adapters
+- **Backup/Restore**: Create complete database snapshots
+- **Testing**: Load/save test fixtures
+- **Portability**: XML format independent of storage technology
+- **Interoperability**: All adapters use the same XML schema
+- **Version Upgrades**: Migrate data from older serialization formats
+
+## Platform Implementations
+
+- [.NET Implementation](dotnet/serialization.md)

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/Profile.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/Profile.cs
@@ -35,5 +35,8 @@ namespace Allors.Database.Adapters.Memory
         }
 
         public override IDatabase CreateDatabase() => this.CreateMemoryDatabase();
+
+        public IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+            => this.CreateMemoryDatabaseWithVersion1Mode(mode);
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/SerializationTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/SerializationTest.cs
@@ -8,7 +8,7 @@ namespace Allors.Database.Adapters.Memory
     using System;
     using Adapters;
 
-    public class ObsoleteSerializationTest : Adapters.ObsoleteSerializationTest, IDisposable
+    public class SerializationTest : Adapters.SerializationTest, IDisposable
     {
         private readonly Profile profile = new Profile();
 
@@ -17,5 +17,8 @@ namespace Allors.Database.Adapters.Memory
         public override void Dispose() => this.profile.Dispose();
 
         protected override IDatabase CreatePopulation() => this.profile.CreateMemoryDatabase();
+
+        protected override IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+            => this.profile.CreateDatabaseWithVersion1Mode(mode);
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Profile.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Profile.cs
@@ -61,6 +61,17 @@ namespace Allors.Database.Adapters
             });
         }
 
+        public IDatabase CreateMemoryDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+        {
+            var metaPopulation = new MetaBuilder().Build();
+            var scope = new DefaultDomainDatabaseServices();
+            return new Database(scope, new Memory.Configuration
+            {
+                ObjectFactory = new ObjectFactory(metaPopulation, typeof(C1)),
+                SerializationVersion1Mode = mode,
+            });
+        }
+
         public abstract IDatabase CreateDatabase();
 
         internal ITransaction CreateTransaction() => this.Database.CreateTransaction();

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/Profile.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/Profile.cs
@@ -207,5 +207,19 @@ AND data_type = 'uuid'";
         }
 
         private NpgsqlConnection CreateConnection() => new NpgsqlConnection(this.ConnectionString);
+
+        public IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+        {
+            var metaPopulation = new MetaBuilder().Build();
+            var scope = new DefaultDomainDatabaseServices();
+            return new Database(scope, new Configuration
+            {
+                ObjectFactory = new ObjectFactory(metaPopulation, typeof(C1)),
+                ConnectionString = this.ConnectionString,
+                ConnectionFactory = this.connectionFactory,
+                CacheFactory = this.cacheFactory,
+                SerializationVersion1Mode = mode,
+            });
+        }
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/SerializationTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/SerializationTest.cs
@@ -8,16 +8,19 @@ namespace Allors.Database.Adapters.Sql.Npgsql
     using Xunit;
     using Adapters;
 
-    public class ObsoleteSerializationTest : Adapters.ObsoleteSerializationTest, IClassFixture<Fixture<ObsoleteSerializationTest>>
+    public class SerializationTest : Adapters.SerializationTest, IClassFixture<Fixture<SerializationTest>>
     {
         private readonly Profile profile;
 
-        public ObsoleteSerializationTest() => this.profile = new Profile(this.GetType().Name);
+        public SerializationTest() => this.profile = new Profile(this.GetType().Name);
 
         protected override IProfile Profile => this.profile;
 
         public override void Dispose() => this.profile.Dispose();
 
         protected override IDatabase CreatePopulation() => this.profile.CreateMemoryDatabase();
+
+        protected override IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+            => this.profile.CreateDatabaseWithVersion1Mode(mode);
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Profile.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Profile.cs
@@ -275,5 +275,19 @@ AND column_name=@columnName";
                 }
             }
         }
+
+        public IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+        {
+            var metaPopulation = new MetaBuilder().Build();
+            var scope = new DefaultDomainDatabaseServices();
+            return new Database(scope, new Sql.Configuration
+            {
+                ObjectFactory = new ObjectFactory(metaPopulation, typeof(C1)),
+                ConnectionString = this.ConnectionString,
+                ConnectionFactory = this.connectionFactory,
+                CacheFactory = this.cacheFactory,
+                SerializationVersion1Mode = mode,
+            });
+        }
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/SerializationTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/SerializationTest.cs
@@ -8,16 +8,19 @@ namespace Allors.Database.Adapters.Sql.SqlClient
     using Adapters;
     using Xunit;
 
-    public class ObsoleteSerializationTest : Adapters.ObsoleteSerializationTest, IClassFixture<Fixture<ObsoleteSerializationTest>>
+    public class SerializationTest : Adapters.SerializationTest, IClassFixture<Fixture<SerializationTest>>
     {
         private readonly Profile profile;
 
-        public ObsoleteSerializationTest() => this.profile = new Profile(this.GetType().Name);
+        public SerializationTest() => this.profile = new Profile(this.GetType().Name);
 
         protected override IProfile Profile => this.profile;
 
         public override void Dispose() => this.profile.Dispose();
 
         protected override IDatabase CreatePopulation() => this.profile.CreateMemoryDatabase();
+
+        protected override IDatabase CreateDatabaseWithVersion1Mode(SerializationVersion1Mode mode)
+            => this.profile.CreateDatabaseWithVersion1Mode(mode);
     }
 }


### PR DESCRIPTION
Summary

  This PR introduces serialization format version 2 with base64-encoded strings and adds backward compatibility support for version 1 files.

  Key Changes

  Serialization v2 Format:
  - Strings are now base64 encoded (UTF-8) to safely handle all byte sequences
  - Solves issues with XML-illegal characters (control chars, surrogate pairs)
  - All saves now output version 2 format

  v1 Backward Compatibility:
  - Version 1 is rejected by default (ambiguous between Allors 2 and early Allors 3)
  - New SerializationVersion1Mode configuration option:
    - Reject (default) - throws error on v1 files
    - PlainText - interprets v1 strings as plain text (Allors 2 format)
    - Base64 - interprets v1 strings as base64 (early Allors 3 format)

  Test Coverage:
  - Added LoadV1PlainText test - verifies loading Allors 2 format
  - Added LoadV1Base64 test - verifies loading early Allors 3 format
  - Added LoadV1RejectedByDefault test - verifies default rejection behavior
  - Added LoadV2StringFormat test - verifies v2 base64 string loading
  - Added SaveOutputsV2 test - verifies saves produce v2 format
  - Tests run across Memory, Npgsql, and SqlClient adapters

  Documentation:
  - Added comprehensive serialization format documentation
  - Documents XML structure, encoding rules, and version handling

  Test Plan

  - Memory adapter tests pass (23 serialization tests)
  - Npgsql adapter tests (requires PostgreSQL)
  - SqlClient adapter tests (requires SQL Server)