### PR TITLE
fix(dotnet-system): Instantiate tolerates duplicate object ids [BUG-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `Instantiate(IEnumerable<long>)` (SQL adapters) no longer throws `ArgumentException` ("An item with the
+  same key has already been added") when the ids contain a duplicate of an already-cached object alongside
+  an uncached id; the per-id reference lookup now tolerates duplicate keys.
 - The in-memory adapter's change set now reports the association that is displaced when a one-to-one
   composite role is reassigned. `SetCompositeRoleOne2One` recorded the displaced association's original
   role as the wrong value, so when the new association had no prior role its role change (now → null) was

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Transaction.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Transaction.cs
@@ -202,7 +202,11 @@ namespace Allors.Database.Adapters.Sql
                 references.AddRange(nonCachedReferences);
 
                 // Return objects in the same order as objectIds
-                var referenceById = references.ToDictionary(v => v.ObjectId);
+                var referenceById = new Dictionary<long, Reference>();
+                foreach (var reference in references)
+                {
+                    referenceById[reference.ObjectId] = reference;
+                }
                 references = new List<Reference>();
                 foreach (var objectId in objectIdArray)
                 {

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
@@ -16204,6 +16204,34 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void InstantiateDuplicateIds()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                var m = this.Transaction.Database.Context().M;
+
+                var c1 = (C1)this.Transaction.Create(m.C1);
+                var c2 = (C1)this.Transaction.Create(m.C1);
+                this.Transaction.Commit();
+                var id1 = c1.Id;
+                var id2 = c2.Id;
+
+                using (var transaction = this.CreateTransaction())
+                {
+                    transaction.Instantiate(id1); // cache id1 in this transaction
+
+                    // id1 (cached, listed twice) + id2 (uncached) makes the non-cached branch build a
+                    // Dictionary over references that already holds id1 twice -> duplicate-key throw.
+                    var objects = transaction.Instantiate(new[] { id1, id1, id2 });
+
+                    Assert.Contains(objects, o => o.Id == id1);
+                    Assert.Contains(objects, o => o.Id == id2);
+                }
+            }
+        }
+
+        [Fact]
         public void RoleStringLike()
         {
             foreach (var init in this.Inits)


### PR DESCRIPTION
## Summary
`Transaction.Instantiate(IEnumerable<long>)` builds a `Dictionary` keyed by `ObjectId` from the resolved references. When the ids include a **duplicate of an already-cached object** (each occurrence adds a reference) **together with an uncached id** (which enters this branch), `references` holds the cached id twice and `ToDictionary` threw `ArgumentException` ("An item with the same key has already been added").

(Pure duplicate *uncached* ids do not reproduce it -- the SQL `IN` dedupes -- so the trigger is the cached-duplicate + uncached mix.)

## Fix
Build the per-id lookup with a duplicate-tolerant loop (same `ObjectId` -> same `Reference`). The subsequent re-expansion loop still restores input order/multiplicity; non-duplicate inputs are unchanged.

## Tests
Adds `InstantiateDuplicateIds` to the shared `ExtentTest`: in a fresh transaction, cache one id, then `Instantiate([id1, id1, id2])` (id2 uncached); assert both ids resolve. RED on SqlClient (`ArgumentException`) -> GREEN; Memory passes. Full SqlClient suite: 260 passed, 0 failed, 2 skipped.