### PR TITLE
fix(dotnet-system): prefetch uses an object's modified composites role [BUG-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- Prefetching (SQL adapters) now uses an object's modified (uncommitted) composites role.
+  `PrefetchTryGetCompositesRole` set its out-parameter from the modified role but always returned `false`, so
+  the prefetcher ignored it and prefetched the committed value instead — leaving targets added in the
+  transaction out of the transitive prefetch (extra database round-trips).
 - The in-memory adapter's change set now reports the association that is displaced when a one-to-one
   composite role is reassigned. `SetCompositeRoleOne2One` recorded the displaced association's original
   role as the wrong value, so when the new association had no prior role its role change (now → null) was

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Strategy.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Strategy.cs
@@ -1215,6 +1215,7 @@ namespace Allors.Database.Adapters.Sql
             if (this.TryGetModifiedCompositesRole(roleType, out var compositesRole))
             {
                 roleIds = compositesRole.ObjectIds;
+                return true;
             }
 
             return false;

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/TracingTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/TracingTest.cs
@@ -6,10 +6,12 @@
 namespace Allors.Database.Adapters.Sql
 {
     using System;
+    using System.Linq;
     using Meta;
     using Tracing;
     using Xunit;
     using C1 = Domain.C1;
+    using C2 = Domain.C2;
 
     public abstract class TracingTest : IDisposable
     {
@@ -96,6 +98,52 @@ namespace Allors.Database.Adapters.Sql
             transactionSink.Clear();
 
             var c2b = c1b.C1C2one2one;
+
+            Assert.Empty(transactionSink.Nodes);
+        }
+
+        [Fact]
+        public void PrefetchUsesModifiedCompositesRole()
+        {
+            this.Init();
+            var database = (Database)this.CreateDatabase();
+
+            long c1Id;
+            long c2bId;
+            using (var setup = database.CreateTransaction())
+            {
+                var setupC1 = C1.Create(setup);
+                var setupC2a = C2.Create(setup);
+                var setupC2b = C2.Create(setup);
+                var setupC2x = C2.Create(setup);
+                setupC1.AddC1C2one2many(setupC2a);    // committed: c1 -> [c2a]
+                setupC2b.AddC2C2one2many(setupC2x);   // committed nested: c2b -> [c2x]
+                setup.Commit();
+                c1Id = setupC1.Id;
+                c2bId = setupC2b.Id;
+            }
+
+            var sink = new Sink();
+            database.Sink = sink;
+
+            using var transaction = (Transaction)database.CreateTransaction();
+
+            var c1 = (C1)transaction.Instantiate(c1Id);
+            var c2b = (C2)transaction.Instantiate(c2bId);
+
+            // Modify (uncommitted): c1 -> [c2a, c2b].
+            c1.AddC1C2one2many(c2b);
+
+            var nestedPolicy = new PrefetchPolicyBuilder().WithRule(this.M.C2.C2C2one2manies).Build();
+            var prefetchPolicy = new PrefetchPolicyBuilder().WithRule(this.M.C1.C1C2one2manies, nestedPolicy).Build();
+            transaction.Prefetch(prefetchPolicy, c1);
+
+            var transactionSink = sink.TreeByTransaction[transaction];
+            transactionSink.Clear();
+
+            // c2b was added to c1's composites role in-memory; the prefetch must include it in the
+            // transitive prefetch, so reading its nested role issues no database command.
+            _ = c2b.C2C2one2manies.ToArray();
 
             Assert.Empty(transactionSink.Nodes);
         }


### PR DESCRIPTION
## Summary
`PrefetchTryGetCompositesRole` set its `out` parameter from the **modified (uncommitted)** composites role but then unconditionally `return false`, so its only caller (`Prefetcher.FilterForPrefetchCompositesRoles`) ignored the modified value and prefetched the **committed** value instead. Targets added to the role in the current transaction were therefore excluded from the transitive prefetch (extra DB round-trips later). The single-composite sibling `PrefetchTryGetCompositeRole` already returns `true`.

(Role *values* read by callers stayed correct -- `ModifiedRoles` wins -- so the effect was prefetch completeness/perf, not wrong data.)

## Fix
`return true;` when the modified composites role is found.

## Tests
Adds `PrefetchUsesModifiedCompositesRole` to `TracingTest`, using the SQL command-tracing `Sink`: it adds a target to a composites role in a fresh transaction (uncommitted), runs a nested prefetch (`C1.C1C2one2manies -> C2.C2C2one2manies`), then asserts that reading the added target's nested role issues **no** DB command (it was prefetched). RED before the fix (a `SqlGetCompositesRoleEvent` fires) -> GREEN after. Full SqlClient suite: 260 passed, 0 failed, 2 skipped.