### PR TITLE
fix(core): preserve resx structure when merging duplicate keys [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The resource `Merger` no longer corrupts a resx `<data>` entry when the same key appears in more than one
+  input directory. For an existing key it ran `data.Value = mergeData.Value`, whose setter replaces the
+  entry's child elements (the `<value>`, and any `<comment>`) with a single raw-text node — emitting
+  `<data name="…">text</data>` instead of `<data name="…"><value>text</value></data>`, which is not valid
+  resx. It now replaces the whole element with a clone of the incoming one (matching the new-key branch),
+  preserving the `<value>`/`<comment>` children and the incoming attributes.
 - `PrefetchPolicyBuilder.WithNodes` now nests a tree node's child prefetch rules under their parent role
   instead of flattening them onto the root policy. The `WithNode` helper created a nested builder for the
   child nodes but recursed on the outer builder (`@this`), so the nested policy was always empty (deeper

--- a/dotnet/Core/Database/Merge/Merging/ResourceFile.cs
+++ b/dotnet/Core/Database/Merge/Merging/ResourceFile.cs
@@ -44,7 +44,7 @@ namespace Allors.R1.Development.Resources
 
                 if (data != null)
                 {
-                    data.Value = mergeData.Value;
+                    data.ReplaceWith(new XElement(mergeData));
                 }
                 else
                 {

--- a/dotnet/Core/Database/Resources/DomainErrors.resx
+++ b/dotnet/Core/Database/Resources/DomainErrors.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DerivationErrorAtLeastOne" xml:space="preserve">
-    {0} at least one!
+    <value>{0} at least one!</value>
   </data>
   <data name="DerivationErrorAtMostOne" xml:space="preserve">
     <value>{0} at most one</value>


### PR DESCRIPTION
## BUG-09 — `ResourceFile.Merge` corrupts a resx `<data>` entry for overlapping keys

`Merger` overlays same-named resx files across input directories (`Resources/Core`, then `Resources/Custom`). For a key present in both, `ResourceFile.Merge` ran:

```csharp
data.Value = mergeData.Value;
```

The `XElement.Value` **setter** replaces all child nodes with a single text node, so a resx entry `<data name="X" xml:space="preserve"><value>…</value></data>` collapsed to `<data name="X" …>…raw text…</data>` — dropping the `<value>` (and any `<comment>`) child, which is not valid resx.

This was not hypothetical: `DerivationErrorAtLeastOne` exists in both `Core/DomainErrors.resx` and `Custom/DomainErrors.resx`, and the committed merge output `Resources/DomainErrors.resx` shipped it corrupted (raw text, no `<value>`).

### Fix
Replace the whole element with a clone of the incoming one (mirroring the new-key `else` branch), preserving the `<value>`/`<comment>` children and attributes:

```diff
-                    data.Value = mergeData.Value;
+                    data.ReplaceWith(new XElement(mergeData));
```

### Validation (fix-only + regenerate)
`ResourceFile`/`Merger` have no test project (a follow-up to add `Merge.Tests` is tracked separately). Validated via the real pipeline:

1. `.\build.ps1 DotnetCoreMerge` on unmodified code → **empty git diff** (the committed corruption reproduces exactly — stable baseline / RED).
2. After the fix, `.\build.ps1 DotnetCoreMerge` regenerates the output; the only change is the restored wrapper:

```diff
   <data name="DerivationErrorAtLeastOne" xml:space="preserve">
-    {0} at least one!
+    <value>{0} at least one!</value>
   </data>
```

`ErrorMessages.resx` is unchanged. The regenerated `Resources/DomainErrors.resx` (a tracked merge output) is committed alongside the fix. CHANGELOG updated under `[Unreleased] › Fixed`.