### PR TITLE
fix(dotnet-system): Local Push releases its database transaction [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The Local workspace adapter's `Push` now releases (disposes) the database transaction it opens, instead of
+  leaving it open. `Session.PushAsync` previously returned without disposing on both the error path (the early
+  return when the push has errors — the transaction was then neither committed nor rolled back) and the success
+  path (committed but never disposed), leaking a database connection on every push — benign on the in-memory
+  adapter but a real connection leak on the SQL adapters. The transaction is now released on every path via
+  `try`/`finally`; on the error path disposal rolls back the uncommitted failed push.
 - The Local workspace adapter's `Pull` now releases (disposes) the database transaction it opens, once the
   pull has been executed and synced, instead of leaving it open. Previously `Session.PullAsync` / `CallAsync`
   created a transaction per pull that was never committed or disposed, leaking a database connection on every

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Push/Push.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Database/Push/Push.cs
@@ -138,6 +138,8 @@ namespace Allors.Workspace.Adapters.Local
             }
         }
 
+        internal void ReleaseTransaction() => this.Transaction.Dispose();
+
         private void PushRequestRoles(Strategy local, IObject obj)
         {
             if (local.DatabaseOriginState.ChangedRoleByRelationType == null)

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Local/Session/Session.cs
@@ -112,35 +112,42 @@ namespace Allors.Workspace.Adapters.Local
 
             var result = new Push(this);
 
-            result.Execute(databaseTracker);
-
-            if (result.HasErrors)
+            try
             {
+                result.Execute(databaseTracker);
+
+                if (result.HasErrors)
+                {
+                    return Task.FromResult<IPushResult>(result);
+                }
+
+                databaseTracker.Changed = null;
+
+                if (result.ObjectByNewId?.Count > 0)
+                {
+                    foreach (var kvp in result.ObjectByNewId)
+                    {
+                        var workspaceId = kvp.Key;
+                        var databaseId = kvp.Value.Id;
+
+                        this.OnDatabasePushResponseNew(workspaceId, databaseId);
+                    }
+                }
+
+                databaseTracker.Created = null;
+
+                foreach (var @object in result.Objects)
+                {
+                    var strategy = this.GetStrategy(@object.Id);
+                    strategy.OnDatabasePushed();
+                }
+
                 return Task.FromResult<IPushResult>(result);
             }
-
-            databaseTracker.Changed = null;
-
-            if (result.ObjectByNewId?.Count > 0)
+            finally
             {
-                foreach (var kvp in result.ObjectByNewId)
-                {
-                    var workspaceId = kvp.Key;
-                    var databaseId = kvp.Value.Id;
-
-                    this.OnDatabasePushResponseNew(workspaceId, databaseId);
-                }
+                result.ReleaseTransaction();
             }
-
-            databaseTracker.Created = null;
-
-            foreach (var @object in result.Objects)
-            {
-                var strategy = this.GetStrategy(@object.Id);
-                strategy.OnDatabasePushed();
-            }
-
-            return Task.FromResult<IPushResult>(result);
         }
 
         internal void OnPulled(Pull pull)


### PR DESCRIPTION
## Summary
`Push` (Local workspace adapter) opened a database transaction in its constructor and never disposed it. On the success path it committed but never released the connection; on the error path (the `HasErrors` early return in `Session.PushAsync`) it neither committed, rolled back, nor disposed it. Either way the connection leaked on every push — benign on the in-memory adapter (which reuses a single cached transaction) but a real connection leak on the SQL adapters.

The original review flagged only the error path; verifying confirmed **both** paths leak.

## Fix
- Add `Push.ReleaseTransaction()`, which disposes the transaction (`Commit`/`Rollback` are *rolling* and keep the connection; only `Dispose` releases it).
- Wrap the whole `PushAsync` body in `try`/`finally` so the transaction is released on the error return, the success return, and any exception. On the error path `Dispose` rolls back the uncommitted failed push. The post-`Execute` bookkeeping (`OnDatabasePushResponseNew`, `OnDatabasePushed`) runs inside the `try` before the `finally`, so the transaction is alive for it; the returned `IPushResult`'s error accessors read workspace-side, so disposal after is safe.

Completes the workspace transaction-leak cluster: `Pull` (#44, merged), `Invoke` (#45), `Push` (this PR).

## Tests
No automated test, same as #44/#45: the leak is unobservable in the only in-repo workspace test harness (the Local tests run on the in-memory adapter, which returns a single cached transaction). Verified by `dotnet build` (0 errors) and review against the `Pull`/`Invoke` pattern. Regression gate: the `DotnetCoreWorkspace*Test` CI suites.