### PR TITLE
test(core): add Merge.Tests project for the resource Merger [BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ under a dated version heading.
 
 <!-- Add entries under one of: Added, Changed, Deprecated, Removed, Fixed, Security -->
 
+### Added
+
+- A `Merge.Tests` project for the resource `Merger` (`Core/Database/Merge`), driven black-box through its
+  public `Input`/`Output` API. It covers structure preservation for overlapping keys (the regression that
+  motivated the resx-merge fix — `<value>`/`<comment>` children and `xml:space`/`type` attributes survive),
+  last-writer-wins precedence across input directories, key union, `<xsd:schema>`/`<resheader>` survival, and
+  `Input` robustness (missing directories skipped, non-`.resx` files ignored, case-insensitive extension). The
+  project is wired into the `DotnetCoreDatabaseTest` target (CI `CiDotnetCoreDatabaseTest`) so it actually gates.
+
 ### Changed
 
 - The SqlClient adapter's `LIKE` filter now follows ANSI semantics like the Npgsql and in-memory adapters:

--- a/build/Dotnet/Core/Build.cs
+++ b/build/Dotnet/Core/Build.cs
@@ -31,6 +31,12 @@ partial class Build
                 .SetProjectFile(Paths.DotnetCoreDatabaseGenerate));
         });
 
+    private Target DotnetCoreDatabaseTestMerge => _ => _
+        .Executes(() => DotNetTest(s => s
+            .SetProjectFile(Paths.DotnetCoreDatabaseMergeTests)
+            .AddLoggers("trx;LogFileName=CoreDatabaseMerge.trx")
+            .SetResultsDirectory(Paths.ArtifactsTests)));
+
     private Target DotnetCoreDatabaseTestMeta => _ => _
         .DependsOn(DotnetCoreGenerate)
         .Executes(() => DotNetTest(s => s
@@ -144,6 +150,7 @@ partial class Build
         });
 
     private Target DotnetCoreDatabaseTest => _ => _
+        .DependsOn(DotnetCoreDatabaseTestMerge)
         .DependsOn(DotnetCoreDatabaseTestMeta)
         .DependsOn(DotnetCoreDatabaseTestDomain)
         .DependsOn(DotnetCoreDatabaseTestServerLocal)

--- a/build/Dotnet/Core/Paths.cs
+++ b/build/Dotnet/Core/Paths.cs
@@ -9,6 +9,7 @@ public partial class Paths
     public AbsolutePath DotnetCoreDatabaseMetaGenerated => DotnetCoreDatabase / "Meta/Generated";
     public AbsolutePath DotnetCoreDatabaseGenerate => DotnetCoreDatabase / "Generate/Generate.csproj";
     public AbsolutePath DotnetCoreDatabaseMerge => DotnetCoreDatabase / "Merge/Merge.csproj";
+    public AbsolutePath DotnetCoreDatabaseMergeTests => DotnetCoreDatabase / "Merge.Tests/Merge.Tests.csproj";
     public AbsolutePath DotnetCoreDatabaseServer => DotnetCoreDatabase / "Server";
     public AbsolutePath DotnetCoreDatabaseCommands => DotnetCoreDatabase / "Commands";
     public AbsolutePath DotnetCoreDatabaseMetaTests => DotnetCoreDatabase / "Meta.Tests/Meta.Tests.csproj";

--- a/dotnet/Core/Database/Merge.Tests/Merge.Tests.csproj
+++ b/dotnet/Core/Database/Merge.Tests/Merge.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Merge\Merge.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/Core/Database/Merge.Tests/MergerTests.cs
+++ b/dotnet/Core/Database/Merge.Tests/MergerTests.cs
@@ -1,0 +1,249 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="MergerTests.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+// ---------------------------------------------------------------------------------------------
+
+namespace Allors.R1.Development.Resources.Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+    using Xunit;
+
+    public sealed class MergerTests : IDisposable
+    {
+        private static readonly XNamespace Xsd = "http://www.w3.org/2001/XMLSchema";
+        private static readonly XNamespace Xml = "http://www.w3.org/XML/1998/namespace";
+
+        private readonly string root;
+
+        public MergerTests()
+        {
+            this.root = Path.Combine(Path.GetTempPath(), "allors-merge-tests", Path.GetRandomFileName());
+            Directory.CreateDirectory(this.root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(this.root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best-effort cleanup of the temp tree
+            }
+        }
+
+        [Fact]
+        public void OverlappingKeyPreservesValueAndCommentStructure()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(first, "Errors.resx", Data("Greeting", "Hello", "original comment"));
+            WriteResx(second, "Errors.resx", Data("Greeting", "Howdy", "override comment"));
+
+            var greeting = this.MergeAndRead("Errors.resx", first, second).Single(d => Name(d) == "Greeting");
+
+            // BUG-09 guard: the merged element keeps its <value>/<comment> children
+            // instead of being flattened into a single raw text node.
+            Assert.Equal("Howdy", (string)greeting.Element("value"));
+            Assert.Equal("override comment", (string)greeting.Element("comment"));
+            Assert.DoesNotContain(greeting.Nodes().OfType<XText>(), t => !string.IsNullOrWhiteSpace(t.Value));
+        }
+
+        [Fact]
+        public void OverlappingKeyPreservesAttributes()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(first, "Errors.resx", Typed("Count", "1"));
+            WriteResx(second, "Errors.resx", Typed("Count", "2"));
+
+            var count = this.MergeAndRead("Errors.resx", first, second).Single(d => Name(d) == "Count");
+
+            Assert.Equal("preserve", (string)count.Attribute(Xml + "space"));
+            Assert.Equal("System.Int32, mscorlib", (string)count.Attribute("type"));
+            Assert.Equal("2", (string)count.Element("value"));
+        }
+
+        [Fact]
+        public void DisjointKeysAreUnioned()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(first, "Errors.resx", Data("Alpha", "a"));
+            WriteResx(second, "Errors.resx", Data("Beta", "b"));
+
+            var names = this.MergeAndRead("Errors.resx", first, second).Select(Name).ToArray();
+
+            Assert.Contains("Alpha", names);
+            Assert.Contains("Beta", names);
+        }
+
+        [Fact]
+        public void LastInputDirectoryWins()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(first, "Errors.resx", Data("Greeting", "first"));
+            WriteResx(second, "Errors.resx", Data("Greeting", "second"));
+
+            var greeting = this.MergeAndRead("Errors.resx", first, second).Single(d => Name(d) == "Greeting");
+
+            Assert.Equal("second", (string)greeting.Element("value"));
+        }
+
+        [Fact]
+        public void DifferentFilenamesStaySeparate()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(first, "Alpha.resx", Data("A", "a"));
+            WriteResx(second, "Beta.resx", Data("B", "b"));
+
+            var output = this.Output(first, second);
+
+            var alpha = ReadData(output, "Alpha.resx").Select(Name).ToArray();
+            var beta = ReadData(output, "Beta.resx").Select(Name).ToArray();
+
+            Assert.Equal(new[] { "A" }, alpha);
+            Assert.Equal(new[] { "B" }, beta);
+        }
+
+        [Fact]
+        public void NonExistentInputDirectoryIsSkipped()
+        {
+            var first = this.Dir("first");
+            WriteResx(first, "Errors.resx", Data("Greeting", "Hello"));
+            var missing = new DirectoryInfo(Path.Combine(this.root, "does-not-exist"));
+
+            var merger = new Merger();
+            var exception = Record.Exception(() => merger.Input(new[] { missing, new DirectoryInfo(first) }));
+
+            Assert.Null(exception);
+
+            var output = this.OutputOf(merger);
+            Assert.Equal(new[] { "Greeting" }, ReadData(output, "Errors.resx").Select(Name).ToArray());
+        }
+
+        [Fact]
+        public void NonResxFilesAreIgnored()
+        {
+            var first = this.Dir("first");
+            WriteResx(first, "Errors.resx", Data("Greeting", "Hello"));
+            File.WriteAllText(Path.Combine(first, "notes.txt"), "not a resource file");
+
+            var output = this.Output(first);
+
+            Assert.True(File.Exists(Path.Combine(output, "Errors.resx")));
+            Assert.False(File.Exists(Path.Combine(output, "notes.txt")));
+        }
+
+        [Fact]
+        public void UppercaseResxExtensionIsMatched()
+        {
+            var first = this.Dir("first");
+            WriteResx(first, "Errors.RESX", Data("Greeting", "Hello"));
+
+            var output = this.Output(first);
+
+            Assert.Equal(new[] { "Greeting" }, ReadData(output, "Errors.RESX").Select(Name).ToArray());
+        }
+
+        [Fact]
+        public void SchemaAndResHeaderSurviveMerge()
+        {
+            var first = this.Dir("first");
+            var second = this.Dir("second");
+            WriteResx(
+                first,
+                "Errors.resx",
+                Schema(),
+                ResHeader("version", "2.0"),
+                ResHeader("reader", "System.Resources.ResXResourceReader"),
+                Data("Greeting", "Hello"));
+            WriteResx(second, "Errors.resx", Data("Greeting", "Howdy"));
+
+            var rootElement = this.MergeAndReadRoot("Errors.resx", first, second);
+
+            Assert.Contains(rootElement.Elements(), e => e.Name.LocalName == "schema");
+            Assert.Equal(2, rootElement.Elements("resheader").Count());
+            Assert.Equal("Howdy", (string)rootElement.Elements("data").Single().Element("value"));
+        }
+
+        private static XElement Data(string name, string value, string comment = null)
+        {
+            var data = new XElement(
+                "data",
+                new XAttribute("name", name),
+                new XAttribute(Xml + "space", "preserve"),
+                new XElement("value", value));
+
+            if (comment != null)
+            {
+                data.Add(new XElement("comment", comment));
+            }
+
+            return data;
+        }
+
+        private static XElement Typed(string name, string value) =>
+            new XElement(
+                "data",
+                new XAttribute("name", name),
+                new XAttribute("type", "System.Int32, mscorlib"),
+                new XAttribute(Xml + "space", "preserve"),
+                new XElement("value", value));
+
+        private static XElement Schema() =>
+            new XElement(
+                Xsd + "schema",
+                new XAttribute("id", "root"),
+                new XElement(Xsd + "element", new XAttribute("name", "root")));
+
+        private static XElement ResHeader(string name, string value) =>
+            new XElement("resheader", new XAttribute("name", name), new XElement("value", value));
+
+        private static string Name(XElement data) => (string)data.Attribute("name");
+
+        private static void WriteResx(string directory, string fileName, params XElement[] children)
+        {
+            var document = new XDocument(new XElement("root", children));
+            document.Save(Path.Combine(directory, fileName));
+        }
+
+        private string Dir(string name)
+        {
+            var directory = Path.Combine(this.root, name);
+            Directory.CreateDirectory(directory);
+            return directory;
+        }
+
+        private string Output(params string[] inputDirectories)
+        {
+            var merger = new Merger();
+            merger.Input(inputDirectories.Select(d => new DirectoryInfo(d)).ToArray());
+            return this.OutputOf(merger);
+        }
+
+        private string OutputOf(Merger merger)
+        {
+            var output = this.Dir("output");
+            merger.Output(new DirectoryInfo(output));
+            return output;
+        }
+
+        private static XElement[] ReadData(string outputDirectory, string fileName) =>
+            XDocument.Load(Path.Combine(outputDirectory, fileName)).Root.Elements("data").ToArray();
+
+        private XElement[] MergeAndRead(string fileName, params string[] inputDirectories) =>
+            ReadData(this.Output(inputDirectories), fileName);
+
+        private XElement MergeAndReadRoot(string fileName, params string[] inputDirectories) =>
+            XDocument.Load(Path.Combine(this.Output(inputDirectories), fileName)).Root;
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up from BUG-09 (resx-merge corruption). The resource `Merger` (`Core/Database/Merge`) runs on every `DotnetCoreGenerate` and silently rewrites the committed `Resources/*.resx`, yet had **no unit tests** — only the committed golden file caught the corruption. This adds durable regression coverage and wires it into CI so it actually gates.

## What's in it

- **New `Merge.Tests` xUnit project** driving the **public** `Merger.Input`/`Output` API black-box (no `InternalsVisibleTo`). 9 tests:
  - **Structure preservation (the BUG-09 guard):** overlapping keys keep their `<value>`/`<comment>` children, `xml:space`/`type` attributes, and `<xsd:schema>`/`<resheader>` blocks survive.
  - **Merge semantics:** last-writer-wins across input directories, key union, different filenames stay separate.
  - **`Input` robustness:** missing directory skipped (no throw), non-`.resx` ignored, case-insensitive `.RESX`.
- **CI wiring:** new `DotnetCoreDatabaseTestMerge` Nuke target (no codegen/DB dependency — pure black-box on temp dirs) added to the `DotnetCoreDatabaseTest` aggregate, so it runs under CI's `CiDotnetCoreDatabaseTest`.

## Validation

- `./build.ps1 DotnetCoreDatabaseTestMerge` → target Succeeded, **9/9 green**, 0 build errors.
- **Teeth proven:** temporarily reverting the #09 fix (`data.ReplaceWith(...)` → `data.Value = mergeData.Value`) turns the 4 overlapping-key tests RED; restored → 9/9 green. `ResourceFile.cs` is untouched in this PR.