### PR TITLE
fix(dotnet-system): Remote GetValue<T> converts pulled JSON values [BUG-20]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The remote workspace adapter's `IPullResult.GetValue<T>` now converts a pulled value to `T` instead of
+  hard-casting the raw deserialized JSON. `PullResult.Values` exposes values as received over the wire (a
+  `JsonElement` for System.Text.Json, a boxed/`JToken` value for Newtonsoft), so `GetValue<T>` threw
+  `InvalidCastException` (e.g. casting `JsonElement` to `int`/`byte[]`). It now routes the value through the
+  adapter's `IUnitConvert`, mapping the requested CLR type to its unit tag, so values round-trip to the correct
+  type. (Pull values are sent untagged, so the conversion is keyed by `T`.)
 - The workspace `ContainedIn` predicate with an explicit object list now round-trips over the JSON protocol.
   Both `ToJsonVisitor`s (the workspace and the database one) serialized the objects to the `vs` (values) field,
   but the database `FromJsonVisitor` reads them from `obs` (the object-id field), so the object list was lost in

--- a/dotnet/Core/Database/Domain/Custom/Procedures/TestValues.cs
+++ b/dotnet/Core/Database/Domain/Custom/Procedures/TestValues.cs
@@ -1,0 +1,24 @@
+// <copyright file="TestValues.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Allors.Database.Domain
+{
+    using System;
+
+    public class TestValues : IProcedure
+    {
+        public void Execute(IProcedureContext context, IProcedureInput input, IProcedureOutput output)
+        {
+            output.AddValue("allorsBinary", new byte[] { 1, 2, 3 });
+            output.AddValue("allorsBoolean", true);
+            output.AddValue("allorsDateTime", new DateTime(1973, 3, 27, 0, 0, 0, DateTimeKind.Utc));
+            output.AddValue("allorsDecimal", 12.34m);
+            output.AddValue("allorsDouble", 123d);
+            output.AddValue("allorsInteger", 1000);
+            output.AddValue("allorsString", "a string");
+            output.AddValue("allorsUnique", new Guid("2946CF37-71BE-4681-8FE6-D0024D59BEFF"));
+        }
+    }
+}

--- a/dotnet/Core/Workspace/Tests/Tests/ProcedureTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/ProcedureTests.cs
@@ -81,6 +81,28 @@ namespace Tests.Workspace
         }
 
         [Fact]
+        public async void TestValues()
+        {
+            await this.Login("administrator");
+            var session = this.Workspace.CreateSession();
+
+            var procedure = new Procedure("TestValues");
+
+            var result = await session.CallAsync(procedure);
+
+            Assert.False(result.HasErrors);
+
+            Assert.Equal(new byte[] { 1, 2, 3 }, result.GetValue<byte[]>("allorsBinary"));
+            Assert.True(result.GetValue<bool>("allorsBoolean"));
+            Assert.Equal(new DateTime(1973, 3, 27, 0, 0, 0, DateTimeKind.Utc), result.GetValue<DateTime>("allorsDateTime"));
+            Assert.Equal(12.34m, result.GetValue<decimal>("allorsDecimal"));
+            Assert.Equal(123d, result.GetValue<double>("allorsDouble"));
+            Assert.Equal(1000, result.GetValue<int>("allorsInteger"));
+            Assert.Equal("a string", result.GetValue<string>("allorsString"));
+            Assert.Equal(new Guid("2946CF37-71BE-4681-8FE6-D0024D59BEFF"), result.GetValue<Guid>("allorsUnique"));
+        }
+
+        [Fact]
         public async void NonExistingProcedure()
         {
             await this.Login("administrator");

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Remote/Database/Pull/PullResult.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Remote/Database/Pull/PullResult.cs
@@ -5,8 +5,10 @@
 
 namespace Allors.Workspace.Adapters.Remote
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Allors.Protocol.Json;
     using Allors.Protocol.Json.Api.Pull;
 
     public class PullResult : Result, IPullResultInternals
@@ -19,10 +21,13 @@ namespace Allors.Workspace.Adapters.Remote
 
         private readonly PullResponse pullResponse;
 
-        public PullResult(Adapters.Session session, PullResponse response) : base(session, response)
+        private readonly IUnitConvert unitConvert;
+
+        public PullResult(Adapters.Session session, PullResponse response, IUnitConvert unitConvert) : base(session, response)
         {
             this.Workspace = session.Workspace;
             this.pullResponse = response;
+            this.unitConvert = unitConvert;
         }
 
         private IWorkspace Workspace { get; }
@@ -53,6 +58,32 @@ namespace Allors.Workspace.Adapters.Remote
 
         public object GetValue(string key) => this.Values[key.ToUpperInvariant()];
 
-        public T GetValue<T>(string key) => (T)this.GetValue(key.ToUpperInvariant());
+        public T GetValue<T>(string key)
+        {
+            var value = this.GetValue(key.ToUpperInvariant());
+
+            return value switch
+            {
+                null => default,
+                T typed => typed,
+                _ => (T)this.unitConvert.UnitFromJson(UnitTagForType(typeof(T)), value),
+            };
+        }
+
+        private static string UnitTagForType(Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (type == typeof(int)) return UnitTags.Integer;
+            if (type == typeof(string)) return UnitTags.String;
+            if (type == typeof(bool)) return UnitTags.Boolean;
+            if (type == typeof(decimal)) return UnitTags.Decimal;
+            if (type == typeof(double)) return UnitTags.Float;
+            if (type == typeof(DateTime)) return UnitTags.DateTime;
+            if (type == typeof(Guid)) return UnitTags.Unique;
+            if (type == typeof(byte[])) return UnitTags.Binary;
+
+            throw new ArgumentException($"Unit type not supported: {type}");
+        }
     }
 }

--- a/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Remote/Session/Session.cs
+++ b/dotnet/System/Workspace/Adapters/Allors.Workspace.Adapters.Remote/Session/Session.cs
@@ -49,7 +49,7 @@ namespace Allors.Workspace.Adapters.Remote
 
         internal async Task<IPullResult> OnPull(PullResponse pullResponse)
         {
-            var pullResult = new PullResult(this, pullResponse);
+            var pullResult = new PullResult(this, pullResponse, this.DatabaseConnection.UnitConvert);
 
             if (pullResult.HasErrors)
             {


### PR DESCRIPTION
## Summary
`PullResult.Values` (remote workspace adapter) exposes pull values exactly as received over the wire — a `JsonElement` for System.Text.Json, a boxed/`JToken` value for Newtonsoft — and `GetValue<T>` did a hard `(T)` cast, throwing `InvalidCastException` (e.g. `JsonElement` → `int`/`byte[]`). Pull values are sent **untagged** (`PullResponseBuilder` ships raw CLR values), so the client must convert keyed by the requested `T`. No existing procedure outputs a *value* (all return objects), so `GetValue<T>` had no coverage and the bug hid.

## Fix (`dotnet/System`, no public-API addition)
`GetValue<T>` now returns `default` for null, returns the value if it's already a `T`, and otherwise converts via the adapter's existing `IUnitConvert.UnitFromJson(tag, value)` with a CLR-type→`UnitTags` map (`int`→Integer, `string`→String, `bool`→Boolean, `decimal`→Decimal, `double`→Float, `DateTime`→DateTime, `Guid`→Unique, `byte[]`→Binary; `Nullable<T>` unwrapped). `IUnitConvert` is injected via the `PullResult` ctor (single call site, `Session.OnPull`). Works for both JSON adapters.

## Test (real red→green)
Added a `TestValues` procedure (`dotnet/Core`, auto-discovered) that emits one value of each unit type, plus `ProcedureTests.TestValues` asserting `GetValue<T>` for each. Verified against the **Remote.Json server harness**: `InvalidCastException` before the fix → passes after. Regression gate: the `DotnetCoreWorkspaceRemoteJson*Test` (SystemText + Newtonsoft) CI suites.

PR spans `dotnet/System` (fix) + `dotnet/Core` (test procedure + test).