### PR TITLE
fix(base): TryParse route id in PersonEdit [BUG-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The `PersonEdit` Blazor page no longer crashes when its `{id}` route parameter is not a number. It parsed
+  the segment with `long.Parse(id)` in `OnInitializedAsync`, throwing `FormatException` for a non-numeric id
+  (e.g. `/person/edit/abc`); it now uses `long.TryParse` and skips the pull when the id is invalid (the page
+  renders nothing instead of throwing).
 - The Json API no longer auto-retries `Invoke` and `Push` on a `DbException`. Both are non-idempotent writes,
   but `PolicyService` retried them with the same policy as the idempotent `Pull`/`Sync` reads — so a
   `DbException` surfacing after the write's commit (e.g. an ambiguous / lost-ack commit, or post-commit work)

--- a/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Pages/Person/PersonEdit.razor
+++ b/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Pages/Person/PersonEdit.razor
@@ -48,9 +48,14 @@
     {
         this.Session = this.Workspace.CreateSession();
 
+        if (!long.TryParse(id, out var objectId))
+        {
+            return;
+        }
+
         var pull = new Pull
             {
-                ObjectId = long.Parse(id)
+                ObjectId = objectId
             };
 
         var result = await this.Session.PullAsync(pull);


### PR DESCRIPTION
## What

`PersonEdit.razor` parses its `{id}` route parameter with `long.Parse` in `OnInitializedAsync`:

```razor
@page "/person/edit/{id}"
...
[Parameter] public string id { get; set; }
...
var pull = new Pull { ObjectId = long.Parse(id) };
```

A non-numeric route id (e.g. `/person/edit/abc`) makes `long.Parse` throw `FormatException` from `OnInitializedAsync`, which is unhandled → Blazor error.

## Fix

Use `long.TryParse` and skip the pull when the id is invalid; the existing `@if (person != null)` block then renders nothing instead of crashing:

```csharp
this.Session = this.Workspace.CreateSession();

if (!long.TryParse(id, out var objectId))
{
    return;
}

var pull = new Pull { ObjectId = objectId };
```

## Validation

Fix-only (PersonEdit's `OnInitializedAsync` is bound to `IWorkspace`/`Session`/`Pull` with no Blazor/workspace test harness or CI target). Verified by a targeted local build (Razor-compiles the page):

```
dotnet build Workspace/Blazor/Blazor.Bootstrap.Site/Allors.Workspace.Blazor.Bootstrap.Site.csproj
  → 0 Error(s)
```