### PR TITLE
fix(base): flag empty required many-valued role in RoleField.Validate [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ under a dated version heading.
   transit — a `ContainedIn { Objects = … }` pull reached the server with neither objects nor extent and failed
   with HTTP 500. The writers now use `obs`, matching the reader and the `ob`/`obs` convention. (The `Extent`
   form of `ContainedIn` was unaffected.)
+- A required many-valued role is now flagged as missing when its collection is empty. `RoleField.Validate`
+  tested `Model == null`, but for a many-valued role `Model` is a non-null (possibly empty) composites
+  collection, so an empty required many-role was never reported as required. It now treats an empty collection
+  as missing for many-valued roles; unit and single-composite roles keep the existing null check.
 - The Local workspace adapter's `Push` now releases (disposes) the database transaction it opens, instead of
   leaving it open. `Session.PushAsync` previously returned without disposing on both the error path (the early
   return when the push has errors — the transaction was then neither committed nor rolled back) and the success

--- a/dotnet/Base/Workspace/Blazor/Blazor/Forms/RoleField.cs
+++ b/dotnet/Base/Workspace/Blazor/Blazor/Forms/RoleField.cs
@@ -1,6 +1,8 @@
 namespace Allors.Workspace.Blazor
 {
     using System;
+    using System.Collections;
+    using System.Linq;
     using Meta;
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Forms;
@@ -137,7 +139,11 @@ namespace Allors.Workspace.Blazor
 
         public override void Validate(ValidationMessageStore messages)
         {
-            if (this.RoleType.IsRequired && this.Model == null)
+            var model = this.Model;
+            var isEmpty = model == null ||
+                (this.RoleType.IsMany && model is IEnumerable composites && !composites.Cast<object>().Any());
+
+            if (this.RoleType.IsRequired && isEmpty)
             {
                 messages.Add(this.FieldIdentifier, $"{this.RoleType.Name} is required");
             }


### PR DESCRIPTION
## What

`RoleField.Validate` reported a required role as missing with `this.Model == null`:

```csharp
public virtual object Model => this.ExistObject ? this.Object.Strategy.GetRole(this.RoleType) : null;
...
if (this.RoleType.IsRequired && this.Model == null)
```

For a **many-valued** role, `Strategy.GetRole` returns a non-null (possibly empty) composites collection — never `null`. So `Model == null` is false even when the collection is empty, and a required many-valued role with zero elements was never flagged (a validation gap). The `== null` check only detects "missing" for unit and single-composite roles.

## Fix

Treat an empty collection as missing for many-valued roles:

```csharp
var model = this.Model;
var isEmpty = model == null ||
    (this.RoleType.IsMany && model is IEnumerable composites && !composites.Cast<object>().Any());

if (this.RoleType.IsRequired && isEmpty)
{
    messages.Add(this.FieldIdentifier, $"{this.RoleType.Name} is required");
}
else
{
    messages.Clear(this.FieldIdentifier);
}
```

The `IsMany` guard keeps unit/single-composite roles on the `== null` check (so a unit string isn't treated as a collection). Scoped to the many-role gap.

## Validation

Fix-only (no Base Blazor C# test harness/CI target — a new test project wouldn't gate). Verified by a targeted local build:

```
dotnet build Workspace/Blazor/Blazor/Allors.Workspace.Blazor.csproj  → 0 Error(s)
```