### PR TITLE
fix(dotnet-system): ContainedIn-by-objects round-trips over JSON via obs [BUG-06][BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The workspace `ContainedIn` predicate with an explicit object list now round-trips over the JSON protocol.
+  Both `ToJsonVisitor`s (the workspace and the database one) serialized the objects to the `vs` (values) field,
+  but the database `FromJsonVisitor` reads them from `obs` (the object-id field), so the object list was lost in
+  transit — a `ContainedIn { Objects = … }` pull reached the server with neither objects nor extent and failed
+  with HTTP 500. The writers now use `obs`, matching the reader and the `ob`/`obs` convention. (The `Extent`
+  form of `ContainedIn` was unaffected.)
 - The Local workspace adapter's `Push` now releases (disposes) the database transaction it opens, instead of
   leaving it open. `Session.PushAsync` previously returned without disposing on both the error path (the early
   return when the push has errors — the transaction was then neither committed nor rolled back) and the success

--- a/dotnet/Core/Workspace/Tests/Tests/PullTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/PullTests.cs
@@ -155,6 +155,42 @@ namespace Tests.Workspace
         }
 
         [Fact]
+        public async void AssociationMany2ManyContainedInObjects()
+        {
+            await this.Login("administrator");
+
+            var session = this.Workspace.CreateSession();
+            var m = this.M;
+
+            // The "ᴀbra" C1 objects, passed explicitly (the by-Objects form of ContainedIn,
+            // as opposed to the by-Extent form exercised by AssociationMany2ManyContainedIn).
+            var c1Result = await session.PullAsync(new Pull
+            {
+                Extent = new Filter(this.M.C1)
+                {
+                    Predicate = new Equals(m.C1.C1AllorsString) { Value = "ᴀbra" }
+                }
+            });
+            var abraC1s = c1Result.GetCollection<C1>();
+
+            var pull = new Pull
+            {
+                Extent = new Filter(this.M.C2)
+                {
+                    Predicate = new ContainedIn(m.C2.C1sWhereC1C2Many2Many) { Objects = abraC1s }
+                }
+            };
+
+            var result = await session.PullAsync(pull);
+
+            Assert.Single(result.Collections);
+            Assert.Empty(result.Objects);
+            Assert.Empty(result.Values);
+
+            result.Assert().Collection<C2>().Equal(c2B);
+        }
+
+        [Fact]
         public async void AssociationMany2ManyContains()
         {
             await this.Login("administrator");

--- a/dotnet/System/Database/Allors.Database.Workspace.Json/Data/ToJsonVisitor.cs
+++ b/dotnet/System/Database/Allors.Database.Workspace.Json/Data/ToJsonVisitor.cs
@@ -96,7 +96,7 @@ namespace Allors.Database.Protocol.Json
                 d = visited.Dependencies,
                 a = (visited.PropertyType as IAssociationType)?.RelationType.Tag,
                 r = (visited.PropertyType as IRoleType)?.RelationType.Tag,
-                vs = visited.Objects?.Select(v => v.Id.ToString()).ToArray(),
+                obs = visited.Objects?.Select(v => v.Id).ToArray(),
                 p = visited.Parameter,
             };
 

--- a/dotnet/System/Workspace/Allors.Workspace.Protocol.Json/Data/ToJsonVisitor.cs
+++ b/dotnet/System/Workspace/Allors.Workspace.Protocol.Json/Data/ToJsonVisitor.cs
@@ -96,7 +96,7 @@ namespace Allors.Workspace.Protocol.Json
                 d = visited.Dependencies,
                 a = (visited.PropertyType as IAssociationType)?.RelationType.Tag,
                 r = (visited.PropertyType as IRoleType)?.RelationType.Tag,
-                vs = visited.Objects?.Select(v => v.Id as object).ToArray(),
+                obs = visited.Objects?.Select(v => v.Id).ToArray(),
                 p = visited.Parameter,
             };
 


### PR DESCRIPTION
## Summary
A workspace `ContainedIn` predicate built with an explicit object list (`new ContainedIn(...) { Objects = ... }`) lost its objects over the JSON protocol. Both `ToJsonVisitor`s (workspace and database) serialized `visited.Objects` to the **`vs`** (values) field, but the database `FromJsonVisitor` reads them from **`obs`** (the object-id field, matching the `ob`/`obs` convention). So the predicate reached the server with neither objects nor extent and the pull failed with **HTTP 500**.

The `Extent` form of `ContainedIn` (serialized via `e`) was unaffected — which is why every existing (Extent-form) `ContainedIn` test passed and the bug hid.

## Fix (one PR for #06 + D1)
Both writers now emit `obs` (a `long[]`):
- `Allors.Workspace.Protocol.Json/.../ToJsonVisitor.cs`
- `Allors.Database.Workspace.Json/.../ToJsonVisitor.cs`

The database `FromJsonVisitor` reader was already canonical (`obs`), so **D1 needs no change** — it's resolved by the writers agreeing on `obs`.

## Test (real red→green)
Added `AssociationMany2ManyContainedInObjects` to the shared `PullTests` (the by-Objects analogue of the existing Extent-form `AssociationMany2ManyContainedIn`). Verified against the **Remote.Json server harness**: the pull **500'd before the fix** and **passes after**. Regression gate: the `DotnetCoreWorkspaceRemoteJson*Test` (SystemText + Newtonsoft) CI suites.