### PR TITLE
fix(dotnet-system): Local Pull releases its database transaction [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Local workspace adapter's `Pull` now releases (disposes) the database transaction it opens, once the
+  pull has been executed and synced, instead of leaving it open. Previously `Session.PullAsync` / `CallAsync`
+  created a transaction per pull that was never committed or disposed, leaking a database connection on every
+  pull — benign on the in-memory adapter (which reuses a single transaction) but a real connection leak on the
+  SQL adapters. The transaction is now released on every path via `try`/`finally`.
 - The SQL adapters' `CreateObjects` stored procedure now holds the generated object id in a `bigint` variable
   instead of `INT`/`integer`, so creating objects no longer overflows once ids pass `int.MaxValue` (≈2.1 billion):
   SqlClient's `@IDS` table variable and Npgsql's `ID` variable. (The unused `@O INT` declaration on SqlClient was

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Pull/Pull.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Pull/Pull.cs
@@ -325,6 +325,8 @@ namespace Allors.Workspace.Adapters.Local
             }
         }
 
+        internal void ReleaseTransaction() => this.Transaction.Dispose();
+
         private void Add(Database.IObject @object)
         {
             if (this.AccessControl[@object].IsMasked())

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
@@ -48,11 +48,18 @@ namespace Allors.Workspace.Adapters.Local
         {
             var result = new Pull(this);
 
-            result.Execute(procedure);
-            result.Execute(pull);
-            result.AddDependencies();
+            try
+            {
+                result.Execute(procedure);
+                result.Execute(pull);
+                result.AddDependencies();
 
-            this.OnPulled(result);
+                this.OnPulled(result);
+            }
+            finally
+            {
+                result.ReleaseTransaction();
+            }
 
             return Task.FromResult<IPullResult>(result);
         }
@@ -61,7 +68,14 @@ namespace Allors.Workspace.Adapters.Local
         {
             var result = new Pull(this);
 
-            result.Execute(args, name);
+            try
+            {
+                result.Execute(args, name);
+            }
+            finally
+            {
+                result.ReleaseTransaction();
+            }
 
             return Task.FromResult<IPullResult>(result);
         }
@@ -77,9 +91,17 @@ namespace Allors.Workspace.Adapters.Local
             }
 
             var result = new Pull(this);
-            result.Execute(pulls);
 
-            this.OnPulled(result);
+            try
+            {
+                result.Execute(pulls);
+
+                this.OnPulled(result);
+            }
+            finally
+            {
+                result.ReleaseTransaction();
+            }
 
             return Task.FromResult<IPullResult>(result);
         }


### PR DESCRIPTION
## Summary
`Pull` (Local workspace adapter) opened a database transaction in its constructor and never committed, rolled back, or disposed it, leaking a DB connection on every pull. This is benign on the in-memory adapter (which reuses a single cached transaction) but a real connection leak on the SQL adapters.

## Fix
- Add `Pull.ReleaseTransaction()`, which disposes the transaction. A pull is read-only, and per `ITransaction`'s docs `Commit`/`Rollback` are *rolling* (they start a fresh transaction rather than release the connection), so only `Dispose` actually releases it.
- Call it from `Session`'s three pull entry points (`CallAsync(procedure, pull)`, `CallAsync(args, name)`, `PullAsync`) via `try`/`finally`, after `OnPulled` has run its `Sync` (the last use of the transaction). The returned `IPullResult` stays fully usable: `Collections`/`Objects`/`Values` materialize from already-collected ids workspace-side, with no transaction needed.

## Tests
No automated test. The leak is unobservable in the only in-repo workspace test harness: the Local tests run on the in-memory adapter, which returns a single cached transaction and already disposes it via `Sync`'s `using` regardless of this bug. Verified by `dotnet build` (0 errors) and by review against the sibling `Invoke`/`Push` pattern. Regression gate: the `DotnetCoreWorkspace*Test` CI suites.