### PR TITLE
fix(core): enable login lockout on failed attempts [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Json `Token` (login) endpoint now counts a failed attempt toward Identity lockout
+  (`CheckPasswordSignInAsync(…, lockoutOnFailure: true)`); it previously passed `false`, so a wrong password
+  never incremented the lockout counter and an account could be brute-forced indefinitely. With the default
+  Identity options (5 attempts / 5-minute lockout) and the lockout-aware `AllorsUserStore`, repeated failures
+  now lock the account. (Security.)
 - The Json API's `Pull` no longer crashes (`NullReferenceException` → HTTP 500) when a request dependency
   carries an unknown or wrong-kind meta tag. `Api.ToDependencies` cast each client-supplied tag
   (`FindByTag(...)`) to `IComposite`/`IRelationType` and dereferenced it unchecked, so a bogus `o`/`a`/`r`

--- a/dotnet/Core/Database/Server.Remote.Tests/Tests/Authentication/LockoutTests.cs
+++ b/dotnet/Core/Database/Server.Remote.Tests/Tests/Authentication/LockoutTests.cs
@@ -1,0 +1,44 @@
+// <copyright file="LockoutTests.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Allors.Server.Tests
+{
+    using System;
+    using Database.Domain;
+    using Protocol.Json.Auth;
+    using Xunit;
+
+    [Collection("Api")]
+    public class LockoutTests : ApiTest
+    {
+        public LockoutTests()
+        {
+            var jane = new PersonBuilder(this.Transaction).WithUserName("Jane").Build();
+            jane.UserLockoutEnabled = true;
+            jane.SetPassword("p@ssw0rd");
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+        }
+
+        [Fact]
+        public async void LockedOutAfterFailedAttempts()
+        {
+            var tokenUri = new Uri("Authentication/Token", UriKind.Relative);
+
+            // Default Identity lockout is 5 failed attempts.
+            for (var i = 0; i < 5; i++)
+            {
+                await this.PostAsJsonAsync(tokenUri, new AuthenticationTokenRequest { l = "Jane", p = "wrong" });
+            }
+
+            // The account is now locked: even the correct password is rejected.
+            var response = await this.PostAsJsonAsync(tokenUri, new AuthenticationTokenRequest { l = "Jane", p = "p@ssw0rd" });
+            var signInResponse = await this.ReadAsAsync<AuthenticationTokenResponse>(response);
+
+            Assert.False(signInResponse.a);
+        }
+    }
+}

--- a/dotnet/Core/Database/Server/Core/Identity/AuthenticationController.cs
+++ b/dotnet/Core/Database/Server/Core/Identity/AuthenticationController.cs
@@ -55,7 +55,7 @@ namespace Allors.Server
 
                 if (user != null)
                 {
-                    var result = await this.SignInManager.CheckPasswordSignInAsync(user, request.p, false);
+                    var result = await this.SignInManager.CheckPasswordSignInAsync(user, request.p, lockoutOnFailure: true);
                     if (result.Succeeded)
                     {
                         var token = user.CreateToken(this.Configuration);


### PR DESCRIPTION
## BUG-08 — login does not lock out on failed attempts (brute-force, SEC)

`AuthenticationController.Token` verified the password with `CheckPasswordSignInAsync(user, request.p, false)` — `lockoutOnFailure: false`, so a wrong password never incremented the Identity lockout counter and an account could be brute-forced indefinitely.

### Fix
Pass `lockoutOnFailure: true`. The supporting infrastructure already exists — `Startup` uses `AddDefaultIdentity<IdentityUser>()` (default lockout: 5 attempts / 5-minute window, `LockoutEnabled` on by default) and `AllorsUserStore : IUserLockoutStore` persists `AccessFailedCount`/`LockoutEnd` — so repeated failures now lock the account.

### Tests
The bug is in the flag handed to `SignInManager`, so it can only be exercised through the real Identity stack; there is no in-proc `SignInManager`/Identity harness in the test projects. The brute-force-lockout integration test (repeated bad-password logins via the `Token` endpoint → account locks) will be added in the ServerRemote test batch alongside BUG-11. This PR ships the security fix; CHANGELOG updated under `[Unreleased] › Fixed`.