### PR TITLE
test(core): enable WorkspaceY1ObjectInWorkspaceNone with [Fact] [BUG-05]

### DIFF
--- a/dotnet/Core/Database/Server.Local.Tests/Json/Push/PushNewObjectTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/Json/Push/PushNewObjectTests.cs
@@ -69,6 +69,7 @@ namespace Tests
             Assert.Null(pushResponse.n);
         }
 
+        [Fact]
         public void WorkspaceY1ObjectInWorkspaceNone()
         {
             this.SetUser("jane@example.com");


### PR DESCRIPTION
## BUG-05 — Push test missing `[Fact]` (never runs)

`PushNewObjectTests.WorkspaceY1ObjectInWorkspaceNone` is `public` but had no `[Fact]` attribute, so xUnit never executed it (the build warns `xUnit1013`). The method already contains real assertions — it pushes a `WorkspaceYObject1` into workspace `"None"` and asserts the push fails:

```csharp
Assert.True(pushResponse.HasErrors);
Assert.Null(pushResponse.n);
```

### Fix
Add `[Fact]`. The test now runs and passes, mirroring the sibling `WorkspaceX1ObjectInWorkspaceNone`. No production change — it was simply never wired up, not hiding a bug. Test-only (no `CHANGELOG` entry).