### PR TITLE
ci: modernize GitHub Actions + Node runtime, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot keeps the GitHub Actions used in .github/workflows up to date.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"            # scans .github/workflows/ from the repo root
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Brussels"
+    groups:
+      actions:                # bundle all action bumps into ONE PR (not one per action)
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"            # -> "ci(deps): bump ..." matching the repo's conventional commits
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
           fetch-depth: 0      # nbgv needs full history for git-height versioning
@@ -67,7 +67,7 @@ jobs:
         run: Set-Culture -CultureInfo nl-BE
 
       - name: Setup .NET SDK (from global.json)
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -80,9 +80,9 @@ jobs:
         run: dotnet nbgv cloud
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Start PostgreSQL service
         shell: pwsh
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload TRX artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trx-${{ matrix.target }}
           path: artifacts/Tests/*.trx
@@ -139,7 +139,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: ${{ matrix.target }}
           path: artifacts/Tests/*.trx


### PR DESCRIPTION
## Summary

Modernizes CI in `.github/workflows/ci.yml` and adds Dependabot to keep it current going forward.

### Action + Node bumps (`ci.yml`)

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/setup-node` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `dorny/test-reporter` | v1 | **v3** |

Plus `node-version` `'18'` → `'24'` (EOL → current Active LTS). All `with:` inputs are unchanged.

Latest versions were confirmed via the GitHub Releases API and each major's release notes were reviewed. The common requirement across these majors (Node 24 runtime / Actions Runner ≥ 2.327.1) is satisfied automatically by the `windows-latest` hosted runner. The installed Angular 14 toolchain declares `engines.node ">=16.10.0"`, so Node 24 is permitted — and Angular 14 already ran on the newer-than-official Node 18.

### Dependabot (`.github/dependabot.yml`)

Watches the `github-actions` ecosystem, grouping all future action bumps into a single weekly PR (Mondays, Europe/Brussels) with a `ci(deps)` commit prefix. npm and NuGet are intentionally excluded for now to avoid noise on the Angular 14 npm workspace and the 110 .NET projects.

## Verification

- [ ] CI matrix runs on this PR (`pull_request` → `main`); the **Setup Node.js** step uses Node 24
- [ ] Angular/TypeScript targets pass on Node 24: `CiTypescriptWorkspaceTest`, `CiTypescriptWorkspaceAdaptersJsonTest`, `CiTypescriptE2EAngularBaseTest`, `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`
- [ ] After merge to `main`: Dependabot lists the `github-actions` ecosystem (Insights → Dependency graph → Dependabot) with no config errors

> Note: on Dependabot's own PRs the `dorny/test-reporter` step may not post results (read-only token). Harmless here — that step is `if: always()` + `fail-on-error: false`, so the build/tests/artifacts still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
