### PR TITLE
fix(core): validate Pull dependency meta tags [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Json API's `Pull` no longer crashes (`NullReferenceException` → HTTP 500) when a request dependency
+  carries an unknown or wrong-kind meta tag. `Api.ToDependencies` cast each client-supplied tag
+  (`FindByTag(...)`) to `IComposite`/`IRelationType` and dereferenced it unchecked, so a bogus `o`/`a`/`r`
+  tag null-crashed the whole pull. Unresolvable dependencies — which are only prefetch hints — are now
+  skipped (and logged as a warning, since they indicate a faulty client), so the pull proceeds normally.
 - The workspace UML diagram template (`Workspace/Templates/uml.cs.stg`) now renders a many-valued role as
   an array type (`ElementType[]`), matching the database diagram template; its many-valued branch previously
   emitted the element type without the `[]`, so a collection role looked like a single-valued one.

--- a/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullInstantiateTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullInstantiateTests.cs
@@ -217,5 +217,34 @@ namespace Tests
             Assert.Single(pool);
             Assert.Contains(pool, v => v.i == c1b.Id);
         }
+
+        [Fact]
+        public void UnknownPullDependencyTagIsIgnored()
+        {
+            this.SetUser("jane@example.com");
+
+            var c1b = new C1s(this.Transaction).Extent().First(v => "c1B".Equals(v.Name));
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
+            var pull = new Pull { Object = c1b, Results = new[] { new Result { Name = "Data" }, } };
+
+            var pullRequest = new PullRequest
+            {
+                l = new[] { pull.ToJson(this.UnitConvert) },
+                d = new[]
+                {
+                    new PullDependency { o = "an-unknown-object-type-tag", r = this.M.C1.C1C2One2One.RelationType.Tag },
+                },
+            };
+
+            var api = new Api(this.Transaction, "Default", CancellationToken.None);
+
+            // An unknown dependency tag must be ignored, not crash the pull (previously a NullReferenceException).
+            var pullResponse = api.Pull(pullRequest);
+
+            Assert.Equal(c1b.Id, pullResponse.o["Data"]);
+        }
     }
 }

--- a/dotnet/Core/Database/Server/Core/Api/Json/Api.cs
+++ b/dotnet/Core/Database/Server/Core/Api/Json/Api.cs
@@ -22,6 +22,7 @@ namespace Allors.Database.Protocol.Json
     using Security;
     using Services;
     using Tracing;
+    using NLog;
 
     public class Api
     {
@@ -89,6 +90,8 @@ namespace Allors.Database.Protocol.Json
         public Func<IValidation> Derive { get; }
 
         public UnitConvert UnitConvert { get; }
+
+        private Logger Logger => LogManager.GetCurrentClassLogger();
 
         public InvokeResponse Invoke(InvokeRequest invokeRequest)
         {
@@ -190,15 +193,32 @@ namespace Allors.Database.Protocol.Json
 
             foreach (var pullDependency in pullDependencies)
             {
-                var objectType = (IComposite)this.M.FindByTag(pullDependency.o);
+                if (this.M.FindByTag(pullDependency.o) is not IComposite objectType)
+                {
+                    this.Logger.Warn("Ignoring pull dependency: unknown or non-composite object type tag {ObjectTypeTag}", pullDependency.o);
+                    continue;
+                }
+
                 IPropertyType propertyType;
                 if (pullDependency.a != null)
                 {
-                    propertyType = ((IRelationType)this.M.FindByTag(pullDependency.a)).AssociationType;
+                    if (this.M.FindByTag(pullDependency.a) is not IRelationType associationRelationType)
+                    {
+                        this.Logger.Warn("Ignoring pull dependency: unknown or non-relation association tag {AssociationTag}", pullDependency.a);
+                        continue;
+                    }
+
+                    propertyType = associationRelationType.AssociationType;
                 }
                 else
                 {
-                    propertyType = ((IRelationType)this.M.FindByTag(pullDependency.r)).RoleType;
+                    if (this.M.FindByTag(pullDependency.r) is not IRelationType roleRelationType)
+                    {
+                        this.Logger.Warn("Ignoring pull dependency: unknown or non-relation role tag {RoleTag}", pullDependency.r);
+                        continue;
+                    }
+
+                    propertyType = roleRelationType.RoleType;
                 }
 
                 foreach (var @class in objectType.Classes)


### PR DESCRIPTION
## BUG-06 — Pull dependency meta-tags used without validation (null-crash)

`Api.Pull` calls `ToDependencies(pullRequest.d)` on the client-supplied `PullDependency[]`. Each dependency carries three string **tags** (`o` object-type, `a` association, `r` role). `ToDependencies` cast each `FindByTag(...)` result to `IComposite`/`IRelationType` and dereferenced it **without checking**:

```csharp
var objectType = (IComposite)this.M.FindByTag(pullDependency.o);   // null if tag unknown
…
foreach (var @class in objectType.Classes)                          // NRE
```

`MetaPopulation.FindByTag` returns `null` for an unknown tag (and a valid tag of the wrong kind makes the cast fail), so a client sending a bogus `o`/`a`/`r` tag triggers a `NullReferenceException`/`InvalidCastException` and crashes the whole Pull (HTTP 500). Client input was trusted unchecked.

### Fix
Pattern-match each lookup (`is not IComposite` / `is not IRelationType`, which handles both `null` and wrong-kind) and **skip** an unresolvable dependency — dependencies are prefetch *hints*, so degrading gracefully beats a 500. Each skip logs an NLog warning naming the offending tag (same `LogManager.GetCurrentClassLogger()` pattern as the controllers), since a bad tag means a faulty client. No public-API change.

### Test (TDD, ServerLocal)
Added `PullInstantiateTests.UnknownPullDependencyTagIsIgnored`: a normal named-result pull plus `d = [ new PullDependency { o = "an-unknown-object-type-tag", r = <valid relation tag> } ]`.

- RED (before): `NullReferenceException at …ToDependencies … Api.cs:line 204`.
- GREEN (after): the unknown dependency is ignored and the pull returns its normal result.

CHANGELOG updated under `[Unreleased] › Fixed`.