### PR TITLE
fix(adapters): raise SqlClient LocalDB test timeouts to curb CI flakiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@ under a dated version heading.
   similar socket/connection errors) that surface sporadically on CI. The console-error assertion
   now ignores this known-transient class while still catching real JS errors and HTTP 4xx/5xx
   resource failures.
+- SqlClient adapter tests now run with a 300s command timeout and `Connection Timeout=0` against
+  SQL Server LocalDB, matching the Npgsql adapter tests. This stops sporadic CI failures
+  (`SqlException: Execution Timeout Expired`) caused by LocalDB slowness on hosted runners.

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Fixture.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Fixture.cs
@@ -13,9 +13,10 @@ namespace Allors.Database.Adapters.Sql.SqlClient
         {
             var database = typeof(T).Name;
 
-            using var connection = new SqlConnection(@"Server=(localdb)\MSSQLLocalDB;Database=master;Integrated Security=true");
+            using var connection = new SqlConnection(@"Server=(localdb)\MSSQLLocalDB;Database=master;Integrated Security=true;Connection Timeout=0");
             connection.Open();
             using var command = connection.CreateCommand();
+            command.CommandTimeout = 300;
             command.CommandText = $"DROP DATABASE IF EXISTS {database}";
             command.ExecuteNonQuery();
             command.CommandText = $"CREATE DATABASE {database}";

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Profile.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/Profile.cs
@@ -58,7 +58,7 @@ namespace Allors.Database.Adapters.Sql.SqlClient
             }
         }
 
-        protected string ConnectionString => $@"server=(localdb)\MSSQLLocalDB;database={this.database};Integrated Security=true";
+        protected string ConnectionString => $@"server=(localdb)\MSSQLLocalDB;database={this.database};Integrated Security=true;Connection Timeout=0";
 
         public override IDatabase CreateDatabase()
         {
@@ -70,6 +70,7 @@ namespace Allors.Database.Adapters.Sql.SqlClient
                 ConnectionString = this.ConnectionString,
                 ConnectionFactory = this.connectionFactory,
                 CacheFactory = this.cacheFactory,
+                CommandTimeout = 300,
             });
         }
 


### PR DESCRIPTION
## Problem
`CiDotnetSystemAdaptersTestSqlClient` intermittently fails against SQL Server **LocalDB** with:
```
Microsoft.Data.SqlClient.SqlException : Execution Timeout Expired.
```
Seen on PR #27's first attempt (test `One2OneTest.I3_I4one2one`); it passed on re-run. `Execution Timeout Expired` is a **command** timeout — the SqlCommand default of **30s** — hit when a LocalDB query is slow under load on the hosted Windows runner. Not a logic bug.

## Root cause
The SqlClient adapter already applies a configurable command timeout to every command (`Allors.Database.Adapters.Sql.SqlClient/Connection/Connection.cs` → `sqlCommand.CommandTimeout = Database.CommandTimeout.Value` when set), but the **test `Profile` never sets `CommandTimeout`**, so tests ran with the 30s default. The sibling **Npgsql** adapter tests don't flake because they already run with `CommandTimeout=300`.

## Fix
In `dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/`:
- **`Profile.cs`** — set `CommandTimeout = 300` on the test `Sql.Configuration` (mirrors Npgsql), and add `Connection Timeout=0` to the LocalDB connection string.
- **`Fixture.cs`** — add `Connection Timeout=0` to the `master` connection and raise the `DROP`/`CREATE DATABASE` command timeout to 300s.

`Connection Timeout=0` completes the connect-timeout hardening from `4abe78fa5a` (which only touched the server appsettings, documenting LocalDB post-login approaching the 15s connect timeout on runners). The CI target runs only `Tests.Static` filtered to `...Sql.SqlClient`, so these two files cover the whole job.

**Timeouts are only ever raised**, so this cannot introduce new failures — it can only remove transient timeout flakes. A genuinely deadlocked query still fails at 300s rather than hanging to the 360-min job cap.

## Verification
- `dotnet build .../Tests.Static/Tests.Static.csproj` → 0 errors.
- CI: `CiDotnetSystemAdaptersTestSqlClient` should pass (and stay green across runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)