### PR TITLE
fix(base): quote forwarded args in commands.sh [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,12 @@ under a dated version heading.
 - The workspace UML diagram template (`Workspace/Templates/uml.cs.stg`) now renders a many-valued role as
   an array type (`ElementType[]`), matching the database diagram template; its many-valued branch previously
   emitted the element type without the `[]`, so a collection role looked like a single-valued one.
-- `commands.sh` now forwards its arguments with `"$@"` instead of the unquoted `$*`, so an argument
+- `Core/commands.sh` now forwards its arguments with `"$@"` instead of the unquoted `$*`, so an argument
   containing spaces (or shell glob characters) reaches `Database/Commands` as a single token instead of
   being word-split/globbed. Previously e.g. a file path with a space was split into several arguments.
+- `Base/commands.sh` had the identical unquoted `$*` defect; it now also forwards its arguments with
+  `"$@"`, so an argument containing spaces (or shell glob characters) reaches `Database/Commands` as a
+  single token instead of being word-split/globbed.
 - The resource `Merger` no longer corrupts a resx `<data>` entry when the same key appears in more than one
   input directory. For an existing key it ran `data.Value = mergeData.Value`, whose setter replaces the
   entry's child elements (the `<value>`, and any `<comment>`) with a single raw-text node — emitting

--- a/dotnet/Base/commands.sh
+++ b/dotnet/Base/commands.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet run --verbosity q --project Database/Commands -- $*
+dotnet run --verbosity q --project Database/Commands -- "$@"


### PR DESCRIPTION
## What

`dotnet/Base/commands.sh` forwarded its arguments to `Database/Commands` with an unquoted `$*`:

```sh
dotnet run --verbosity q --project Database/Commands -- $*
```

Unquoted `$*` undergoes word-splitting (on `IFS`) and glob expansion, so any argument containing a space (e.g. a file path or a quoted multi-word value) is shattered into several arguments, and any argument with `*`/`?`/`[` is glob-expanded against the cwd. This switches to the correct POSIX idiom `"$@"`, which forwards each positional parameter as a single, unmodified word.

Identical to the already-merged `Core/commands.sh` fix (#51) and the dotnet-system fix.

## Validation

Fix-only (no shell-test harness in the repo; same approach as the merged Core fix):

- `bash -n dotnet/Base/commands.sh` — parses clean.
- Live forwarding check with `dotnet` stubbed: `commands.sh "Population Import" extra` now forwards `argc=2` with `"Population Import"` intact (was `argc=3`, split into `Population` + `Import`).

## Notes

- CHANGELOG `[Unreleased] → Fixed` updated (added a `Base/commands.sh` entry; qualified the pre-existing generic entry to `Core/commands.sh` so they read as unambiguous siblings).
- Out-of-scope sibling noted for follow-up: `dotnet/Apps/commands.sh:8` has an unquoted `$arguments` from an interactive `read` (different shape, outside this PR's scope).