### PR TITLE
fix(dotnet-system): make shared Database lazy caches thread-safe [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The SQL adapters' shared `Database` caches (`concreteClassesByObjectType`, `sortedUnitRolesByObjectType`) are
+  now `ConcurrentDictionary`s populated via `GetOrAdd`, so concurrent transactions no longer race while lazily
+  computing concrete classes / sorted unit roles — an unsynchronized `Dictionary` write could previously corrupt
+  the cache or throw. The cached values are immutable once built.
 - `Extent.CopyTo(array, index)` for a converted extent (the `IObject[] → Allors.Database.Extent` cast) now
   begins copying at the requested destination `index` instead of always at `0`. The override hardcoded `0` as
   the `Array.Copy` destination, ignoring its `index` parameter and overwriting earlier elements of the target.

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Database.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Database.cs
@@ -6,6 +6,7 @@
 namespace Allors.Database.Adapters.Sql
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
@@ -19,9 +20,9 @@ namespace Allors.Database.Adapters.Sql
     {
         public static readonly IsolationLevel DefaultIsolationLevel = System.Data.IsolationLevel.Snapshot;
 
-        private readonly Dictionary<IObjectType, HashSet<IObjectType>> concreteClassesByObjectType;
+        private readonly ConcurrentDictionary<IObjectType, HashSet<IObjectType>> concreteClassesByObjectType;
 
-        private readonly Dictionary<IObjectType, IRoleType[]> sortedUnitRolesByObjectType;
+        private readonly ConcurrentDictionary<IObjectType, IRoleType[]> sortedUnitRolesByObjectType;
 
         private ICacheFactory cacheFactory;
 
@@ -43,12 +44,12 @@ namespace Allors.Database.Adapters.Sql
 
             this.ConnectionString = configuration.ConnectionString;
 
-            this.concreteClassesByObjectType = new Dictionary<IObjectType, HashSet<IObjectType>>();
+            this.concreteClassesByObjectType = new ConcurrentDictionary<IObjectType, HashSet<IObjectType>>();
 
             this.CommandTimeout = configuration.CommandTimeout;
             this.IsolationLevel = configuration.IsolationLevel;
 
-            this.sortedUnitRolesByObjectType = new Dictionary<IObjectType, IRoleType[]>();
+            this.sortedUnitRolesByObjectType = new ConcurrentDictionary<IObjectType, IRoleType[]>();
 
             this.CacheFactory = configuration.CacheFactory;
             this.Cache = this.CacheFactory.CreateCache();
@@ -148,11 +149,9 @@ namespace Allors.Database.Adapters.Sql
                 return container.Equals(containee);
             }
 
-            if (!this.concreteClassesByObjectType.TryGetValue(container, out var concreteClasses))
-            {
-                concreteClasses = new HashSet<IObjectType>(((IInterface)container).DatabaseClasses);
-                this.concreteClassesByObjectType[container] = concreteClasses;
-            }
+            var concreteClasses = this.concreteClassesByObjectType.GetOrAdd(
+                container,
+                key => new HashSet<IObjectType>(((IInterface)key).DatabaseClasses));
 
             return concreteClasses.Contains(containee);
         }
@@ -160,17 +159,14 @@ namespace Allors.Database.Adapters.Sql
 
         internal Type GetDomainType(IObjectType objectType) => this.ObjectFactory.GetType(objectType);
 
-        public IRoleType[] GetSortedUnitRolesByObjectType(IObjectType objectType)
-        {
-            if (!this.sortedUnitRolesByObjectType.TryGetValue(objectType, out var sortedUnitRoles))
-            {
-                var sortedUnitRoleList = new List<IRoleType>(((IComposite)objectType).DatabaseRoleTypes.Where(r => r.ObjectType.IsUnit));
-                sortedUnitRoleList.Sort();
-                sortedUnitRoles = sortedUnitRoleList.ToArray();
-                this.sortedUnitRolesByObjectType[objectType] = sortedUnitRoles;
-            }
-
-            return sortedUnitRoles;
-        }
+        public IRoleType[] GetSortedUnitRolesByObjectType(IObjectType objectType) =>
+            this.sortedUnitRolesByObjectType.GetOrAdd(
+                objectType,
+                key =>
+                {
+                    var sortedUnitRoleList = new List<IRoleType>(((IComposite)key).DatabaseRoleTypes.Where(r => r.ObjectType.IsUnit));
+                    sortedUnitRoleList.Sort();
+                    return sortedUnitRoleList.ToArray();
+                });
     }
 }


### PR DESCRIPTION
## BUG-10 — thread-safe shared `Database` lazy caches

The shared `Database` caches `concreteClassesByObjectType` and `sortedUnitRolesByObjectType` (computed lazily, read by every transaction) were plain `Dictionary`s populated with an unsynchronized `TryGetValue`-then-write. Two concurrent transactions hitting a cold cache could corrupt the dictionary (a documented `Dictionary` thread-safety hazard) or throw.

### Fix
Both fields -> `ConcurrentDictionary`, populated via `GetOrAdd`. The cached values (a `HashSet` and a sorted `IRoleType[]`) are immutable once built, so concurrent reads are safe; `GetOrAdd`''s factory may run more than once under contention but only one value is stored and returned to all callers. Used nowhere else.

### Tests
A race has no deterministic RED and a stress test would be flaky, so none was added — coverage is deferred to the planned general test-suite restructure (as with #08/#09). Build verified locally (0 errors); CI confirms no regression.