### PR TITLE
fix(core): render many-valued roles with [] in uml.cs.stg [BUG-14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The workspace UML diagram template (`Workspace/Templates/uml.cs.stg`) now renders a many-valued role as
+  an array type (`ElementType[]`), matching the database diagram template; its many-valued branch previously
+  emitted the element type without the `[]`, so a collection role looked like a single-valued one.
 - `commands.sh` now forwards its arguments with `"$@"` instead of the unquoted `$*`, so an argument
   containing spaces (or shell glob characters) reaches `Database/Commands` as a single token instead of
   being word-split/globbed. Previously e.g. a file path with a space was split into several arguments.

--- a/dotnet/Core/Workspace/Templates/uml.cs.stg
+++ b/dotnet/Core/Workspace/Templates/uml.cs.stg
@@ -48,7 +48,7 @@ roleType(roleType) ::= <<
 $if(roleType.IsOne)$
 			$nullableName(roleType)$ $roleType.SingularName$ {set;}
 $else$
-			$nullableName(roleType)$ $roleType.PluralName$ {set;}
+			$nullableName(roleType)$[] $roleType.PluralName$ {set;}
 $endif$
 >>
 


### PR DESCRIPTION
## BUG-14 — `uml.cs.stg` omits `[]` for many-valued roles

The workspace UML diagram template (`Workspace/Templates/uml.cs.stg`) rendered a many-valued role without array brackets:

```stg
$else$
            $nullableName(roleType)$ $roleType.PluralName$ {set;}   <- no []
$endif$
```

`nullableName` yields the **element** type, so a collection role was emitted as if it were single-valued. Add `[]` to match the actively-generated database template (`Database/Templates/uml.cs.stg`), whose many-valued branch is `$nullableName(roleType)$[] …`.

### Scope
Minimal: `[]` only. The Database template also prefixes `$prefix(roleType)$`, but the workspace template defines no `prefix` helper and the finding is scoped to the missing `[]`.

### Validation
Fix-only / golden-by-reference. Note: the workspace uml generation is currently **commented out** in `Database/Generate/Program.cs`, so `DotnetCoreGenerate` does not exercise this template; this is a latent template-correctness fix, validated by structural parity with the proven database template. CHANGELOG updated under `[Unreleased] › Fixed`.