### PR TITLE
fix(dotnet-system): Memory LIKE follows SQL semantics, escaping metacharacters [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The in-memory adapter's `LIKE` filter now follows SQL `LIKE` semantics: `%` (any sequence) and `_`
+  (any single character) are wildcards and every other character — including regex metacharacters such
+  as `.`, `(`, `[`, `\` — is matched literally. Previously the pattern was compiled to a regex without
+  escaping, so metacharacters were misinterpreted and `_` was treated literally.
 - `DefaultStructRanges.Union` no longer drops a leading element equal to `default(T)` (e.g. `0`).
   Both merge branches relied on a sentinel that never fired (`Equals(previous, default)` resolves
   `default` to `null`, so it is always false for a value type); they now use a nullable `T? previous`

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Memory/Predicates/RoleLike.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Memory/Predicates/RoleLike.cs
@@ -22,7 +22,7 @@ namespace Allors.Database.Adapters.Memory
 
             this.roleType = roleType;
             this.isEmpty = like.Length == 0;
-            this.regex = new Regex("^" + like.Replace("%", ".*") + "$");
+            this.regex = new Regex("^" + Regex.Escape(like).Replace("%", ".*").Replace("_", ".") + "$");
         }
 
         internal override ThreeValuedLogic Evaluate(Strategy strategy)

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
@@ -16173,6 +16173,37 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void RoleStringLikeSqlSemantics()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                this.Populate();
+                var m = this.Transaction.Database.Context().M;
+
+                // '.' is a literal, not regex "any char" (else it would match "ᴀbra").
+                var extent = this.Transaction.Extent(m.C1);
+                extent.Filter.AddLike(m.C1.C1AllorsString, "ᴀbr.");
+                Assert.Empty(extent);
+
+                // '.*' is literal, not regex "any sequence" (else it would match every C1 with a string).
+                extent = this.Transaction.Extent(m.C1);
+                extent.Filter.AddLike(m.C1.C1AllorsString, ".*");
+                Assert.Empty(extent);
+
+                // '_' is a single-character wildcard (ANSI SQL LIKE): "ᴀbr_" matches the 4-char "ᴀbra".
+                extent = this.Transaction.Extent(m.C1);
+                extent.Filter.AddLike(m.C1.C1AllorsString, "ᴀbr_");
+                Assert.Single(extent);
+
+                // '%' (any sequence) still works after escaping.
+                extent = this.Transaction.Extent(m.C1);
+                extent.Filter.AddLike(m.C1.C1AllorsString, "ᴀbra%");
+                Assert.Equal(3, extent.Count);
+            }
+        }
+
+        [Fact]
         public void RoleStringLike()
         {
             foreach (var init in this.Inits)


### PR DESCRIPTION
## Summary
The in-memory adapter compiled a `LIKE` pattern into a .NET `Regex` via `like.Replace("%", ".*")` with no escaping, so regex metacharacters (`.`, `(`, `[`, `\`, ...) were misinterpreted and the SQL `_` single-char wildcard was treated literally. The SQL adapters pass the pattern to the database `LIKE` verbatim, and `ICompositePredicate.AddLike` is documented "(Sql like)", so Memory diverged from the intended behavior.

## Fix
`Allors.Database.Adapters.Memory/Predicates/RoleLike.cs` now uses `Regex.Escape(like).Replace("%", ".*").Replace("_", ".")` -- the portable ANSI SQL `LIKE` subset: `%` (any sequence) and `_` (any single char) are wildcards; everything else is matched literally. This matches Npgsql exactly, and SqlClient apart from its T-SQL `[...]` extension.

## Tests
Adds `RoleStringLikeSqlSemantics` to the shared `ExtentTest` (runs Memory/SqlClient/Npgsql): asserts `.` and `.*` are literal, `_` is a single-char wildcard, and `%` still works. Before the fix Memory over-matched (`.`/`.*`) and under-matched (`_`); the SQL adapters already passed. Full Memory adapter suite: 247 passed, 0 failed.

## Note
A separate cross-adapter `LIKE` inconsistency surfaced -- T-SQL `[...]` character classes work only on SqlClient, not Npgsql/Memory -- tracked separately, not addressed here.