### PR TITLE
fix(base): add /allors prefix to image revision redirect [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ under a dated version heading.
   logged server-side), leaking internal details (e.g. SQL errors, paths). Production responses are now a
   generic message (`"An internal server error has occurred."`, or `"Authentication token expired."` for an
   expired token); Development still returns the message and stack trace. (Security.)
+- The image content endpoint's stale-revision redirect now targets `/allors/image/{id}/{revision}` instead of
+  `/image/{id}/{revision}`. `BaseImageController.Get` is routed at `/allors/image/...`, but on a revision
+  mismatch it issued a permanent redirect to a path missing the `/allors` prefix — which matches no route, so
+  the redirect 404'd instead of serving the current revision. The prefix now matches the route (and the
+  image URL builders, which already emit `/allors/image/...`).
 - The Json API's `Pull` no longer crashes (`NullReferenceException` → HTTP 500) when a request dependency
   carries an unknown or wrong-kind meta tag. `Api.ToDependencies` cast each client-supplied tag
   (`FindByTag(...)`) to `IComposite`/`IRelationType` and dereferenced it unchecked, so a bogus `o`/`a`/`r`

--- a/dotnet/Base/Database/Server/Base/Content/BaseImageController.cs
+++ b/dotnet/Base/Database/Server/Base/Content/BaseImageController.cs
@@ -56,7 +56,7 @@ namespace Allors.Database.Server.Controllers
                 {
                     if (media.Revision != revision)
                     {
-                        return this.RedirectPermanent($"/image/{id}/{media.Revision}");
+                        return this.RedirectPermanent($"/allors/image/{id}/{media.Revision}");
                     }
 
                     if (media.MediaContent?.Data == null)


### PR DESCRIPTION
## What

`BaseImageController.Get` is routed at `/allors/image/{idString}/{revisionString}/{*name}`. When a client requests an image with a stale revision, the handler 301-redirects to the canonical current-revision URL — but built the target as `/image/{id}/{revision}`, dropping the `/allors` prefix:

```csharp
[HttpGet("/allors/image/{idString}/{revisionString}/{*name}")]   // the route
...
return this.RedirectPermanent($"/image/{id}/{media.Revision}");  // before — no /allors prefix
```

A leading-slash redirect is host-root-relative, so the browser follows it to `/image/...`, which matches no route → HTTP 404. The stale-revision redirect therefore never served the current revision. Fixed by prefixing the redirect with `/allors`.

## Why this is the right path

- The route literally requires `/allors/image/...`.
- Both image URL builders already emit it: `LocalImageService` and `WeservImageService` build `…/allors/image/{UniqueId}/{Revision}`.
- No bare `/image/...` route exists anywhere (verified: no `HttpGet("/image`, `Route("/image`, `MapGet("/image` matches).

## Validation

Fix-only (no Base server xUnit harness; the redirect is bound to `ITransactionService` + a DB-backed `Medias` lookup, not cleanly unit-extractable). Verified by inspection: route, redirect, and URL builders now all agree on `/allors/image/...`. Build + `CiDotnetBaseDatabaseTest` gate it in CI.

## Scope

Minimal change — preserves the existing `RedirectPermanent` (301) semantics. The unrelated `w.Value` NRE in the same file (separate finding) is **not** touched here.