### PR TITLE
fix(base): guard null width in image Process [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ under a dated version heading.
   `InvalidCastException` (e.g. casting `JsonElement` to `int`/`byte[]`). It now routes the value through the
   adapter's `IUnitConvert`, mapping the requested CLR type to its unit tag, so values round-trip to the correct
   type. (Pull values are sent untagged, so the conversion is keyed by `T`.)
+- The image content endpoint no longer returns HTTP 500 for an overlay-only request (an overlay with no
+  width). `BaseImageController.Get` enters its image-processing branch when a width *or* an overlay is
+  supplied, but always passed `w.Value` to `Process`, throwing `InvalidOperationException` when only the
+  overlay was set (width null). `Process` now takes a nullable width and resizes only when one is given; an
+  overlay-only request keeps the original dimensions and just draws the overlay.
 - The workspace adapters' session-origin `SetCompositeRoleMany2One` no longer leaves a stale inverse when an
   object's many-to-one composite role is reassigned. When changing `A`'s role from `PR` to `R` it detached the
   *new* role `R` (a no-op, since `A` was not yet associated with `R`) instead of the *previous* role `PR`, so

--- a/dotnet/Base/Database/Server/Base/Content/BaseImageController.cs
+++ b/dotnet/Base/Database/Server/Base/Content/BaseImageController.cs
@@ -78,7 +78,7 @@ namespace Allors.Database.Server.Controllers
 
                         if (width != null || !string.IsNullOrWhiteSpace(overlay))
                         {
-                            data = this.Process(data, w.Value, overlay);
+                            data = this.Process(data, width, overlay);
                         }
                     }
 
@@ -105,17 +105,17 @@ namespace Allors.Database.Server.Controllers
             return this.Content(string.Empty);
         }
 
-        private byte[] Process(byte[] src, int width, string overlay, SKFilterQuality quality = SKFilterQuality.High)
+        private byte[] Process(byte[] src, int? width, string overlay, SKFilterQuality quality = SKFilterQuality.High)
         {
             try
             {
                 using var ms = new MemoryStream(src);
                 using var sourceBitmap = SKBitmap.Decode(ms);
 
-                var aspectRatio = (float)sourceBitmap.Height / sourceBitmap.Width;
-                var height = (int)Math.Round(width * aspectRatio);
-
-                using var scaledBitmap = sourceBitmap.Resize(new SKImageInfo(width, height), quality);
+                // Resize only when a width is requested; an overlay-only request keeps the original size.
+                using var scaledBitmap = width.HasValue
+                    ? sourceBitmap.Resize(new SKImageInfo(width.Value, (int)Math.Round(width.Value * ((float)sourceBitmap.Height / sourceBitmap.Width))), quality)
+                    : sourceBitmap.Copy();
 
                 if (!string.IsNullOrWhiteSpace(overlay))
                 {


### PR DESCRIPTION
## What

`BaseImageController.Get` enters its image-processing branch when a width **or** an overlay is supplied, but unconditionally dereferenced `w.Value`:

```csharp
if (width != null || !string.IsNullOrWhiteSpace(overlay))
{
    data = this.Process(data, w.Value, overlay);   // w is int?; throws when only the overlay is set
}
```

For an overlay-only request (e.g. `/allors/image/{id}/{rev}?o=SOLD` with no `w`), `w` has no value, so `w.Value` throws `InvalidOperationException` (uncaught at the call site — `Process`'s `try/catch` is inside the method) → HTTP 500.

## Fix

`Process` now takes a nullable width and resizes only when one is given; an overlay-only request keeps the original dimensions and just draws the overlay. The call site passes the nullable `width` (no `.Value`).

```csharp
data = this.Process(data, width, overlay);

private byte[] Process(byte[] src, int? width, string overlay, SKFilterQuality quality = SKFilterQuality.High)
{
    ...
    using var sourceBitmap = SKBitmap.Decode(ms);
    using var scaledBitmap = width.HasValue
        ? sourceBitmap.Resize(new SKImageInfo(width.Value, (int)Math.Round(width.Value * ((float)sourceBitmap.Height / sourceBitmap.Width))), quality)
        : sourceBitmap.Copy();
    ...
}
```

`Copy()` keeps `scaledBitmap` a distinct disposable, so the existing `using` disposals don't double-free `sourceBitmap`. Width-only and width+overlay behaviour are unchanged.

## Validation

Fix-only (no Base server xUnit harness; `Process` is a private SkiaSharp-bound method). Verified by a targeted local build:

```
dotnet build dotnet/Base/Database/Server/Server.csproj  → 0 Error(s)
```

CI's `CiDotnetBaseDatabaseTest` also builds the Server project.