### PR TITLE
fix(dotnet-system): Load honors the configured schema name [BUG-08][BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The SQL adapters' serialization `Load` now reads the staging objects table using the configured schema
+  (`{SchemaName}._o`) instead of a hardcoded `allors._o`, so loading into a database configured with a
+  non-default `SchemaName` no longer fails with "Invalid object name 'allors._o'". Fixes the SqlClient and
+  Npgsql adapters.
 - `Extent.CopyTo(array, index)` for a converted extent (the `IObject[] → Allors.Database.Extent` cast) now
   begins copying at the requested destination `index` instead of always at `0`. The override hardcoded `0` as
   the `Array.Copy` destination, ignoring its `index` parameter and overwriting earlier elements of the target.

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.Npgsql/Serialization/Load.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.Npgsql/Serialization/Load.cs
@@ -144,7 +144,7 @@ namespace Allors.Database.Adapters.Sql.Npgsql
                         command.CommandType = CommandType.Text;
                         command.CommandText = $@"
 insert into {tableName} (o, c)
-select o, c from allors._o
+select o, c from {this.database.Mapping.TableNameForObjects}
 where c = '{@class.Id}'";
 
                         command.ExecuteNonQuery();

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Serialization/Load.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Serialization/Load.cs
@@ -139,7 +139,7 @@ namespace Allors.Database.Adapters.Sql.SqlClient
                         command.CommandType = CommandType.Text;
                         command.CommandText = $@"
 insert into {tableName} (o, c)
-select o, c from allors._o
+select o, c from {this.database.Mapping.TableNameForObjects}
 where c = '{@class.Id}'";
 
                         command.ExecuteNonQuery();


### PR DESCRIPTION
## BUG-08 + BUG-09 — `Load` honors the configured schema name (SqlClient + Npgsql)

Both SQL adapters'' serialization `Load` bulk-copy objects into the schema-qualified `{SchemaName}._o` staging table, but the follow-up "insert from `_o` into the per-class tables" step hardcoded `select o, c from allors._o`. Loading into a database configured with a non-default `SchemaName` therefore failed with `Invalid object name 'allors._o'` (the `allors` schema does not exist there).

### Fix
- SqlClient `Serialization/Load.cs` and Npgsql `Serialization/Load.cs`: read from `{this.database.Mapping.TableNameForObjects}` (the schema-qualified value the same method already uses for the bulk-copy/COPY destination) instead of the hardcoded `allors._o`. Unchanged for the default `allors` schema; correct for any configured schema.

### Tests
Verified locally RED -> GREEN with a custom-schema Save/Load test (`SqlException: Invalid object name 'allors._o'` before the fix; passed after). The test is intentionally not included here — coverage is deferred to a planned general restructuring of the adapter test suite. The existing CI suite runs on the default `allors` schema and does not exercise this path.