### PR TITLE
fix(dotnet-system): SetCompositeRoleMany2One detaches the previous role [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ under a dated version heading.
   `InvalidCastException` (e.g. casting `JsonElement` to `int`/`byte[]`). It now routes the value through the
   adapter's `IUnitConvert`, mapping the requested CLR type to its unit tag, so values round-trip to the correct
   type. (Pull values are sent untagged, so the conversion is keyed by `T`.)
+- The workspace adapters' session-origin `SetCompositeRoleMany2One` no longer leaves a stale inverse when an
+  object's many-to-one composite role is reassigned. When changing `A`'s role from `PR` to `R` it detached the
+  *new* role `R` (a no-op, since `A` was not yet associated with `R`) instead of the *previous* role `PR`, so
+  `PR`'s inverse association still listed `A` while `A`'s role was already `R`. It now detaches the previous
+  role, matching the one-to-one sibling. Affects the Local and Remote workspace adapters.
 - The workspace `ContainedIn` predicate with an explicit object list now round-trips over the JSON protocol.
   Both `ToJsonVisitor`s (the workspace and the database one) serialized the objects to the `vs` (values) field,
   but the database `FromJsonVisitor` reads them from `obs` (the object-id field), so the object list was lost in

--- a/dotnet/Core/Workspace/Tests/Tests/Session/ManyToOneTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/ManyToOneTests.cs
@@ -110,5 +110,49 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
                 }
             }
         }
+
+        [Fact]
+        public async void ReplaceRole()
+        {
+            foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
+            {
+                foreach (DatabaseMode mode2 in Enum.GetValues(typeof(DatabaseMode)))
+                {
+                    foreach (var contextFactory in this.contextFactories)
+                    {
+                        var ctx = contextFactory();
+                        var (session1, session2) = ctx;
+
+                        var c1x_1 = await ctx.Create<C1>(session1, mode1);
+                        var c1a_2 = await ctx.Create<C1>(session2, mode2);
+                        var c1b_2 = await ctx.Create<C1>(session2, mode2);
+
+                        c1x_1.ShouldNotBeNull(ctx, mode1, mode2);
+                        c1a_2.ShouldNotBeNull(ctx, mode1, mode2);
+                        c1b_2.ShouldNotBeNull(ctx, mode1, mode2);
+
+                        await session2.PushAsync();
+                        var resultA = await session1.PullAsync(new Pull { Object = c1a_2 });
+                        var c1a_1 = (C1)resultA.Objects.Values.First();
+                        var resultB = await session1.PullAsync(new Pull { Object = c1b_2 });
+                        var c1b_1 = (C1)resultB.Objects.Values.First();
+
+                        c1a_1.ShouldNotBeNull(ctx, mode1, mode2);
+                        c1b_1.ShouldNotBeNull(ctx, mode1, mode2);
+
+                        // initial role
+                        c1x_1.SessionC1Many2One = c1a_1;
+                        c1x_1.SessionC1Many2One.ShouldEqual(c1a_1, ctx, mode1, mode2);
+                        c1a_1.C1sWhereSessionC1Many2One.ShouldContain(c1x_1, ctx, mode1, mode2);
+
+                        // reassign to another role: the previous role's inverse association must be cleared
+                        c1x_1.SessionC1Many2One = c1b_1;
+                        c1x_1.SessionC1Many2One.ShouldEqual(c1b_1, ctx, mode1, mode2);
+                        c1b_1.C1sWhereSessionC1Many2One.ShouldContain(c1x_1, ctx, mode1, mode2);
+                        c1a_1.C1sWhereSessionC1Many2One.ShouldNotContain(c1x_1, ctx, mode1, mode2);
+                    }
+                }
+            }
+        }
     }
 }

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters/Session/OriginState/SessionOriginState.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters/Session/OriginState/SessionOriginState.cs
@@ -168,7 +168,7 @@ namespace Allors.Workspace.Adapters
             // A --x-- PR
             if (previousRole != null)
             {
-                this.RemoveCompositeRoleMany2One(association, roleType, role);
+                this.RemoveCompositeRoleMany2One(association, roleType, previousRole);
             }
 
             // A <---- R


### PR DESCRIPTION
## Summary
Reassigning an object's session-origin many-to-one composite role from `PR` to `R` detached the **new** role `R` (a no-op, since the object was not yet associated with `R`) instead of the **previous** role `PR`. As a result `PR`'s inverse association still listed the object while its role was already `R` — a stale inverse.

`SessionOriginState.SetCompositeRoleMany2One` now passes `previousRole` (not `role`) to `RemoveCompositeRoleMany2One`, matching the one-to-one sibling. Affects the Local and Remote workspace adapters (shared `Allors.Workspace.Adapters`).

## Test (real red→green)
Added `[Fact] ReplaceRole` to the shared session `ManyToOneTests` (`dotnet/Core/Workspace/Tests`), mirroring the existing `SetRole`/`RemoveRole` (mode × context matrix). No existing test reassigned a many-to-one role, which is how the bug slipped through. It sets the role to one target, reassigns to another, and asserts the previous target's inverse no longer contains the object.

- **RED** (before fix): `[C1:…] should not contain C1:…` at `ManyToOneTests.cs:152`.
- **GREEN** (after fix): passes across all mode/context combinations (Local/in-memory harness).

This PR spans `dotnet/System` (the fix) and `dotnet/Core` (the test — the only workspace test home). Regression gate: the `DotnetCoreWorkspace*Test` CI suites.