### PR TITLE
fix(dotnet-system): balance parentheses in NotAssociationContainedInEnumerable SQL [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The SQL adapters no longer emit invalid SQL for a `NOT (association ContainedIn enumerable)` filter on a
+  many-to-many association (or a relation without exclusive database classes): that branch opened three
+  parentheses but closed only two, causing a syntax error (`Incorrect syntax near ')'`) at query execution.
 - The in-memory adapter's change set now reports the association that is displaced when a one-to-one
   composite role is reassigned. `SetCompositeRoleOne2One` recorded the displaced association's original
   role as the wrong value, so when the new association had no prior role its role change (now → null) was

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Predicates/NotAssociationContainedInEnumerable.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Predicates/NotAssociationContainedInEnumerable.cs
@@ -44,7 +44,7 @@ namespace Allors.Database.Adapters.Sql
                 statement.Append(" NOT " + this.association.SingularFullName + "_A." + Mapping.ColumnNameForRole + " IN (\n");
                 statement.Append(" SELECT " + Mapping.ColumnNameForRole + " FROM " + schema.TableNameForRelationByRelationType[this.association.RelationType] + " WHERE " + Mapping.ColumnNameForAssociation + " IN (");
                 statement.Append(inStatement.ToString());
-                statement.Append(" ))\n");
+                statement.Append(" )))\n");
             }
             else if (this.association.RelationType.RoleType.IsMany)
             {

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
@@ -224,6 +224,30 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void AssociationMany2ManyNotContainedInEnumerable()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                this.Populate();
+                var m = this.Transaction.Database.Context().M;
+
+                // NOT (C2's many-to-many C1 association contained in [all C1s]) — exercises the
+                // NotAssociationContainedInEnumerable many-to-many branch, whose generated SQL had
+                // unbalanced parentheses (3 opened, 2 closed).
+                var inExtent = this.Transaction.Extent(m.C1);
+                var enumerable = (IEnumerable<IObject>)(Extent<IObject>)inExtent;
+
+                var extent = this.Transaction.Extent(m.C2);
+                extent.Filter.AddNot().AddContainedIn(m.C2.C1sWhereC1C2many2many, enumerable);
+
+                // Only the C2 with no many-to-many C1 association remains.
+                Assert.Single(extent);
+                this.AssertC2(extent, true, false, false, false);
+            }
+        }
+
+        [Fact]
         public void AssociationMany2ManyContainedIn()
         {
             foreach (var init in this.Inits)


### PR DESCRIPTION
## Summary
`NotAssociationContainedInEnumerable.BuildWhere`'s first branch -- used for a `NOT (association ContainedIn enumerable)` filter on a **many-to-many** association (or a relation without exclusive database classes) -- opened **three** parentheses:
- `(COL IS NULL OR ` (outer group)
- `NOT COL IN (` (subquery)
- `SELECT ... WHERE assoc IN (` (the IN list)

...but closed only **two** (`))`), leaving the outer group unclosed -> invalid SQL -> `SqlException: Incorrect syntax near ')'` at query execution. The other two branches open 2 / close 2 (balanced).

## Fix
Close all three parentheses (`))` -> `)))`) in the first branch only.

## Tests
Adds `AssociationMany2ManyNotContainedInEnumerable` to the shared `ExtentTest`: `Filter.AddNot().AddContainedIn(m.C2.C1sWhereC1C2many2many, <all C1s>)`, then enumerate; asserts only the C2 with no many-to-many C1 remains. RED on SqlClient (`Incorrect syntax near ')'`) -> GREEN; the Memory variant validated the expected result. Full SqlClient suite: 260 passed, 0 failed, 2 skipped.