### PR TITLE
fix(base): require antiforgery token on logout [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ under a dated version heading.
   never incremented the lockout counter and an account could be brute-forced indefinitely. With the default
   Identity options (5 attempts / 5-minute lockout) and the lockout-aware `AllorsUserStore`, repeated failures
   now lock the account. (Security.)
+- The Blazor.Bootstrap.Site server's Identity logout page (`Areas/Identity/Pages/Account/LogOut.cshtml`) no
+  longer carries `@attribute [IgnoreAntiforgeryToken]`, so the logout POST is antiforgery-protected again.
+  Without it, a cross-site request could log a signed-in user out without consent (logout CSRF). The
+  scaffolded logout form (`_LoginPartial`) already posts the antiforgery token, so normal logout is
+  unaffected. (Security.)
 - The production error handler no longer returns raw exception detail to clients. `ExceptionHandler`'s
   middleware wrote `error.Message` to the response in non-development environments (the full error is already
   logged server-side), leaking internal details (e.g. SQL errors, paths). Production responses are now a

--- a/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site.Server/Areas/Identity/Pages/Account/LogOut.cshtml
+++ b/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site.Server/Areas/Identity/Pages/Account/LogOut.cshtml
@@ -1,6 +1,5 @@
 ﻿@page
 @using Microsoft.AspNetCore.Identity
-@attribute [IgnoreAntiforgeryToken]
 @inject SignInManager<IdentityUser> SignInManager
 @functions {
     public async Task<IActionResult> OnPost()


### PR DESCRIPTION
## What

The Identity logout Razor Page carried `@attribute [IgnoreAntiforgeryToken]`:

```razor
@page
@using Microsoft.AspNetCore.Identity
@attribute [IgnoreAntiforgeryToken]   // removed
@inject SignInManager<IdentityUser> SignInManager
@functions {
    public async Task<IActionResult> OnPost() { … SignInManager.SignOutAsync() … }
}
```

Razor Pages validate the antiforgery token on POST by default; this attribute disabled that for the logout POST, so a cross-site auto-submitting form could log a signed-in user out without consent (**logout CSRF**). The standard ASP.NET Identity scaffold does not place this attribute on the logout page. Removed it.

## Why removing it doesn't break logout

The functioning logout is the scaffolded form in `Areas/Identity/Pages/Shared/_LoginPartial.cshtml`:

```html
<form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="/" method="post"> … </form>
```

The MVC Form Tag Helper auto-injects `__RequestVerificationToken` into this `method="post"` form, so the real logout already sends a valid token and validates fine now that the attribute is gone.

## Validation

Fix-only (no Razor Pages / Identity xUnit harness; the Base Blazor projects aren't in the CI matrix). Verified locally:

```
dotnet build Workspace/Blazor/Blazor.Bootstrap.Site.Server/Allors.Workspace.Blazor.Bootstrap.Site.Server.csproj
  → 0 Error(s)
```

(The build Razor-compiles the `.cshtml`.)

## Note (out of scope here)

Separately, the Blazor menu "Log out" (`MainLayout` → `/logout` → `NavigateTo("/Identity/Account/Logout", forceLoad: true)`) issues a GET to this POST-only page, so that menu path appears not to actually sign the user out. Pre-existing and independent of this CSRF fix; not addressed here.