### PR TITLE
fix(base): correct versioned many-role change detection [BUG-03][BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ under a dated version heading.
   child nodes but recursed on the outer builder (`@this`), so the nested policy was always empty (deeper
   tree levels were never prefetched) and the child rules — and their security rules — leaked onto the
   outer policy. It now recurses on the nested builder.
+- Object versioning no longer creates a redundant `*Version` on every derive of a versioned object that has a
+  non-empty many-role (and no longer throws when comparing one). `VersionedExtensions.CoreOnPostDerive`'s
+  many-role change check led with `!(!versionedRole.Any() && !versionRole.Any())`, which is `true` whenever
+  either side is non-empty — so the role always looked "changed" (a new version every derive) and the real
+  `Count()`/`SequenceEqual` comparison was short-circuited. Removing that clause exposed a second defect: the
+  comparison ordered the composites with `OrderBy(s => s)` on `IObject` (which is not `IComparable`), throwing
+  `ArgumentException`. The clause is removed and the composites are ordered by `.Id`, so a versioned many-role
+  now creates a new version only when its contents actually change.
 - The remote workspace adapter's `IPullResult.GetValue<T>` now converts a pulled value to `T` instead of
   hard-casting the raw deserialized JSON. `PullResult.Values` exposes values as received over the wire (a
   `JsonElement` for System.Text.Json, a boxed/`JToken` value for Newtonsoft), so `GetValue<T>` threw

--- a/dotnet/Base/Database/Domain.Tests/Domain/Common/VersioningTests.cs
+++ b/dotnet/Base/Database/Domain.Tests/Domain/Common/VersioningTests.cs
@@ -116,5 +116,55 @@ namespace Allors.Database.Domain.Tests
             Assert.Single(version.OrderLines);
             Assert.Equal(orderLine, version.OrderLines.ElementAt(0));
         }
+
+        [Fact]
+        public void VersionedCompositesRoleUnchanged()
+        {
+            // Two lines so the equal-count comparison runs OrderBy over more than one element
+            // (a single element never invokes the comparer).
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+
+            var order = new OrderBuilder(this.Transaction)
+                .WithOrderLine(orderLine1)
+                .WithOrderLine(orderLine2)
+                .Build();
+
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            // Force a re-derivation without changing any versioned role.
+            order.NonVersionedAmount = 20m;
+
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
+
+        [Fact]
+        public void VersionedCompositesRoleChanged()
+        {
+            var orderLine = new OrderLineBuilder(this.Transaction).Build();
+
+            var order = new OrderBuilder(this.Transaction)
+                .WithOrderLine(orderLine)
+                .Build();
+
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            var anotherOrderLine = new OrderLineBuilder(this.Transaction).Build();
+            order.AddOrderLine(anotherOrderLine);
+
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.NotEqual(currentVersion, order.CurrentVersion);
+        }
     }
 }

--- a/dotnet/Base/Database/Domain/Base/Common/VersionedExtensions.cs
+++ b/dotnet/Base/Database/Domain/Base/Common/VersionedExtensions.cs
@@ -41,10 +41,9 @@ namespace Allors.Database.Domain
                         var versionedRole = @this.Strategy.GetCompositesRole<IObject>(versionedRoleType);
                         var versionRole = currentVersion.Strategy.GetCompositesRole<IObject>(versionRoleType);
                         // TODO: use Numbers
-                        if (!(!versionedRole.Any() && !versionRole.Any()) ||
-                            versionedRole.Count() != versionRole.Count() ||
-                            !versionedRole.ToArray().OrderBy(s => s)
-                                .SequenceEqual(versionRole.ToArray().OrderBy(t => t)))
+                        if (versionedRole.Count() != versionRole.Count() ||
+                            !versionedRole.ToArray().OrderBy(s => s.Id)
+                                .SequenceEqual(versionRole.ToArray().OrderBy(t => t.Id)))
                         {
                             isNewVersion = true;
                             break;


### PR DESCRIPTION
## What

`VersionedExtensions.CoreOnPostDerive` builds a new `*Version` of a versioned object whenever its roles differ from its `CurrentVersion` snapshot. The many-role (`IsMany`) comparison had two coupled defects:

```csharp
if (!(!versionedRole.Any() && !versionRole.Any()) ||        // BUG-03
    versionedRole.Count() != versionRole.Count() ||
    !versionedRole.ToArray().OrderBy(s => s)                // BUG-D1
        .SequenceEqual(versionRole.ToArray().OrderBy(t => t)))
```

- **BUG-03** — clause 1 is `!(!a.Any() && !b.Any())` ≡ `(a.Any() || b.Any())`, i.e. **true whenever either side is non-empty**. OR'd into the change test, every derive of a versioned object with a non-empty many-role reported a change → a **redundant new version on every derive**, and the real `Count()`/`SequenceEqual` comparison was short-circuited.
- **BUG-D1** — clauses 2 + 3 already decide change correctly on their own. But clause 3 orders the composites with `OrderBy(s => s)` on `IObject`, which does not implement `IComparable`; once clause 1 no longer short-circuits it, ordering 2+ elements throws `ArgumentException: At least one object must implement IComparable`.

## Fix

Drop clause 1; order by `.Id` (`Allors.Database.IObject.Id` is `long`):

```csharp
if (versionedRole.Count() != versionRole.Count() ||
    !versionedRole.ToArray().OrderBy(s => s.Id)
        .SequenceEqual(versionRole.ToArray().OrderBy(t => t.Id)))
```

A versioned many-role now creates a new version only when its contents actually change. Kept minimal (no perf/style changes).

## Tests (added to `VersioningTests`)

- `VersionedCompositesRoleUnchanged` — order with **two** `OrderLine`s; re-derive without changing them (via `NonVersionedAmount`) → asserts **no** new version. Two lines so the equal-count path runs `OrderBy` over more than one element (a single element never invokes the comparer), exercising D1.
- `VersionedCompositesRoleChanged` — add a line → asserts a new version.

3-state RED→GREEN proof:
1. buggy `main` → `Unchanged` fails (`Assert.Single() Failure: collection contained 2 items`) — BUG-03;
2. clause 1 removed, `OrderBy(s => s)` kept → throws `ArgumentException: At least one object must implement IComparable` — BUG-D1;
3. full fix → all `VersioningTests` green (7/7).

```
dotnet test dotnet/Base/Database/Domain.Tests/Domain.Tests.csproj --filter "FullyQualifiedName~VersioningTests"
  → Passed: 7, Failed: 0
```

## Note

A follow-up, test-only PR will add comprehensive versioning regression coverage (snapshot-captures-old-value, sequential versions, unit/single/many add-remove-clear, child-object versioning, multi-role change). A separate latent observation (reference-equality comparison of binary unit roles in the single-role branch) is not reachable by Base's versioned classes and is left for follow-up.