### PR TITLE
fix(base): parse Allors user id as long in workspace config [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ under a dated version heading.
   *new* role `R` (a no-op, since `A` was not yet associated with `R`) instead of the *previous* role `PR`, so
   `PR`'s inverse association still listed `A` while `A`'s role was already `R`. It now detaches the previous
   role, matching the one-to-one sibling. Affects the Local and Remote workspace adapters.
+- The Blazor server workspace configuration now parses the Allors user id from the `NameIdentifier` claim as a
+  `long` instead of an `int`. Object ids are `long` (`DefaultStructRanges<long>`, and
+  `DatabaseConnection.UserId` is `long`), so `int.Parse` threw `OverflowException` once a user's id exceeded
+  `int.MaxValue` (~2.1 billion), preventing the workspace from being created for that user.
 - The workspace `ContainedIn` predicate with an explicit object list now round-trips over the JSON protocol.
   Both `ToJsonVisitor`s (the workspace and the database one) serialized the objects to the `vs` (values) field,
   but the database `FromJsonVisitor` reads them from `obs` (the object-id field), so the object list was lost in

--- a/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site.Server/Configuration/WorkspaceConfiguration.cs
+++ b/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site.Server/Configuration/WorkspaceConfiguration.cs
@@ -33,7 +33,7 @@ namespace Allors.Workspace.Configuration
                 var claimsPrincipalService = serviceProvider.GetRequiredService<IClaimsPrincipalService>();
                 var user = claimsPrincipalService.User;
                 var claim = user.FindFirst(ClaimTypes.NameIdentifier);
-                var userId = claim != null ? int.Parse(claim.Value, CultureInfo.InvariantCulture) : 0;
+                var userId = claim != null ? long.Parse(claim.Value, CultureInfo.InvariantCulture) : 0;
                 return new Adapters.Local.DatabaseConnection(configuration, database, servicesBuilder, rangesFactory) { UserId = userId };
             });
 


### PR DESCRIPTION
## What

`AddAllorsWorkspace` resolves the current user's Allors id from the `NameIdentifier` claim and sets it on the workspace `DatabaseConnection`:

```csharp
var rangesFactory = () => new DefaultStructRanges<long>();   // ids are long
...
var userId = claim != null ? int.Parse(claim.Value, CultureInfo.InvariantCulture) : 0;
return new Adapters.Local.DatabaseConnection(...) { UserId = userId };
```

Allors database object ids are `long`, and `Allors.Workspace.Adapters.Local.DatabaseConnection.UserId` is `long`. Parsing the claim with `int.Parse` throws `OverflowException` once a user's id exceeds `int.MaxValue` (~2.1 billion), so the per-request workspace cannot be created for that user.

## Fix

`int.Parse` → `long.Parse` (keeping `CultureInfo.InvariantCulture`). The ternary's `0` widens to `long`, so `userId` is `long` and assigns cleanly to the `long UserId`. Kept `Parse` (not `TryParse`) — the defect is the integer width, not parse-failure; the claim is the framework-issued numeric user id.

## Validation

Fix-only (the parse is inside a DI scope-factory lambda — not cleanly unit-extractable). The Base Blazor projects aren't in the CI matrix, so verified locally:

```
dotnet build Workspace/Blazor/Blazor.Bootstrap.Site.Server/Allors.Workspace.Blazor.Bootstrap.Site.Server.csproj
  → 0 Error(s)
```