### PR TITLE
test(base): comprehensive versioning regression coverage [BUG-D2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ under a dated version heading.
   last-writer-wins precedence across input directories, key union, `<xsd:schema>`/`<resheader>` survival, and
   `Input` robustness (missing directories skipped, non-`.resx` files ignored, case-insensitive extension). The
   project is wired into the `DotnetCoreDatabaseTest` target (CI `CiDotnetCoreDatabaseTest`) so it actually gates.
+- Comprehensive regression coverage for object versioning in `VersioningTests` (Base) — 16 tests over the
+  `Order`/`OrderLine` model: changed vs unchanged unit / single-composite / many-composite roles;
+  add / remove / clear / repopulate and order-independent set comparison on the many-role; version-snapshot
+  history (each version keeps the value at its own derivation); sequential versions; several versioned roles
+  changing in one cycle producing a single new version; independent child (`OrderLine`) versioning; and
+  non-versioned roles not creating versions. Run by `CiDotnetBaseDatabaseTest`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The `PersonEdit` Blazor page no longer crashes when its `{id}` route parameter is not a number. It parsed
+  the segment with `long.Parse(id)` in `OnInitializedAsync`, throwing `FormatException` for a non-numeric id
+  (e.g. `/person/edit/abc`); it now uses `long.TryParse` and skips the pull when the id is invalid (the page
+  renders nothing instead of throwing).
 - The Json API no longer auto-retries `Invoke` and `Push` on a `DbException`. Both are non-idempotent writes,
   but `PolicyService` retried them with the same policy as the idempotent `Pull`/`Sync` reads — so a
   `DbException` surfacing after the write's commit (e.g. an ambiguous / lost-ack commit, or post-commit work)

--- a/dotnet/Base/Database/Domain.Tests/Domain/Common/VersioningTests.cs
+++ b/dotnet/Base/Database/Domain.Tests/Domain/Common/VersioningTests.cs
@@ -166,5 +166,319 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(2, order.AllVersions.Count());
             Assert.NotEqual(currentVersion, order.CurrentVersion);
         }
+
+        // --- versioned unit role (Amount) ---
+
+        [Fact]
+        public void ChangedVersionedUnitRoleCreatesNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).WithAmount(10m).Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            order.Amount = 20m;
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.NotEqual(currentVersion, order.CurrentVersion);
+            Assert.Equal(20m, order.CurrentVersion.Amount);
+        }
+
+        [Fact]
+        public void UnchangedVersionedUnitRoleDoesNotCreateNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).WithAmount(10m).Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            // Re-derive without changing the versioned Amount.
+            order.NonVersionedAmount = 99m;
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
+
+        // --- versioned single composite role (OrderState) ---
+
+        [Fact]
+        public void ChangedVersionedSingleCompositeRoleCreatesNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            var initial = new OrderStates(this.Transaction).Initial;
+            order.OrderState = initial;
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.NotEqual(currentVersion, order.CurrentVersion);
+            Assert.Equal(initial, order.CurrentVersion.OrderState);
+        }
+
+        [Fact]
+        public void UnchangedVersionedSingleCompositeRoleDoesNotCreateNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction)
+                .WithOrderState(new OrderStates(this.Transaction).Initial)
+                .Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            // Re-derive without changing the versioned OrderState (mutate a non-versioned composite role).
+            order.NonVersionedCurrentObjectState = new OrderStates(this.Transaction).Initial;
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
+
+        // --- versioned many composite role (OrderLines) ---
+
+        [Fact]
+        public void AddedCompositesRoleElementCreatesNewVersion()
+        {
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction).WithOrderLine(orderLine1).Build();
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+            order.AddOrderLine(orderLine2);
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.Equal(2, order.CurrentVersion.OrderLines.Count());
+        }
+
+        [Fact]
+        public void RemovedCompositesRoleElementCreatesNewVersion()
+        {
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction)
+                .WithOrderLine(orderLine1)
+                .WithOrderLine(orderLine2)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+
+            order.RemoveOrderLine(orderLine1);
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.Single(order.CurrentVersion.OrderLines);
+            Assert.Equal(orderLine2, order.CurrentVersion.OrderLines.ElementAt(0));
+        }
+
+        [Fact]
+        public void ClearedCompositesRoleCreatesNewVersion()
+        {
+            var orderLine = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction).WithOrderLine(orderLine).Build();
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+
+            order.RemoveOrderLines();
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.False(order.CurrentVersion.ExistOrderLines);
+        }
+
+        [Fact]
+        public void PopulatedEmptyCompositesRoleCreatesNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).Build();
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+
+            var orderLine = new OrderLineBuilder(this.Transaction).Build();
+            order.AddOrderLine(orderLine);
+            this.Transaction.Derive();
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.Single(order.CurrentVersion.OrderLines);
+        }
+
+        [Fact]
+        public void ReassignedSameCompositesRoleSetDoesNotCreateNewVersion()
+        {
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction)
+                .WithOrderLine(orderLine1)
+                .WithOrderLine(orderLine2)
+                .Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            // Re-assign the same set in a different order, and force a re-derive: the change detection
+            // orders by Id, so an unchanged set must not bump the version.
+            order.RemoveOrderLines();
+            order.AddOrderLine(orderLine2);
+            order.AddOrderLine(orderLine1);
+            order.NonVersionedCurrentObjectState = new OrderStates(this.Transaction).Initial;
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
+
+        // --- history / snapshot content ---
+
+        [Fact]
+        public void VersionSnapshotCapturesValueAtEachDerivation()
+        {
+            var order = new OrderBuilder(this.Transaction).WithAmount(10m).Build();
+            this.Transaction.Derive();
+
+            var firstVersion = order.CurrentVersion;
+
+            order.Amount = 20m;
+            this.Transaction.Derive();
+
+            var secondVersion = order.CurrentVersion;
+
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.NotEqual(firstVersion, secondVersion);
+            Assert.Equal(10m, firstVersion.Amount);   // history: the first version keeps the old value
+            Assert.Equal(20m, secondVersion.Amount);
+        }
+
+        [Fact]
+        public void SequentialChangesCreateSequentialVersions()
+        {
+            var order = new OrderBuilder(this.Transaction).WithAmount(1m).Build();
+            this.Transaction.Derive();
+            Assert.Single(order.AllVersions);
+
+            order.Amount = 2m;
+            this.Transaction.Derive();
+            Assert.Equal(2, order.AllVersions.Count());
+
+            order.Amount = 3m;
+            this.Transaction.Derive();
+            Assert.Equal(3, order.AllVersions.Count());
+            Assert.Equal(3m, order.CurrentVersion.Amount);
+        }
+
+        [Fact]
+        public void ChangedCompositesRoleSnapshotReflectsEachVersion()
+        {
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction).WithOrderLine(orderLine1).Build();
+            this.Transaction.Derive();
+
+            var firstVersion = order.CurrentVersion;
+
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+            order.AddOrderLine(orderLine2);
+            this.Transaction.Derive();
+
+            var secondVersion = order.CurrentVersion;
+
+            Assert.NotEqual(firstVersion, secondVersion);
+            Assert.Single(firstVersion.OrderLines);   // history: the first version still snapshots only line1
+            Assert.Equal(orderLine1, firstVersion.OrderLines.ElementAt(0));
+            Assert.Equal(2, secondVersion.OrderLines.Count());
+        }
+
+        // --- multiple versioned roles changing together ---
+
+        [Fact]
+        public void MultipleVersionedRolesChangedCreateSingleNewVersion()
+        {
+            var orderLine1 = new OrderLineBuilder(this.Transaction).Build();
+            var order = new OrderBuilder(this.Transaction)
+                .WithAmount(10m)
+                .WithOrderLine(orderLine1)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+
+            // Change three versioned roles in one derivation cycle.
+            var initial = new OrderStates(this.Transaction).Initial;
+            order.Amount = 20m;
+            order.OrderState = initial;
+            var orderLine2 = new OrderLineBuilder(this.Transaction).Build();
+            order.AddOrderLine(orderLine2);
+            this.Transaction.Derive();
+
+            // Exactly one new version, capturing all of the new values.
+            Assert.Equal(2, order.AllVersions.Count());
+            Assert.Equal(20m, order.CurrentVersion.Amount);
+            Assert.Equal(initial, order.CurrentVersion.OrderState);
+            Assert.Equal(2, order.CurrentVersion.OrderLines.Count());
+        }
+
+        // --- child object (OrderLine) is independently versioned ---
+
+        [Fact]
+        public void OrderLineIsIndependentlyVersioned()
+        {
+            var orderLine = new OrderLineBuilder(this.Transaction).WithAmount(5m).Build();
+            var order = new OrderBuilder(this.Transaction).WithOrderLine(orderLine).Build();
+            this.Transaction.Derive();
+
+            Assert.Single(orderLine.AllVersions);
+
+            orderLine.Amount = 10m;
+            this.Transaction.Derive();
+
+            Assert.Equal(2, orderLine.AllVersions.Count());
+            Assert.Equal(10m, orderLine.CurrentVersion.Amount);
+        }
+
+        // --- non-versioned roles must not create versions ---
+
+        [Fact]
+        public void NonVersionedSingleCompositeRoleDoesNotCreateNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            order.NonVersionedCurrentObjectState = new OrderStates(this.Transaction).Initial;
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
+
+        [Fact]
+        public void NonVersionedManyRoleDoesNotCreateNewVersion()
+        {
+            var order = new OrderBuilder(this.Transaction).Build();
+            this.Transaction.Derive();
+
+            var currentVersion = order.CurrentVersion;
+            Assert.Single(order.AllVersions);
+
+            var orderLine = new OrderLineBuilder(this.Transaction).Build();
+            order.AddNonVersionedOrderLine(orderLine);
+            this.Transaction.Derive();
+
+            Assert.Single(order.AllVersions);
+            Assert.Equal(currentVersion, order.CurrentVersion);
+        }
     }
 }

--- a/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Pages/Person/PersonEdit.razor
+++ b/dotnet/Base/Workspace/Blazor/Blazor.Bootstrap.Site/Pages/Person/PersonEdit.razor
@@ -48,9 +48,14 @@
     {
         this.Session = this.Workspace.CreateSession();
 
+        if (!long.TryParse(id, out var objectId))
+        {
+            return;
+        }
+
         var pull = new Pull
             {
-                ObjectId = long.Parse(id)
+                ObjectId = objectId
             };
 
         var result = await this.Session.PullAsync(pull);


### PR DESCRIPTION
## What

Adds 16 regression tests to `VersioningTests` (Base — where object versioning is introduced: the `Versioned`/`Version` interfaces, the `VersionedExtensions.CoreOnPostDerive` engine, and the `Order`/`OrderVersion` test model all live in `dotnet/Base/**`; nothing versioning-related is in Core/System). This builds on the #03+D1 fix (#71) and locks the behavior down broadly. Each test asserts both the `AllVersions` count and the relevant **snapshot content** (history), not just counts.

Coverage:
- **Unit role (`Amount`):** changed → new version (+ snapshot); unchanged-rederive → none.
- **Single composite (`OrderState`):** changed (null→`Initial`) → new version (+ snapshot); unchanged → none.
- **Many composite (`OrderLines`):** added / removed / cleared / empty→populated → new version (+ snapshot count/content); re-assigned same set (forced re-derive) → no new version (covers the `.Id` order-independent comparison from D1).
- **History:** version snapshot keeps the value at each derivation (`V1.Amount==10`, `V2.Amount==20`); the first version keeps its original line set; 3 sequential changes → 3 versions.
- **Multi-role:** Amount + OrderState + a line changed in one cycle → exactly one new version.
- **Child versioning:** `OrderLine` is versioned independently (`orderLine.Amount` change → `orderLine.AllVersions == 2`).
- **Non-versioned roles** (single composite, many) → no new version.

The "unchanged / no-new-version" tests force a re-derive by mutating a **non-versioned role of the same kind as the subject** (unit tests use `NonVersionedAmount`; composite tests use `NonVersionedCurrentObjectState`), so each test's action matches its subject.

## Verification

```
dotnet test dotnet/Base/Database/Domain.Tests/Domain.Tests.csproj --filter "FullyQualifiedName~VersioningTests"
  → Passed: 23, Failed: 0   (5 pre-existing + 2 from #71 + 16 new)
```

These pass on current main; the unchanged-many and reassigned-set cases would have failed/thrown before #71. Gated by `CiDotnetBaseDatabaseTest`.