### PR TITLE
test(core): remove SelectRef stub duplicating ExtentRef [BUG-10]

### DIFF
--- a/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullExtentTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/Json/Pull/PullExtentTests.cs
@@ -53,32 +53,6 @@ namespace Tests
         }
 
         [Fact]
-        public async void SelectRef()
-        {
-            // TODO: Not implemented
-            this.SetUser("jane@example.com");
-
-            var pullRequest = new PullRequest
-            {
-                l = new[]
-                {
-                    new Pull
-                    {
-                        er = PreparedExtents.OrganisationByName,
-                        a = new Dictionary<string, object> { ["name"] = "Acme" },
-                    },
-                },
-            };
-
-            var api = new Api(this.Transaction, "Default", CancellationToken.None);
-            var pullResponse = api.Pull(pullRequest);
-
-            var organisations = pullResponse.c["Organisations"];
-
-            Assert.Single(organisations);
-        }
-
-        [Fact]
         public async void NamedResult()
         {
             var user = this.SetUser("jane@example.com");


### PR DESCRIPTION
## BUG-10 — `SelectRef` test duplicates `ExtentRef` (SKIPPED + cleanup)

`PullExtentTests.SelectRef` was flagged `// TODO: Not implemented` and its body was a verbatim copy of `ExtentRef` — it used `er = PreparedExtents.OrganisationByName` (an **extent** ref), so it silently duplicated the extent-ref test and added no coverage.

### Why removed rather than implemented
A prepared **select** ref does not exist in the protocol: the Json `Pull` type (`Allors.Protocol.Json.Data.Pull`) has `er` (ExtentRef) but no `sr`/SelectRef field, and `PreparedSelects` has no registered selects. Implementing one would be a feature (a new protocol field in `dotnet/System` + a `PreparedSelects` entry + resolver), not a test-defect fix. The real select mechanism (`Result.Select`) is already covered by `PullInstantiateTests` (`SelectRoleOne2OneIncludeRoleOne2One`, etc.).

Build clean. Test-only change (no `CHANGELOG`).