### PR TITLE
fix(core): resolve current user via IUserService in TestShareHoldersController [BUG-13]

### DIFF
--- a/dotnet/Core/Database/Server/Custom/Pull/TestShareHoldersController.cs
+++ b/dotnet/Core/Database/Server/Custom/Pull/TestShareHoldersController.cs
@@ -12,9 +12,9 @@ namespace Allors.Server.Controllers
     using Database.Domain;
     using Database.Meta;
     using Database.Protocol.Json;
+    using Database.Services;
     using Microsoft.AspNetCore.Mvc;
     using Services;
-    using User = Database.Domain.User;
 
     public class TestShareHoldersController : Controller
     {
@@ -40,7 +40,7 @@ namespace Allors.Server.Controllers
                 var response = api.CreatePullResponseBuilder();
 
                 var m = this.Transaction.Database.Services.Get<MetaPopulation>();
-                var organisation = new Organisations(this.Transaction).FindBy(m.Organisation.Owner, this.Transaction.Services.Get<User>());
+                var organisation = new Organisations(this.Transaction).FindBy(m.Organisation.Owner, this.Transaction.Services.Get<IUserService>().User);
                 response.AddObject("root", organisation,
                     new[] {
                                 new Node(m.Organisation.Shareholders)


### PR DESCRIPTION
## BUG-13 — `TestShareHoldersController` resolves the user via `Get<User>()` (throws)

The `Pull` action resolved the current user with `this.Transaction.Services.Get<User>()`. `User` is a domain object, not a registered service, so `Services.Get<User>()` throws — the action always failed (caught → `BadRequest`).

It is a copy-paste slip: the two sibling demo controllers do it correctly — `TestHomeController.cs:40` and `TestEmployeesController.cs:40` both use `Services.Get<IUserService>().User` (the same pattern as `Api`'s constructor).

### Fix
Use `Get<IUserService>().User`, matching the siblings. Adds the missing `using Database.Services;` (where `IUserService` lives) and removes the now-unused `using User = Database.Domain.User;` alias.

Fix-only: controllers are not constructed/tested in `Server.Local.Tests`, and the corrected call is the established pattern already exercised across the test suite and the two working sibling controllers. Server project builds clean. No `CHANGELOG` entry (demo/sample controller).