### PR TITLE
fix(base): reset file input so a removed file can be re-selected [BUG-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Material single-file upload field can re-select a file after it was removed. `onFileInput` read the
+  picked file but never reset the hidden `<input type="file">`, so its `value` kept the previous filename;
+  after deleting the media, re-picking the **same** file did not fire the input's `change` event (a file input
+  only re-fires when its value changes), so the file could not be re-selected. The input is now reset
+  (`input.value = ''`) once the selection has been read.
 - The Material prompt dialog's **Cancel** button no longer returns the typed value. Both the Ok and Cancel
   buttons in `dialog.component.html` bound `[mat-dialog-close]="value"`, so cancelling a prompt closed it with
   the same string as Ok; callers test the result for truthiness, so a cancelled prompt was indistinguishable

--- a/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/file/file.component.ts
+++ b/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/file/file.component.ts
@@ -85,6 +85,10 @@ export class AllorsMaterialFileComponent extends RoleField {
 
         reader.addEventListener('load', load, false);
         reader.readAsDataURL(file);
+
+        // Reset the input so re-selecting the same file fires `change` again
+        // (a file input does not re-fire when its value is unchanged).
+        input.value = '';
       }
     }
   }


### PR DESCRIPTION
## What

The Material single-file upload field (`a-mat-file`) drives a hidden file input:

```html
<input #fileInput type="file" (change)="onFileInput($event)" style="display: none" />
```

`onFileInput` reads the picked file into a `Media` but never resets the input, so its `value` keeps the previous filename. The selected media can be removed via `<a-mat-media (delete)="delete()">` (which sets `model = undefined`), but the hidden input is untouched. Because a `<input type="file">` only fires `change` when its value *changes*, re-picking the **same** file after removal does nothing — the removed file can't be re-selected.

## Fix

`onFileInput` now clears the input once the selection has been read:

```ts
reader.addEventListener('load', load, false);
reader.readAsDataURL(file);

// Reset the input so re-selecting the same file fires `change` again
// (a file input does not re-fire when its value is unchanged).
input.value = '';
```

`file` is already captured by reference and the in-flight `FileReader` holds its own reference to the `Blob`, so clearing `input.value` doesn't affect the read. Clearing after every selection also means the input is already empty by the time `delete()` runs, so no `@ViewChild` is needed there.

## Validation

Fix-only (`ng`): `npx nx lint base-workspace-angular-material-foundation` → 0 errors. No automated test added:

- **Unit:** the lib has no component-test harness, and reaching the reset requires mocking the session/workspace/`Media` creation + a `File` event — disproportionate for a one-liner.
- **E2E:** the symptom is not reproducible under Playwright — `setInputFiles` dispatches `change` unconditionally, so it bypasses the native "no `change` on an unchanged value" behavior that *is* the bug; a remove→re-pick-same test would pass even unfixed. (The only RED→GREEN e2e would assert the implementation invariant that the input resets to empty, which pins the mechanism rather than the symptom.)

Regression gate: CI e2e `CiTypescriptE2EAngularBaseTest`.
