### PR TITLE
test(dotnet-system): rename adapter ServicesTest back to LifeCycleTest

### DIFF
--- a/dotnet/System/Database/Adapters/Tests.Static/Static/LifeCycleTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/LifeCycleTest.cs
@@ -1,4 +1,4 @@
-// <copyright file="ServicesTest.cs" company="Allors bv">
+// <copyright file="LifeCycleTest.cs" company="Allors bv">
 // Copyright (c) Allors bv. All rights reserved.
 // Licensed under the LGPL license. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -16,7 +16,7 @@ namespace Allors.Database.Adapters
     using ClassWithoutRoles = Domain.ClassWithoutRoles;
     using ClassWithoutUnitRoles = Domain.ClassWithoutUnitRoles;
 
-    public abstract class ServicesTest : IDisposable
+    public abstract class LifeCycleTest : IDisposable
     {
         protected static readonly bool[] TrueFalse = { true, false };
 

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/LifeCycleTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Memory/LifeCycleTest.cs
@@ -1,24 +1,30 @@
-// <copyright file="ServicesTest.cs" company="Allors bv">
+// <copyright file="LifeCycleTest.cs" company="Allors bv">
 // Copyright (c) Allors bv. All rights reserved.
 // Licensed under the LGPL license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace Allors.Database.Adapters.Sql.Npgsql
+namespace Allors.Database.Adapters.Memory
 {
+    using System;
     using Adapters;
     using Xunit;
 
-    public class ServicesTest : Adapters.ServicesTest, IClassFixture<Fixture<ServicesTest>>
+    public class LifeCycleTest : Adapters.LifeCycleTest, IDisposable
     {
-        private readonly Profile profile;
-
-        public ServicesTest() => this.profile = new Profile(this.GetType().Name);
+        private readonly Profile profile = new Profile();
 
         protected override IProfile Profile => this.profile;
 
+        [Fact]
+        public override void DifferentTransactions()
+        {
+        }
+
         public override void Dispose() => this.profile.Dispose();
 
-        protected override void SwitchDatabase() => this.profile.SwitchDatabase();
+        protected override void SwitchDatabase()
+        {
+        }
 
         protected override IDatabase CreatePopulation() => this.profile.CreateDatabase();
 

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/LifeCycleTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/Npgsql/LifeCycleTest.cs
@@ -1,18 +1,18 @@
-// <copyright file="ServicesTest.cs" company="Allors bv">
+// <copyright file="LifeCycleTest.cs" company="Allors bv">
 // Copyright (c) Allors bv. All rights reserved.
 // Licensed under the LGPL license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace Allors.Database.Adapters.Sql.SqlClient
+namespace Allors.Database.Adapters.Sql.Npgsql
 {
     using Adapters;
     using Xunit;
 
-    public class ServicesTest : Adapters.ServicesTest, IClassFixture<Fixture<ServicesTest>>
+    public class LifeCycleTest : Adapters.LifeCycleTest, IClassFixture<Fixture<LifeCycleTest>>
     {
         private readonly Profile profile;
 
-        public ServicesTest() => this.profile = new Profile(this.GetType().Name);
+        public LifeCycleTest() => this.profile = new Profile(this.GetType().Name);
 
         protected override IProfile Profile => this.profile;
 

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/LifeCycleTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/Sql/SqlClient/LifeCycleTest.cs
@@ -1,30 +1,24 @@
-// <copyright file="ServicesTest.cs" company="Allors bv">
+// <copyright file="LifeCycleTest.cs" company="Allors bv">
 // Copyright (c) Allors bv. All rights reserved.
 // Licensed under the LGPL license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace Allors.Database.Adapters.Memory
+namespace Allors.Database.Adapters.Sql.SqlClient
 {
-    using System;
     using Adapters;
     using Xunit;
 
-    public class ServicesTest : Adapters.ServicesTest, IDisposable
+    public class LifeCycleTest : Adapters.LifeCycleTest, IClassFixture<Fixture<LifeCycleTest>>
     {
-        private readonly Profile profile = new Profile();
+        private readonly Profile profile;
+
+        public LifeCycleTest() => this.profile = new Profile(this.GetType().Name);
 
         protected override IProfile Profile => this.profile;
 
-        [Fact]
-        public override void DifferentTransactions()
-        {
-        }
-
         public override void Dispose() => this.profile.Dispose();
 
-        protected override void SwitchDatabase()
-        {
-        }
+        protected override void SwitchDatabase() => this.profile.SwitchDatabase();
 
         protected override IDatabase CreatePopulation() => this.profile.CreateDatabase();
 


### PR DESCRIPTION
## What

Renames the adapter test class `ServicesTest` back to its original, accurate name `LifeCycleTest` across the 4 `Tests.Static` files (abstract base + Memory / Npgsql / SqlClient subclasses).

## Why

In June 2021, commit `12020547` ("Workspace (WIP)") did a blanket *"Lifecycle → Services"* terminology sweep. It renamed `LifeCycleTest.cs` → `ServicesTest.cs` **at 99% similarity**, even though the class tests object/transaction **lifecycle**, not services.

A method-by-method audit of the (~5,200-line) class found **zero** service-container tests:

- **16 lifecycle** — `NextId`, `CreateMany`, `Delete`, `IsDeleted`, `Identity`, `Instantiate`, `InstantiateMany`, `Versioning`, `Rollback`, `SwitchPopulation`, `SwitchTransaction`, `ObjectType`, …
- **3 role** — `UnitRole`, `CompositeRole`, `CompositeRoles`
- **19 prefetch** — `Prefetch*`
- **2 misc**

The Workspace test suite already uses `LifecycleTests` for lifecycle concerns and has no `ServicesTests`; this brings the DB adapters back in line.

## Intentionally NOT changed

The genuine production service containers stay `Services` — their core member is `Get<T>()` resolving real services (`IDerivationService`, `IMetaCache`, `ISecurity`, `IPrefetchPolicyCache`, `IPermissions`, …); an `OnInit` hook does not make them "lifecycle":

- `IDatabaseServices`, `ITransactionServices`, `ISessionServices`, `IWorkspaceServices`, their implementations, and the `Services` namespaces/properties.

## Notes

- Pure identifier rename in self-contained files; git tracks all 4 as renames (99 / 86 / 75 / 75%). No `.csproj` change (SDK globbing); no external references to `ServicesTest`.
- ⚠️ **Not built/tested end-to-end**: the `Meta` project has a **pre-existing, unrelated** compile break — `Meta/MetaBuilder.cs` references not-yet-generated types `Domains` / `RelationTypes` / `MethodTypes` and fails independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
