### PR TITLE
fix(base): distinguish prompt dialog Cancel from Ok [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Material prompt dialog's **Cancel** button no longer returns the typed value. Both the Ok and Cancel
+  buttons in `dialog.component.html` bound `[mat-dialog-close]="value"`, so cancelling a prompt closed it with
+  the same string as Ok; callers test the result for truthiness, so a cancelled prompt was indistinguishable
+  from a confirmed one and the typed value was acted upon anyway. Cancel now closes with `undefined` (matching
+  dismissal via Escape or a backdrop click), so a non-empty result unambiguously means the user pressed Ok.
 - The dynamic **edit extent panel** no longer crashes when a displayed `DateTime` column is unset. Its row
   builder formatted every DateTime cell with `format(value, 'dd-MM-yyyy')` (date-fns), which throws
   `RangeError: Invalid time value` on a null value — so a single unset DateTime (e.g. an included organisation's

--- a/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/dialog/dialog.component.html
+++ b/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/dialog/dialog.component.html
@@ -27,5 +27,5 @@
   <button *ngIf="confirmation" mat-button [mat-dialog-close]="true">Yes</button>
   <button *ngIf="confirmation" mat-button [mat-dialog-close]="false">No</button>
   <button *ngIf="prompt" mat-button [mat-dialog-close]="value">Ok</button>
-  <button *ngIf="prompt" mat-button [mat-dialog-close]="value">Cancel</button>
+  <button *ngIf="prompt" mat-button [mat-dialog-close]="undefined">Cancel</button>
 </mat-dialog-actions>


### PR DESCRIPTION
## What

The prompt branch of the Material dialog bound both action buttons to the same result:

```html
<button *ngIf="prompt" mat-button [mat-dialog-close]="value">Ok</button>
<button *ngIf="prompt" mat-button [mat-dialog-close]="value">Cancel</button>
```

`AllorsMaterialDialogService.prompt()` returns `afterClosed()` (`Observable<string>`), and consumers guard the result on truthiness — e.g. the purchase/sales invoice list pages do `if (paymentDateString) { …apply payment… }`. Because **Cancel** closed with the typed `value`, clicking Cancel returned the same non-empty string as Ok, so the caller could not tell cancel from confirm and acted on the typed value anyway.

(A bare `mat-dialog-close` would not fix this cleanly: a static valueless attribute binds the directive's `dialogResult` input to `''`, leaving Cancel indistinguishable from "Ok with an empty field.")

## Fix

Cancel now closes with `undefined`:

```html
<button *ngIf="prompt" mat-button [mat-dialog-close]="undefined">Cancel</button>
```

This makes **Cancel ≡ Escape ≡ backdrop-click** (Angular Material emits `undefined` for all dismissals), unambiguously distinguishable from any Ok string (including an empty one), and type-consistent with `afterClosed()`. Existing truthiness-based consumers correctly treat a cancelled prompt as "no value" with no caller changes.

## Validation

Fix-only (`ng`): no adjacent `*.spec.ts`, and this foundation lib has no test scaffolding (only `lint` + `test` targets, no `build`) — the binding is only Angular-template-compiled by a consuming-app build. The new binding is identical in form to the three sibling `[mat-dialog-close]="…"` buttons in the same `<mat-dialog-actions>`, and was confirmed against the installed Material source to resolve to `close(undefined)`. Regression gate: CI e2e `CiTypescriptE2EAngularBaseTest`.
