### PR TITLE
fix(core): do not auto-retry Invoke/Push on DbException [BUG-01][BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The Json API no longer auto-retries `Invoke` and `Push` on a `DbException`. Both are non-idempotent writes,
+  but `PolicyService` retried them with the same policy as the idempotent `Pull`/`Sync` reads — so a
+  `DbException` surfacing after the write's commit (e.g. an ambiguous / lost-ack commit, or post-commit work)
+  made Polly re-run the controller delegate and re-apply the already-committed invocations/push (double
+  execution). `Invoke`/`Push` now run once; `Pull`/`Sync` still auto-retry. Clients that need to retry a
+  failed write must do so explicitly.
 - The Json `Token` (login) endpoint now counts a failed attempt toward Identity lockout
   (`CheckPasswordSignInAsync(…, lockoutOnFailure: true)`); it previously passed `false`, so a wrong password
   never incremented the lockout counter and an account could be brute-forced indefinitely. With the default

--- a/dotnet/Core/Database/Server.Local.Tests/PolicyServiceTests.cs
+++ b/dotnet/Core/Database/Server.Local.Tests/PolicyServiceTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="PolicyServiceTests.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Tests
+{
+    using System.Data.Common;
+    using Allors.Services;
+    using Xunit;
+
+    public class PolicyServiceTests
+    {
+        // Writes are not idempotent: retrying a DbException after an (ambiguous) commit would
+        // re-apply the write. Invoke/Push must run their delegate exactly once.
+
+        [Fact]
+        public void InvokePolicyDoesNotRetryOnDbException()
+        {
+            var policyService = new PolicyService();
+            var count = 0;
+
+            Assert.Throws<TestDbException>(() =>
+                policyService.InvokePolicy.Execute(() =>
+                {
+                    count++;
+                    throw new TestDbException();
+                }));
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void PushPolicyDoesNotRetryOnDbException()
+        {
+            var policyService = new PolicyService();
+            var count = 0;
+
+            Assert.Throws<TestDbException>(() =>
+                policyService.PushPolicy.Execute(() =>
+                {
+                    count++;
+                    throw new TestDbException();
+                }));
+
+            Assert.Equal(1, count);
+        }
+
+        private sealed class TestDbException : DbException
+        {
+        }
+    }
+}

--- a/dotnet/Core/Database/Server/Core/Services/Policy/PolicyService.cs
+++ b/dotnet/Core/Database/Server/Core/Services/Policy/PolicyService.cs
@@ -13,14 +13,20 @@ namespace Allors.Services
     {
         public PolicyService()
         {
-            var defaultPolicy = Policy
+            // Reads are idempotent — safe to auto-retry a transient DbException.
+            var retryPolicy = Policy
                 .Handle<DbException>()
                 .WaitAndRetry(5, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
 
-            this.PullPolicy = defaultPolicy;
-            this.SyncPolicy = defaultPolicy;
-            this.PushPolicy = defaultPolicy;
-            this.InvokePolicy = defaultPolicy;
+            this.PullPolicy = retryPolicy;
+            this.SyncPolicy = retryPolicy;
+
+            // Writes are not idempotent — auto-retrying a DbException after an (ambiguous) commit
+            // would re-apply the unit (double execution), so Invoke and Push are not retried.
+            var noRetryPolicy = Policy.NoOp();
+
+            this.PushPolicy = noRetryPolicy;
+            this.InvokePolicy = noRetryPolicy;
         }
 
         public Policy PullPolicy { get; }


### PR DESCRIPTION
## BUG-01 (+ BUG-07) — DbException retry re-applies a committed write (double execution)

`PolicyService` gave all four operations the **same** policy — `Policy.Handle<DbException>().WaitAndRetry(5, …)`. The controllers wrap the whole unit of work in it, and the commit happens **inside** `api.Invoke`/`api.Push` (the System layer: `…ResponseBuilder.Build → transaction.Commit`). When a `DbException` surfaces *after* the commit succeeded — post-commit work, or an ambiguous / lost-ack commit — Polly re-runs the controller delegate and **re-applies the already-committed invocations / push**: double execution.

`Pull`/`Sync` are idempotent reads (safe to retry); `Invoke`/`Push` are not, and a non-idempotent write cannot be safely auto-retried across an ambiguous commit.

### Fix
Reads keep the retry; writes get a no-retry policy:

```csharp
var retryPolicy = Policy.Handle<DbException>().WaitAndRetry(5, …);
this.PullPolicy = retryPolicy;  this.SyncPolicy = retryPolicy;
var noRetryPolicy = Policy.NoOp();
this.PushPolicy = noRetryPolicy;  this.InvokePolicy = noRetryPolicy;
```

One cohesive change in `PolicyService`, so this PR fixes **both #01 (Invoke) and #07 (Push)**.

### Test (TDD)
`Server.Local.Tests/PolicyServiceTests.cs` asserts `InvokePolicy`/`PushPolicy` invoke their delegate **exactly once** on a `DbException`. RED first: the Invoke test ran **1m2s** (the 5 backoff retries → `count == 6`); GREEN after the fix (`Failed: 0, Passed: 2`, <1s).

### Behaviour change
Transient write `DbException`s now surface to the client instead of being auto-retried (clients must retry a failed write explicitly). CHANGELOG updated under `[Unreleased] › Fixed`.