### PR TITLE
test(core): remove obsolete denied-permissions pull stub [BUG-04]

### DIFF
--- a/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullSecurityTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullSecurityTests.cs
@@ -205,39 +205,6 @@ namespace Tests
         }
 
         [Fact]
-        public void WithDeniedPermissionsFromDatabaseAndOtherWorkspace()
-        {
-            var m = this.M;
-            var user = this.SetUser("jane@example.com");
-
-            var pull = new Pull { Extent = new Extent(m.Denied) };
-
-            var pullRequest = new PullRequest
-            {
-                l = new[]
-                {
-                    pull.ToJson(this.UnitConvert)
-                },
-            };
-
-            var api = new Api(this.Transaction, "Default", CancellationToken.None);
-            var pullResponse = api.Pull(pullRequest);
-
-            var pullResponseObject = pullResponse.p[0];
-
-            var databaseWrite = new Permissions(this.Transaction).Extent().First(v => v.Operation == Operations.Write && v.OperandType.Equals(m.Denied.DatabaseProperty));
-            var defaultWorkspaceWrite = new Permissions(this.Transaction).Extent().First(v => v.Operation == Operations.Write && v.OperandType.Equals(m.Denied.DefaultWorkspaceProperty) && v.Operation == Operations.Write);
-            var workspaceXWrite = new Permissions(this.Transaction).Extent().First(v => v.Operation == Operations.Write && v.OperandType.Equals(m.Denied.WorkspaceXProperty) && v.Operation == Operations.Write);
-
-            // TODO: Koen
-            //Assert.Single(pullResponseObject.d);
-
-            //Assert.Contains(defaultWorkspaceWrite.Id, pullResponseObject.d);
-            //Assert.DoesNotContain(databaseWrite.Id, pullResponseObject.d);
-            //Assert.DoesNotContain(workspaceXWrite.Id, pullResponseObject.d);
-        }
-
-        [Fact]
         public async void WithoutDeniedPermissions()
         {
             var user = this.SetUser("jane@example.com");


### PR DESCRIPTION
## BUG-04 — vacuous PullSecurityTests assertion (SKIPPED + cleanup)

`WithDeniedPermissionsFromDatabaseAndOtherWorkspace` asserted nothing: its four checks were commented out behind a `// TODO`, and they referenced `PullResponseObject.d` — a per-object **denied-permissions** array that was removed when the Json pull protocol moved to grant/revocation object ids (`.g`/`.r`). So the assertions can''t be restored (the field is gone), and the whole method was only scaffolding for them.

### Why removed rather than rewritten
The behavior the test meant to verify — a `Default`-workspace pull must exclude denied permissions belonging to the database scope or another workspace — is already covered at the domain layer by `Domain.Tests/Domain/Security/WorkspaceAccessControlListsTests.cs` (three active tests: database-only denial excluded; Default denial present; Default denial excluded from the `X` workspace). The pull''s `.g`/`.r` are workspace-scoped via `WorkspaceAccessControl` / `Security.GetVersionedRevocations(…, workspaceName)`, and the per-permission detail now surfaces through the Access API, not the pull. Additionally, the seeded `Denied` object has a single revocation denying all three writes, so a `Default` pull always includes it — the stub couldn''t demonstrate exclusion even if rewritten at the pull layer.

Test project builds clean. Test-only change (no `CHANGELOG` entry).