### PR TITLE
fix(base): align IImageService background default with implementations [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,3 +151,9 @@ under a dated version heading.
   non-gating (`continue-on-error`), so a transient GitHub artifact-service flake on the success path
   no longer fails the whole job. The test report is still published on every run — the reporter reads
   the `.trx` from disk, not from the uploaded artifact.
+- `IImageService.Source`'s `background` parameter now defaults to `"FFF"` on the interface, matching the
+  `LocalImageService` / `WeservImageService` implementations (which already defaulted to `"FFF"`). C# binds
+  optional-argument defaults from the static type of the receiver, and the service is consumed through the
+  `IImageService` interface (DI-registered, injected into `Image.razor`), so callers that omitted `background`
+  picked up the interface's `null` default — not the impls' `"FFF"` — and PNG image URLs were built with an
+  empty `b=` / `bg=` (background) query parameter. The interface and both implementations now agree.

--- a/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Services/Image/IImageService.cs
+++ b/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Services/Image/IImageService.cs
@@ -4,6 +4,6 @@ namespace Allors.Services
 
     public partial interface IImageService
     {
-        string Source(Media media, int? width = null, int? quality = null, string type = null, string background = null);
+        string Source(Media media, int? width = null, int? quality = null, string type = null, string background = "FFF");
     }
 }


### PR DESCRIPTION
## What

`IImageService.Source` declared a different optional-argument default from its implementations:

```csharp
// interface
string Source(Media media, int? width = null, int? quality = null, string type = null, string background = null);
// LocalImageService / WeservImageService
public string Source(…, string background = "FFF")
```

C# binds optional-argument defaults at **compile time, from the static type of the receiver**. The service is registered and consumed as the interface — `AddSingleton<IImageService, LocalImageService>()` and `@inject Allors.Services.IImageService ImageService` in `Image.razor`, which calls `Source(this.Object, …, this.Type)` without `background`. So the compiler substituted the interface's `null`, never the impls' `"FFF"`. For a PNG media, the impls then emitted an empty background query param (`b=` / `bg=`) instead of `b=FFF` / `bg=FFF`.

Fixed by defaulting `background` to `"FFF"` on the interface, so the interface and both implementations agree.

## Why `"FFF"` and not "drop the default"

Dropping the default would force every interface-typed caller (the `Image.razor` call sites) to pass `background` explicitly — a breaking change to the call convention. Setting `"FFF"` is non-breaking and matches the implementations' clear intent.

## Validation

The Base Blazor projects are not part of the CI test matrix, so this was verified locally:

```
dotnet build Workspace/Blazor/Blazor.Bootstrap.Site/Allors.Workspace.Blazor.Bootstrap.Site.csproj
  → 0 Error(s)
```

(The change is a `string` literal default on a `string` parameter — compile-safe; verified through the full workspace → Blazor dependency chain.)