### PR TITLE
fix(dotnet-system): SqlClient LIKE follows ANSI semantics, '[' is literal [BUG-D3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ under a dated version heading.
 
 <!-- Add entries under one of: Added, Changed, Deprecated, Removed, Fixed, Security -->
 
+### Changed
+
+- The SqlClient adapter's `LIKE` filter now follows ANSI semantics like the Npgsql and in-memory adapters:
+  `%` and `_` are the only wildcards and `[` is matched literally. Previously T-SQL character classes
+  (e.g. `[abc]`, `[a-z]`, `[^…]`) were active only on SqlClient, so the same `LIKE` pattern could match
+  differently across adapters. Patterns that relied on SqlClient char-classes no longer match as classes
+  (that behaviour was never portable to Npgsql/Memory).
+
 ### Fixed
 
 - The SQL adapters' serialization `Load` now reads the staging objects table using the configured schema

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Mapping.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Mapping.cs
@@ -65,6 +65,10 @@ namespace Allors.Database.Adapters.Sql.SqlClient
         public override string Ascending => "ASC";
         public override string Descending => "DESC";
 
+        // T-SQL LIKE treats '[' as the start of a character class; '[[]' matches a literal '['. Escaping '['
+        // keeps '%' and '_' as wildcards (ANSI) while disabling char-class/range syntax, matching Npgsql and Memory.
+        public override string EscapeLikePattern(string like) => like.Replace("[", "[[]");
+
         public override IDictionary<IRelationType, string> TableNameForRelationByRelationType => this.tableNameForRelationByRelationType;
 
         internal const string SqlTypeForClass = "uniqueidentifier";

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Predicates/RoleLike.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Predicates/RoleLike.cs
@@ -24,7 +24,7 @@ namespace Allors.Database.Adapters.Sql
         internal override bool BuildWhere(ExtentStatement statement, string alias)
         {
             var schema = statement.Mapping;
-            statement.Append(" " + alias + "." + schema.ColumnNameByRelationType[this.role.RelationType] + " LIKE " + statement.AddParameter(this.like));
+            statement.Append(" " + alias + "." + schema.ColumnNameByRelationType[this.role.RelationType] + " LIKE " + statement.AddParameter(schema.EscapeLikePattern(this.like)));
             return this.Include;
         }
 

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Schema/Mapping.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql/Schema/Mapping.cs
@@ -47,5 +47,12 @@ namespace Allors.Database.Adapters.Sql
         public abstract string StringCollation { get; }
         public abstract string Ascending { get; }
         public abstract string Descending { get; }
+
+        /// <summary>
+        /// Escapes a SQL <c>LIKE</c> pattern so only <c>%</c> and <c>_</c> are wildcards (ANSI semantics). The
+        /// default leaves the pattern unchanged (PostgreSQL); SqlClient overrides it to neutralise T-SQL
+        /// character classes.
+        /// </summary>
+        public virtual string EscapeLikePattern(string like) => like;
     }
 }

--- a/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
+++ b/dotnet/System/Database/Adapters/Tests.Static/Static/ExtentTest.cs
@@ -16228,6 +16228,32 @@ namespace Allors.Database.Adapters
         }
 
         [Fact]
+        public void RoleStringLikeBracketIsLiteral()
+        {
+            foreach (var init in this.Inits)
+            {
+                init();
+                var m = this.Transaction.Database.Context().M;
+
+                var literal = (C1)this.Transaction.Create(m.C1);
+                literal.C1AllorsString = "[abc]";
+
+                var single = (C1)this.Transaction.Create(m.C1);
+                single.C1AllorsString = "a";
+
+                this.Transaction.Commit();
+
+                // ANSI SQL LIKE: '[abc]' is a literal pattern, not a T-SQL character class.
+                // It matches the literal string "[abc]" and not the single character "a".
+                var extent = this.Transaction.Extent(m.C1);
+                extent.Filter.AddLike(m.C1.C1AllorsString, "[abc]");
+
+                Assert.Single(extent);
+                Assert.Equal("[abc]", ((C1)extent[0]).C1AllorsString);
+            }
+        }
+
+        [Fact]
         public void InstantiateDuplicateIds()
         {
             foreach (var init in this.Inits)


### PR DESCRIPTION
## BUG-D3 — SqlClient LIKE follows ANSI semantics (`[` is literal)

The shared Sql `RoleLike` passed the pattern straight to the DB''s `LIKE`, so the same pattern behaved differently per engine:
- **SqlClient (T-SQL):** `[abc]` / `[a-z]` / `[^...]` are character classes.
- **Npgsql (Postgres) & Memory:** `[` is literal; only `%` and `_` are wildcards.

Per the design decision, Allors `LIKE` is now ANSI on every adapter.

### Fix
- New `Sql.Mapping.EscapeLikePattern(string)` hook — no-op default (Npgsql/Postgres already ANSI); SqlClient overrides it to escape `[` -> `[[]` (the T-SQL literal `[`), keeping `%`/`_` as wildcards.
- `RoleLike.BuildWhere` routes the pattern through it — covers `NOT LIKE` and every `AddLike` caller (`RoleLike` is the only LIKE-building predicate).

**Behavior change:** SqlClient `LIKE '[abc]'` is now literal, not a char-class (that behaviour was never portable to Npgsql/Memory).

### Test
New `ExtentTest.RoleStringLikeBracketIsLiteral` — `LIKE "[abc]"` matches the literal `"[abc]"`, not `"a"`. RED->GREEN on SqlClient; runs on Memory + Npgsql too (already ANSI) to confirm all three adapters now agree.