### PR TITLE
fix(dotnet-system): honor destination index in converted Extent.CopyTo [BUG-18]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `Extent.CopyTo(array, index)` for a converted extent (the `IObject[] → Allors.Database.Extent` cast) now
+  begins copying at the requested destination `index` instead of always at `0`. The override hardcoded `0` as
+  the `Array.Copy` destination, ignoring its `index` parameter and overwriting earlier elements of the target.
 - Prefetching (SQL adapters) now uses an object's modified (uncommitted) composites role.
   `PrefetchTryGetCompositesRole` set its out-parameter from the modified role but always returned `false`, so
   the prefetcher ignored it and prefetched the committed value instead — leaving targets added in the

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
@@ -16256,6 +16256,29 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void ConvertedExtentCopyToStartsAtDestinationIndex()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                var m = this.Transaction.Database.Context().M;
+
+                var first = this.Transaction.Create(m.C1);
+                var second = this.Transaction.Create(m.C1);
+
+                Allors.Database.Extent extent = new IObject[] { first, second };
+
+                var destination = new IObject[4];
+                extent.CopyTo(destination, 1);
+
+                Assert.Null(destination[0]);
+                Assert.Same(first, destination[1]);
+                Assert.Same(second, destination[2]);
+                Assert.Null(destination[3]);
+            }
+        }
+
+        [Fact]
         public void RoleStringLike()
         {
             foreach (var init in this.Inits)

--- a/dotnet/System/Database/Allors.Database/Extent.cs
+++ b/dotnet/System/Database/Allors.Database/Extent.cs
@@ -325,7 +325,7 @@ namespace Allors.Database
             /// <exception cref="T:System.ArgumentOutOfRangeException">index is less than zero. </exception>
             /// <exception cref="T:System.ArgumentException">array is multidimensional.-or- index is equal to or greater than the length of array.-or- The number of elements in the source <see cref="T:System.Collections.ICollection"></see> is greater than the available space from index to the end of the destination array. </exception>
             /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.ICollection"></see> cannot be cast automatically to the type of the destination array. </exception>
-            public override void CopyTo(Array array, int index) => Array.Copy(this.objects, 0, array, 0, this.objects.Length);
+            public override void CopyTo(Array array, int index) => Array.Copy(this.objects, 0, array, index, this.objects.Length);
 
             /// <summary>
             /// Returns an enumerator that iterates through a collection.


### PR DESCRIPTION
## BUG-18 — `AllorsExtentConverted.CopyTo` ignores the destination index

`Extent.AllorsExtentConverted.CopyTo(Array array, int index)` passed `0` as the `Array.Copy` destination start, so the `index` parameter was dead. Copying a converted extent (the `IObject[] → Allors.Database.Extent` cast) into an array at a non-zero offset wrote at index `0`, overwriting earlier elements and mis-placing every item — contradicting the method's own XML doc and the `ICollection.CopyTo` contract.

### Fix
`Allors.Database/Extent.cs`: pass `index` as the `Array.Copy` destination start instead of `0`.

### Test (TDD)
Added `ConvertedExtentCopyToStartsAtDestinationIndex` to `Tests.Static/Static/ExtentTest.cs`: cast `new IObject[] { a, b }` to `Allors.Database.Extent`, `CopyTo` into a length-4 array at index `1`, assert `[null, a, b, null]`. RED before the fix (`Assert.Null(dest[0])` failed: "Value is not null"), green after.

### Verification
- `dotnet test … --filter "…Memory.ExtentTest.ConvertedExtentCopyToStartsAtDestinationIndex"` → RED → 1 passed.
- `.\build.ps1 DotnetSystemAdaptersTestMemory` → Succeeded. SqlClient/Npgsql via CI.