### PR TITLE
test(base): assert generated image in BarcodeTest.Default [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ under a dated version heading.
   `default` to `null`, so it is always false for a value type); they now use a nullable `T? previous`
   sentinel (`previous == null`), matching the `DefaultClassRanges` sibling. Object-id ranges never contain `0`
   (`0` denotes null), so this is a generic data-structure correctness/consistency fix.
+- `BarcodeTest.Default` now asserts the generated barcode image instead of only writing it to disk. The test
+  produced a barcode via `IBarcodeGenerator` and wrote the bytes to `barcode.png` without any assertion, so it
+  passed even if `Generate` returned `null`/empty/non-image data (the generator returns `null` when PNG
+  encoding fails). It now asserts the result is non-null, non-empty, and begins with the PNG file signature.
 - E2E tests no longer fail on transient browser network errors (`net::ERR_NO_BUFFER_SPACE` and
   similar socket/connection errors) that surface sporadically on CI. The console-error assertion
   now ignores this known-transient class while still catching real JS errors and HTTP 4xx/5xx

--- a/dotnet/Base/Database/Domain.Tests/Domain/State/BarcodeTest.cs
+++ b/dotnet/Base/Database/Domain.Tests/Domain/State/BarcodeTest.cs
@@ -5,7 +5,6 @@
 
 namespace Allors.Database.Domain.Tests
 {
-    using System.IO;
     using Xunit;
 
     public class BarcodeTest : DomainTest, IClassFixture<Fixture>
@@ -16,8 +15,16 @@ namespace Allors.Database.Domain.Tests
         public void Default()
         {
             var barcodeService = this.Transaction.Database.Services.Get<IBarcodeGenerator>();
+
             var image = barcodeService.Generate("Allors", BarcodeType.CODE_128);
-            File.WriteAllBytes("barcode.png", image);
+
+            Assert.NotNull(image);
+            Assert.NotEmpty(image);
+
+            // The generator encodes to PNG (SKEncodedImageFormat.Png); verify the PNG file signature.
+            var pngSignature = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            Assert.True(image.Length >= pngSignature.Length);
+            Assert.Equal(pngSignature, image[..pngSignature.Length]);
         }
     }
 }


### PR DESCRIPTION
## What

`BarcodeTest.Default` generated a barcode and wrote it to `barcode.png` but **asserted nothing**, so it passed regardless of what `IBarcodeGenerator.Generate` returned:

```csharp
var image = barcodeService.Generate("Allors", BarcodeType.CODE_128);
File.WriteAllBytes("barcode.png", image);   // no assertion
```

`ZXingBarcodeGenerator.Generate` returns `null` when SkiaSharp's PNG `Encode` fails, so a regression that broke barcode generation would still pass this test (a vacuous test). Replaced the file-write with assertions:

```csharp
Assert.NotNull(image);
Assert.NotEmpty(image);

// generated as PNG (SKEncodedImageFormat.Png) — verify the PNG file signature
var pngSignature = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
Assert.True(image.Length >= pngSignature.Length);
Assert.Equal(pngSignature, image[..pngSignature.Length]);
```

Dependency-free (the test project does not directly reference SkiaSharp); a signature check is robust without coupling the test to it.

## Verification

```
dotnet test dotnet/Base/Database/Domain.Tests/Domain.Tests.csproj --filter "FullyQualifiedName~BarcodeTest.Default"
  → Passed: 1, Failed: 0
```

Non-vacuity confirmed: temporarily corrupting the expected signature byte made the test fail (`Actual: [137, 80, 78, 71, …]` — the real PNG magic `0x89 'P' 'N' 'G'`), then reverted → green. The previous assertion-less test could not produce that failure.

## Note (separate, not addressed here)

`IBarcodeGenerator.Generate`'s interface parameter order is `(…, int? height, int? width, …)` while `ZXingBarcodeGenerator.Generate` is `(…, int? width, int? height, …)` — a latent width↔height swap for any caller that passes them through the interface. No current caller does (only `content`/`type`), so it is latent.