### PR TITLE
test(base): re-derive and assert empty-data error in MediaTest.ModifyMediaContent [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,11 @@ under a dated version heading.
   similar socket/connection errors) that surface sporadically on CI. The console-error assertion
   now ignores this known-transient class while still catching real JS errors and HTTP 4xx/5xx
   resource failures.
+- `MediaTest.ModifyMediaContent` now re-derives after changing the media content and asserts the outcome,
+  instead of asserting the pre-modification state. It set `MediaContent.Data` to an empty array but never
+  called `Derive()` again, so its assertions still reflected the original (valid) derivation and the test
+  passed even though emptying the data should be rejected. It now re-derives and asserts the derivation
+  reports an error (`MediaContent`'s post-derivation rejects empty data), matching `BuilderWithEmptyData`.
 - SqlClient adapter tests now run with a 300s command timeout and `Connection Timeout=0` against
   SQL Server LocalDB, matching the Npgsql adapter tests. This stops sporadic CI failures
   (`SqlException: Execution Timeout Expired`) caused by LocalDB slowness on hosted runners.

--- a/dotnet/Base/Database/Domain.Tests/Domain/Content/MediaTest.cs
+++ b/dotnet/Base/Database/Domain.Tests/Domain/Content/MediaTest.cs
@@ -107,10 +107,14 @@ namespace Allors.Database.Domain.Tests
 
             this.Transaction.Derive();
 
-            media.MediaContent.Data = new byte[] { };
-
             Assert.True(media.ExistMediaContent);
-            Assert.Equal(media.MediaContent.Type, "application/octet-stream");
+            Assert.Equal("application/octet-stream", media.MediaContent.Type);
+
+            media.MediaContent.Data = Array.Empty<byte>();
+
+            var derivationLog = this.Transaction.Derive(false);
+
+            Assert.True(derivationLog.HasErrors);
         }
     }
 }


### PR DESCRIPTION
## What

`MediaTest.ModifyMediaContent` modified the media content but never re-derived, so its assertions reflected the **pre-modification** state and the test could not fail:

```csharp
this.Transaction.Derive();                       // Type → "application/octet-stream"
media.MediaContent.Data = new byte[] { };        // modify to empty — no Derive() follows
Assert.True(media.ExistMediaContent);
Assert.Equal(media.MediaContent.Type, "application/octet-stream");   // still the original derivation
```

`MediaContent.CoreOnPostDerive` raises a `"Empty data"` validation error whenever the content's `Data` is missing/empty — the same rule that makes the sibling `BuilderWithEmptyData` test report `HasErrors`. Because `ModifyMediaContent` never re-derived, that path was never exercised.

The test now asserts the valid initial state, modifies the content, **re-derives**, and asserts the error:

```csharp
this.Transaction.Derive();
Assert.True(media.ExistMediaContent);
Assert.Equal("application/octet-stream", media.MediaContent.Type);

media.MediaContent.Data = Array.Empty<byte>();
var derivationLog = this.Transaction.Derive(false);
Assert.True(derivationLog.HasErrors);
```

(Also corrects the `Assert.Equal(actual, expected)` argument order — clears the xUnit2000 analyzer warning — and uses `Array.Empty<byte>()`.)

## Verification

```
dotnet test dotnet/Base/Database/Domain.Tests/Domain.Tests.csproj --filter "FullyQualifiedName~MediaTest.ModifyMediaContent"
  → Passed: 1, Failed: 0
```

Non-vacuity confirmed: temporarily flipping the final assertion to `Assert.False(derivationLog.HasErrors)` made the test fail (`Assert.False() Failure`), then reverted → green. The previous (no-re-derive) test could not produce that failure.