### PR TITLE
fix(core): quote forwarded arguments in commands.sh [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `commands.sh` now forwards its arguments with `"$@"` instead of the unquoted `$*`, so an argument
+  containing spaces (or shell glob characters) reaches `Database/Commands` as a single token instead of
+  being word-split/globbed. Previously e.g. a file path with a space was split into several arguments.
 - The resource `Merger` no longer corrupts a resx `<data>` entry when the same key appears in more than one
   input directory. For an existing key it ran `data.Value = mergeData.Value`, whose setter replaces the
   entry's child elements (the `<value>`, and any `<comment>`) with a single raw-text node — emitting

--- a/dotnet/Core/commands.sh
+++ b/dotnet/Core/commands.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet run --verbosity q --project Database/Commands -- $*
+dotnet run --verbosity q --project Database/Commands -- "$@"


### PR DESCRIPTION
## BUG-02 — Unquoted `$*` word-splits forwarded arguments

`dotnet/Core/commands.sh` forwarded its arguments to `Database/Commands` with an unquoted `$*`:

```sh
dotnet run --verbosity q --project Database/Commands -- $*
```

Unquoted `$*` undergoes word-splitting (on `IFS`) and pathname expansion (globbing), so an argument containing a space is broken into several tokens — and any `*`/`?`/`[` is glob-expanded — before it reaches the command.

### Fix
Forward with `"$@"`, which expands each positional parameter as a separate, individually-quoted word (preserving spaces, suppressing globbing). One line.

### Verification
Fix-only (`shell` tier — no .NET test for a shell wrapper):

- `bash -n` and `sh -n` both pass (script is `#!/bin/sh`; `"$@"` is POSIX).
- Behavioural demo `set -- Populate "my file.xml" --flag; printf '[%s]\n' "$@"` → `[Populate] [my file.xml] [--flag]` (the spaced argument stays a single token).

CHANGELOG updated under `[Unreleased] › Fixed`.