### PR TITLE
fix(core): stop leaking exception detail in production responses [BUG-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ under a dated version heading.
   never incremented the lockout counter and an account could be brute-forced indefinitely. With the default
   Identity options (5 attempts / 5-minute lockout) and the lockout-aware `AllorsUserStore`, repeated failures
   now lock the account. (Security.)
+- The production error handler no longer returns raw exception detail to clients. `ExceptionHandler`'s
+  middleware wrote `error.Message` to the response in non-development environments (the full error is already
+  logged server-side), leaking internal details (e.g. SQL errors, paths). Production responses are now a
+  generic message (`"An internal server error has occurred."`, or `"Authentication token expired."` for an
+  expired token); Development still returns the message and stack trace. (Security.)
 - The Json API's `Pull` no longer crashes (`NullReferenceException` → HTTP 500) when a request dependency
   carries an unknown or wrong-kind meta tag. `Api.ToDependencies` cast each client-supplied tag
   (`FindByTag(...)`) to `IComposite`/`IRelationType` and dereferenced it unchecked, so a bogus `o`/`a`/`r`

--- a/dotnet/Core/Database/Server.Local.Tests/ExceptionHandlerTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/ExceptionHandlerTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="ExceptionHandlerTests.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Tests
+{
+    using System;
+    using Allors.Server;
+    using Microsoft.IdentityModel.Tokens;
+    using Xunit;
+
+    public class ExceptionHandlerTests
+    {
+        [Fact]
+        public void ProductionMessageDoesNotLeakExceptionDetail()
+        {
+            var error = new Exception("secret-internal-detail");
+
+            var message = ExceptionHandler.ErrorMessage(error, isDevelopment: false);
+
+            Assert.DoesNotContain("secret-internal-detail", message);
+        }
+
+        [Fact]
+        public void ProductionTokenExpiredMessageDoesNotLeakExceptionDetail()
+        {
+            var error = new SecurityTokenExpiredException("token-secret-detail");
+
+            var message = ExceptionHandler.ErrorMessage(error, isDevelopment: false);
+
+            Assert.DoesNotContain("token-secret-detail", message);
+        }
+
+        [Fact]
+        public void DevelopmentMessageIncludesExceptionDetail()
+        {
+            var error = new Exception("dev-visible-detail");
+
+            var message = ExceptionHandler.ErrorMessage(error, isDevelopment: true);
+
+            Assert.Contains("dev-visible-detail", message);
+        }
+    }
+}

--- a/dotnet/Core/Database/Server/Core/ExceptionHandler.cs
+++ b/dotnet/Core/Database/Server/Core/ExceptionHandler.cs
@@ -35,9 +35,7 @@ namespace Allors.Server
                         ? (int)HttpStatusCode.Unauthorized
                         : (int)HttpStatusCode.InternalServerError;
 
-                    var message = env.IsDevelopment() ?
-                        $"{error.Message}\n{error.StackTrace}" :
-                        $"{error.Message}";
+                    var message = ErrorMessage(error, env.IsDevelopment());
                     await context.Response.WriteAsync(JsonSerializer.Serialize(message));
                 }
                 else
@@ -47,6 +45,19 @@ namespace Allors.Server
             }
 
             return appBuilder.UseExceptionHandler(v => v.Use(Middleware));
+        }
+
+        public static string ErrorMessage(Exception error, bool isDevelopment)
+        {
+            if (isDevelopment)
+            {
+                return $"{error.Message}\n{error.StackTrace}";
+            }
+
+            // Production: never expose the raw exception detail (it is logged server-side above).
+            return error is SecurityTokenExpiredException
+                ? "Authentication token expired."
+                : "An internal server error has occurred.";
         }
     }
 }


### PR DESCRIPTION
## BUG-12 — production exception handler leaks raw `error.Message` (SEC)

The `UseExceptionHandler` middleware built the client response body as `env.IsDevelopment() ? "{Message}\n{StackTrace}" : "{error.Message}"`. In production it returned the **raw exception message** — leaking internal detail (SQL errors, file paths, etc.) — even though the full error is already logged server-side (`logger.Error(error, …)`).

### Fix
Extract the message decision into a pure, testable `public static string ExceptionHandler.ErrorMessage(Exception error, bool isDevelopment)` (the middleware now calls `ErrorMessage(error, env.IsDevelopment())`), and in production return a generic message:

```csharp
if (isDevelopment) return $"{error.Message}\n{error.StackTrace}";
return error is SecurityTokenExpiredException
    ? "Authentication token expired."
    : "An internal server error has occurred.";
```

Development is unchanged; production no longer includes `error.Message`/`StackTrace` (a safe, useful message is kept for an expired token).

### Test (TDD)
Added `Server.Local.Tests/ExceptionHandlerTests.cs` (in-proc — `Server.Local.Tests` references `Server.csproj`). RED first: extracting the helper preserving the original behaviour, the two production tests failed (the message contained the secret); after the fix all 3 pass (prod generic, prod token-expired generic, dev still includes detail).

CHANGELOG updated under `[Unreleased] › Fixed` (security).