### PR TITLE
fix(core): build nested prefetch policy on the nested builder [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `PrefetchPolicyBuilder.WithNodes` now nests a tree node's child prefetch rules under their parent role
+  instead of flattening them onto the root policy. The `WithNode` helper created a nested builder for the
+  child nodes but recursed on the outer builder (`@this`), so the nested policy was always empty (deeper
+  tree levels were never prefetched) and the child rules — and their security rules — leaked onto the
+  outer policy. It now recurses on the nested builder.
 - The remote workspace adapter's `IPullResult.GetValue<T>` now converts a pulled value to `T` instead of
   hard-casting the raw deserialized JSON. `PullResult.Values` exposes values as received over the wire (a
   `JsonElement` for System.Text.Json, a boxed/`JToken` value for Newtonsoft), so `GetValue<T>` threw

--- a/dotnet/Core/Database/Domain.Tests/Domain/Meta/TreeTests.cs
+++ b/dotnet/Core/Database/Domain.Tests/Domain/Meta/TreeTests.cs
@@ -266,5 +266,24 @@ namespace Allors.Database.Domain.Tests
             tree = new[] { new Node(this.M.C1.C1C1Many2Manies) };
             new PrefetchPolicyBuilder().WithNodes(tree, this.M).Build();
         }
+
+        [Fact]
+        public void WithNodeBuildsNestedPolicyWithoutLeakingToOuter()
+        {
+            var outerRole = this.M.C1.C1C1Many2Manies;
+            var nestedRole = this.M.C1.C1C2Many2Manies;
+
+            var tree = new[] { new Node(outerRole).Add(nestedRole) };
+            var prefetchPolicy = new PrefetchPolicyBuilder().WithNodes(tree, this.M).Build();
+
+            var outerRule = Assert.Single(prefetchPolicy.PrefetchRules, r => Equals(r.PropertyType, outerRole));
+
+            // The child rule must live on the nested policy ...
+            Assert.NotNull(outerRule.PrefetchPolicy);
+            Assert.Contains(outerRule.PrefetchPolicy.PrefetchRules, r => Equals(r.PropertyType, nestedRole));
+
+            // ... and must not have leaked onto the outer policy.
+            Assert.DoesNotContain(prefetchPolicy.PrefetchRules, r => Equals(r.PropertyType, nestedRole));
+        }
     }
 }

--- a/dotnet/Core/Database/Domain/Core/Extensions/PrefetchPolicyBuilderExtensions.cs
+++ b/dotnet/Core/Database/Domain/Core/Extensions/PrefetchPolicyBuilderExtensions.cs
@@ -70,7 +70,7 @@ namespace Allors.Database.Domain
                 var nestedPrefetchPolicyBuilder = new PrefetchPolicyBuilder();
                 foreach (var node in treeNode.Nodes)
                 {
-                    @this.WithNode(node, m);
+                    nestedPrefetchPolicyBuilder.WithNode(node, m);
                 }
 
                 var nestedPrefetchPolicy = nestedPrefetchPolicyBuilder.Build();


### PR DESCRIPTION
## BUG-03 — Nested prefetch policy built on the outer builder

`PrefetchPolicyBuilderExtensions.WithNode` builds a nested `PrefetchPolicyBuilder` for a tree node''s children, but the recursion looped on the **outer** builder (`@this`) instead of the nested one. As a result:

- the nested policy attached to the parent role was always **empty** — deeper tree levels were never prefetched;
- the child rules (and, for composite children, their security rules) **leaked onto the outer/root policy**.

### Fix
Recurse on `nestedPrefetchPolicyBuilder` (one line). No public-API change.

### Test (TDD)
Added `TreeTests.WithNodeBuildsNestedPolicyWithoutLeakingToOuter`, asserting on the built `PrefetchPolicy` structure — the existing `Resolve*` tests can''t catch this because `Resolve` loads data on-demand regardless of a malformed prefetch policy:

- before the fix: `Assert.Contains() Failure … Collection: []` (nested policy empty);
- after the fix: passes.

CHANGELOG updated under `[Unreleased] › Fixed`.