### PR TITLE
fix(dotnet-system): CreateObjects holds object ids as bigint, not int [BUG-15][BUG-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The SQL adapters' `CreateObjects` stored procedure now holds the generated object id in a `bigint` variable
+  instead of `INT`/`integer`, so creating objects no longer overflows once ids pass `int.MaxValue` (≈2.1 billion):
+  SqlClient's `@IDS` table variable and Npgsql's `ID` variable. (The unused `@O INT` declaration on SqlClient was
+  also removed.)
 - `Extent.CopyTo(array, index)` for a converted extent (the `IObject[] → Allors.Database.Extent` cast) now
   begins copying at the requested destination `index` instead of always at `0`. The override hardcoded `0` as
   the `Array.Copy` destination, ignoring its `index` parameter and overwriting earlier elements of the target.

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.Npgsql/Schema/Mapping.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.Npgsql/Schema/Mapping.cs
@@ -475,7 +475,7 @@ CREATE FUNCTION {name}({this.ParamNameForClass} {SqlTypeForClass}, {this.ParamNa
     RETURNS SETOF {SqlTypeForObject}
     LANGUAGE plpgsql
 AS $$
-DECLARE ID integer;
+DECLARE ID {SqlTypeForObject};
 DECLARE COUNTER integer := 0;
 BEGIN
     WHILE COUNTER < {this.ParamNameForCount} LOOP

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Mapping.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Mapping.cs
@@ -702,8 +702,8 @@ CREATE PROCEDURE {name}
     {this.ParamNameForCount} {"int"}
 AS
 BEGIN
-    DECLARE @IDS TABLE (id INT);
-    DECLARE @O INT, @COUNTER INT
+    DECLARE @IDS TABLE (id {SqlTypeForObject});
+    DECLARE @COUNTER INT
 
     SET @COUNTER = 0
     WHILE @COUNTER < {this.ParamNameForCount}


### PR DESCRIPTION
## BUG-15 + BUG-16 — `CreateObjects` holds object ids as bigint, not int

The generated `CreateObjects` stored procedure captured the newly-inserted `_o` identity (a **bigint**) into an undersized variable, so creating objects overflows/truncates once ids pass `int.MaxValue` (~2.1 billion):
- **SqlClient** `Mapping.cs`: `DECLARE @IDS TABLE (id INT)` (collects `SCOPE_IDENTITY()`)
- **Npgsql** `Mapping.cs`: `DECLARE ID integer` (holds `RETURNING … INTO ID`)

### Fix
Both now use the canonical object-id type `{SqlTypeForObject}` (= `bigint`, already used for every object-id column/param). Also removed the unused `@O INT` declaration on SqlClient.

### Tests
Fix-only — reproducing needs an identity reseed near 2^31 (SqlClient) and PostgreSQL is not available locally (Npgsql), so coverage is deferred to the planned general test-suite restructure (as with #08/#09, #10). Both adapter projects build clean; CI confirms no regression.