### PR TITLE
fix(dotnet-system): Local Invoke releases its database transaction [BUG-D4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ under a dated version heading.
   created a transaction per pull that was never committed or disposed, leaking a database connection on every
   pull — benign on the in-memory adapter (which reuses a single transaction) but a real connection leak on the
   SQL adapters. The transaction is now released on every path via `try`/`finally`.
+- The Local workspace adapter's `Invoke` now releases (disposes) the database transaction it opens, once the
+  method invocations have executed and been committed/rolled back, instead of leaving it open. `Session.InvokeAsync`
+  previously created a transaction per invoke that was committed/rolled back but never disposed — the same
+  connection leak as `Pull` above (benign on the in-memory adapter, a real connection leak on the SQL adapters).
+  The transaction is now released on every path via `try`/`finally`.
 - The SQL adapters' `CreateObjects` stored procedure now holds the generated object id in a `bigint` variable
   instead of `INT`/`integer`, so creating objects no longer overflows once ids pass `int.MaxValue` (≈2.1 billion):
   SqlClient's `@IDS` table variable and Npgsql's `ID` variable. (The unused `@O INT` declaration on SqlClient was

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Invoke/Invoke.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Invoke/Invoke.cs
@@ -93,6 +93,8 @@ namespace Allors.Workspace.Adapters.Local
             }
         }
 
+        internal void ReleaseTransaction() => this.Transaction.Dispose();
+
         private bool Execute(Method invocation)
         {
             var obj = this.Transaction.Instantiate(invocation.Object.Id);

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
@@ -40,7 +40,16 @@ namespace Allors.Workspace.Adapters.Local
         public override Task<IInvokeResult> InvokeAsync(Method[] methods, InvokeOptions options = null)
         {
             var result = new Invoke(this);
-            result.Execute(methods, options);
+
+            try
+            {
+                result.Execute(methods, options);
+            }
+            finally
+            {
+                result.ReleaseTransaction();
+            }
+
             return Task.FromResult<IInvokeResult>(result);
         }
 


### PR DESCRIPTION
## Summary
`Invoke` (Local workspace adapter) committed/rolled back its database transaction on every path but never disposed it, leaking a DB connection on every invoke. This is benign on the in-memory adapter (which reuses a single cached transaction) but a real connection leak on the SQL adapters. Same root cause as the `Pull` fix in #44 (BUG-03); discovered while fixing it.

## Fix
- Add `Invoke.ReleaseTransaction()`, which disposes the transaction. `Commit`/`Rollback` are *rolling* (they start a fresh transaction rather than release the connection), so only `Dispose` actually releases it.
- Call it from `Session.InvokeAsync(Method[], options)` via `try`/`finally`, after `Execute`. The `InvokeAsync(Method, options)` overload delegates to this one, so both are covered. The returned `IInvokeResult` stays usable: its error accessors read workspace-side via `Session.Instantiate`, and `Invoke` does no post-commit sync.

## Tests
No automated test, for the same reason as #44: the leak is unobservable in the only in-repo workspace test harness (the Local tests run on the in-memory adapter, which returns a single cached transaction). Verified by `dotnet build` (0 errors) and review against the `Pull`/`Push` pattern. Regression gate: the `DotnetCoreWorkspace*Test` CI suites.