### PR TITLE
build(versioning): adopt Nerdbank.GitVersioning (3.1.0-alpha.N)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.9.50",
+      "commands": [
+        "nbgv"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*'
       - 'feature/**'
       - 'issue/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'v[0-9]*'
   workflow_dispatch:
 
 permissions:
@@ -48,13 +51,16 @@ jobs:
       CI: 'true'
       DOTNET_NOLOGO: 'true'
       DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+      # Clean incrementing versions (3.1.0-alpha.N) with no -g<commit> suffix in CI too.
+      PublicRelease: 'true'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: false
-          fetch-depth: 1
+          fetch-depth: 0      # nbgv needs full history for git-height versioning
+          fetch-tags: true
 
       - name: Set culture nl-BE
         shell: pwsh
@@ -64,6 +70,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+
+      - name: Restore .NET local tools
+        shell: pwsh
+        run: dotnet tool restore
+
+      - name: Compute version (nbgv)
+        shell: pwsh
+        run: dotnet nbgv cloud
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/build/Allors/Build.cs
+++ b/build/Allors/Build.cs
@@ -1,6 +1,7 @@
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.NerdbankGitVersioning;
 using static Nuke.Common.Tooling.ProcessTasks;
 
 public partial class Build
@@ -9,7 +10,7 @@ public partial class Build
 
     //[Solution] private readonly Solution Solution;
     //[GitRepository] private readonly GitRepository GitRepository;
-    //[GitVersion] private readonly GitVersion GitVersion;
+    [NerdbankGitVersioning] private readonly NerdbankGitVersioning Versioning;
 
     private readonly Paths Paths = new Paths(RootDirectory);
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -63,4 +63,14 @@ partial class Build : NukeBuild
         .DependsOn(Install)
         .DependsOn(Generate)
         .DependsOn(Scaffold);
+
+    private Target ShowVersion => _ => _
+        .Executes(() =>
+        {
+            Serilog.Log.Information("Version:                      {V}", Versioning.Version);
+            Serilog.Log.Information("AssemblyVersion:              {V}", Versioning.AssemblyVersion);
+            Serilog.Log.Information("AssemblyInformationalVersion: {V}", Versioning.AssemblyInformationalVersion);
+            Serilog.Log.Information("NuGetPackageVersion:          {V}", Versioning.NuGetPackageVersion);
+            Serilog.Log.Information("NpmPackageVersion:            {V}", Versioning.NpmPackageVersion);
+        });
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,4 +20,11 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- nbgv CLI for the [NerdbankGitVersioning] attribute. PackageDownload only fetches the
+         tool package (no compile/runtime reference) so the build assembly stays unversioned.
+         Keep the version in sync with dotnet/Directory.Build.props and .config/dotnet-tools.json. -->
+    <PackageDownload Include="nbgv" Version="[3.9.50]" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,5 +1,14 @@
 <Project>
   <PropertyGroup>
     <LangVersion>default</LangVersion>
+    <!-- Treat every build as a public release so the version is a clean incrementing
+         prerelease (3.1.0-alpha.N) with no -g<commit> suffix. Internal repo, no package
+         feed, so cross-branch version collisions are acceptable. Override on the command
+         line with /p:PublicRelease=false if a dev build ever needs the commit suffix. -->
+    <PublicRelease Condition="'$(PublicRelease)' == ''">true</PublicRelease>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "3.1.0-alpha.{height}",
+  "publicReleaseRefs": [
+    "^refs/heads/main$",
+    "^refs/heads/v\\d+\\.\\d+$"
+  ],
+  "cloudBuild": {
+    "setVersionVariables": true,
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## What

Adopt Nerdbank.GitVersioning (nbgv) as the single source of truth for versioning, and start the 3.1 line.

- Root `version.json` → `3.1.0-alpha.{height}`: the base `3.1.0` is fixed and the git height drives an incrementing prerelease (`3.1.0-alpha.1`, `.2`, …).
- `Nerdbank.GitVersioning` 3.9.50 referenced in `dotnet/Directory.Build.props` → automatically stamps Assembly/File/Informational versions across all .NET projects.
- `PublicRelease=true` forced (props default + CI `env`) → clean versions with **no `-g<commit>` suffix** anywhere (internal repo, no package feed, so cross-branch version collisions are acceptable).
- nbgv CLI pinned via `.config/dotnet-tools.json`; Nuke `[NerdbankGitVersioning]` attribute wired with a `ShowVersion` target. The `nbgv` tool is fetched via `PackageDownload` in the build project — download-only, so the build assembly stays unversioned.

## CI

- Checkout switched to `fetch-depth: 0` + `fetch-tags` — **required**: nbgv computes the version from full git history; the previous shallow clone (`fetch-depth: 1`) would break every build once nbgv is referenced.
- Added `dotnet tool restore` + `nbgv cloud` steps and `PublicRelease: 'true'` env.
- Widened the push/PR branch filters with `v[0-9]*` so version/maintenance branches build.

## Branching

- This PR targets `main`, which becomes the **3.1 development line** (where the substantial/breaking work will land).
- A `v3.0` snapshot branch was cut from `198ece944f` (today's tip) as the **maintenance line**, pinned to a clean `3.0.{height}`.

## Verified locally

- `./build.sh Generate` still succeeds — code generation unaffected.
- A plain `dotnet build` stamps a clean `3.1.0-alpha.N` (no sha); `./build.sh ShowVersion` reports it via the Nuke attribute.
- No conflict with the existing hand-written `AssemblyInfo.cs` files (no duplicate version attributes / CS0579).

## Follow-up (manual, GitHub settings)

- Branch protection for `v*` and tag protection for `v*.*.*` (supports the `nbgv prepare-release` / `nbgv tag` release flow).