### PR TITLE
test(dotnet-system): cover end value/pair in RangesExceptTests [BUG-19]

### DIFF
--- a/dotnet/System/Shared.Tests/Ranges/Long/RangesExceptTests.cs
+++ b/dotnet/System/Shared.Tests/Ranges/Long/RangesExceptTests.cs
@@ -162,10 +162,10 @@ namespace Allors.Ranges.Long
             var num = this.Ranges;
 
             var x = num.Load(2, 3, 4);
-            var y = num.Load(3);
+            var y = num.Load(4);
             var z = num.Except(x, y);
 
-            Assert.Equal(new long[] { 2, 4 }, z);
+            Assert.Equal(new long[] { 2, 3 }, z);
         }
 
         [Fact]
@@ -198,10 +198,10 @@ namespace Allors.Ranges.Long
             var num = this.Ranges;
 
             var x = num.Load(2, 3, 4);
-            var y = num.Load(4);
+            var y = num.Load(3, 4);
             var z = num.Except(x, y);
 
-            Assert.Equal(new long[] { 2, 3 }, z);
+            Assert.Equal(new long[] { 2 }, z);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Two tests in `RangesExceptTests` did not exercise the cases their names claim:

- `TripletValueSameEnd` was a verbatim copy of `TripletValueSameMiddle` (`y = Load(3)`, expecting `{2,4}`), so the "remove the last value" case was never tested. It now removes the end value: `y = Load(4)` -> `{2,3}`.
- `TripletPairSameEnd` was in the *Pair* group but used a single `y = Load(4)`; it now removes a trailing pair: `y = Load(3,4)` -> `{2}`, exercising the two-array `Except` merge loop (the single-value form went through the `Remove` path already covered by the corrected `TripletValueSameEnd`).

## Notes
Test-only change -- no production code is modified. `Except` already handled both cases; this restores/adds the intended coverage. Full `Allors.Shared.Tests`: 56 passed, 0 failed.