### PR TITLE
fix(dotnet-system): report displaced association in one2one change set [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The in-memory adapter's change set now reports the association that is displaced when a one-to-one
+  composite role is reassigned. `SetCompositeRoleOne2One` recorded the displaced association's original
+  role as the wrong value, so when the new association had no prior role its role change (now → null) was
+  trimmed out and omitted from the change set.
 - `DefaultStructRanges.Union` no longer drops a leading element equal to `default(T)` (e.g. `0`).
   Both merge branches relied on a sentinel that never fired (`Equals(previous, default)` resolves
   `default` to `null`, so it is always false for a value type); they now use a nullable `T? previous`

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Memory/Strategy.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Memory/Strategy.cs
@@ -637,7 +637,7 @@ namespace Allors.Database.Adapters.Memory
 
                 if (newPreviousAssociation != null && !this.Equals(newPreviousAssociation))
                 {
-                    this.ChangeLog.OnChangingCompositeRole(newPreviousAssociation, roleType, null, previousRole);
+                    this.ChangeLog.OnChangingCompositeRole(newPreviousAssociation, roleType, null, @new);
 
                     newPreviousAssociation.Backup(roleType);
                     newPreviousAssociation.compositeRoleByRoleType.Remove(roleType);

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ChangesTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ChangesTest.cs
@@ -238,6 +238,32 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void One2OneRoleDisplacedAssociation()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                var m = this.Transaction.Database.Context().M;
+
+                var from1 = (C1)this.Transaction.Create(m.C1);
+                var from2 = (C1)this.Transaction.Create(m.C1);
+                var to = (C1)this.Transaction.Create(m.C1);
+
+                from1.C1C1one2one = to;
+                this.Transaction.Checkpoint();
+
+                // Reassigning `to` to from2 displaces from1: from1.C1C1one2one goes to -> null.
+                from2.C1C1one2one = to;
+
+                var changeSet = this.Transaction.Checkpoint();
+
+                // The displaced association (from1) must be reported in the change set.
+                Assert.Contains(from1, changeSet.Associations);
+                Assert.Contains(m.C1.C1C1one2one, changeSet.GetRoleTypes(from1));
+            }
+        }
+
+        [Fact]
         public void BooleanRole()
         {
             foreach (var init in this.Inits)


### PR DESCRIPTION
## Summary
When a one-to-one composite role is reassigned and the new role object was already held by another association, that association is displaced (its role becomes null). The in-memory adapter's `SetCompositeRoleOne2One` recorded the displaced association's *original* role as `previousRole` (the setting object's old role) instead of `@new` (the role the displaced association actually held).

The change log stores that argument as the association's original role, and `Checkpoint()` trims a role from the change set when its current value equals the recorded original. So when the new association had no prior role, the displaced association's original was recorded as `null`, matched its now-`null` current, and its role change was **omitted from the change set**.

## Fix
`Allors.Database.Adapters.Memory/Strategy.cs` -- pass `@new` (the displaced association's actual original role) instead of `previousRole`. This corrects both the recorded original (so Trim keeps the real change) and the association-change tracking.

## Tests
Adds `One2OneRoleDisplacedAssociation` to the shared `ChangesTest` (runs Memory/SqlClient/Npgsql): reassigns a `C1C1one2one` role to displace an association and asserts the displaced association appears in the change set. Before the fix Memory omitted it; the SQL adapters already report it correctly. Full Memory adapter suite: 247 passed, 0 failed.