### PR TITLE
fix(base): guard unset DateTime in edit-extent panel render [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The dynamic **edit extent panel** no longer crashes when a displayed `DateTime` column is unset. Its row
+  builder formatted every DateTime cell with `format(value, 'dd-MM-yyyy')` (date-fns), which throws
+  `RangeError: Invalid time value` on a null value — so a single unset DateTime (e.g. an included organisation's
+  `IncorporationDate`) threw while building the row array and the whole table failed to render. Both the display
+  and include-display columns now guard the value (`value != null`) before formatting, matching the panel's
+  existing period-date handling; an unset DateTime renders as an empty cell.
 - The `Base` server and command-line tools loaded the `core` configuration instead of `base`, so the
   `config/<provider>/base` templates were never used. They now resolve the `base` domain.
 - The `PersonEdit` Blazor page no longer crashes when its `{id}` route parameter is not a number. It parsed

--- a/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
+++ b/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
@@ -182,5 +182,51 @@ namespace Tests.E2E.Objects
 
             ClassicAssert.AreEqual(before.Length - 1, after.Length);
         }
+
+        [Test]
+        public async Task EmploymentExtentWithUnsetIncorporationDate()
+        {
+            // Regression for the dynamic edit-extent panel: a row whose DateTime display
+            // column is unset must not crash the table render. The person-overview Employment
+            // panel includes the Employer organisation, whose primary display columns include
+            // the DateTime IncorporationDate. With an employer that has no IncorporationDate,
+            // refreshTable previously called date-fns format(null) and threw "Invalid time
+            // value", so the panel rendered no rows (and logged a console error).
+            var person = new People(this.Transaction).FindBy(this.M.Person.FirstName, "John");
+
+            // Employer deliberately built without an IncorporationDate (the column is optional).
+            var organisation = new OrganisationBuilder(this.Transaction)
+                .WithName("Organisation Without IncorporationDate")
+                .Build();
+
+            var employment = new EmploymentBuilder(this.Transaction)
+                .WithEmployee(person)
+                .WithEmployer(organisation)
+                .WithFromDate(this.Transaction.Now().AddDays(-1))
+                .Build();
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
+            var @class = this.M.Person;
+
+            var overview = this.Application.GetOverview(@class);
+            var url = overview.RouteInfo.FullPath.Replace(":id", $"{person.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var personOverview = new PersonOverviewPageComponent(this.AppRoot);
+
+            await personOverview.ViewEmployment.Locator.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var edit = personOverview.EditEmployment;
+
+            var objectIds = await edit.Table.GetObjectIds();
+
+            // The current employment renders (its unset-IncorporationDate employer no longer
+            // throws); without the fix the table is empty and the console-error TearDown trips.
+            ClassicAssert.Contains(employment.Strategy.ObjectId.ToString(), objectIds);
+        }
     }
 }

--- a/typescript/modules/libs/base/workspace/angular-material/application/src/lib/extent/dynamic-edit-extent-panel.component.ts
+++ b/typescript/modules/libs/base/workspace/angular-material/application/src/lib/extent/dynamic-edit-extent-panel.component.ts
@@ -287,7 +287,10 @@ export class AllorsMaterialDynamicEditExtentPanelComponent
           if (w.objectType.isUnit) {
             const unit = w.objectType as Unit;
             const value = include.strategy.getUnitRole(w) as any;
-            row[w.name] = unit.isDateTime ? format(value, 'dd-MM-yyyy') : value;
+            row[w.name] =
+              unit.isDateTime && value != null
+                ? format(value, 'dd-MM-yyyy')
+                : value;
           } else {
             const role = include.strategy.getCompositeRole(w);
             if (role) {
@@ -304,7 +307,10 @@ export class AllorsMaterialDynamicEditExtentPanelComponent
         if (w.objectType.isUnit) {
           const unit = w.objectType as Unit;
           const value = v.strategy.getUnitRole(w) as any;
-          row[w.name] = unit.isDateTime ? format(value, 'dd-MM-yyyy') : value;
+          row[w.name] =
+            unit.isDateTime && value != null
+              ? format(value, 'dd-MM-yyyy')
+              : value;
         } else {
           if (w.isOne) {
             const composite = v.strategy.getCompositeRole(w);


### PR DESCRIPTION
## What

The dynamic edit-extent panel's row builder formats every DateTime display/include column with date-fns `format(value, 'dd-MM-yyyy')`:

```ts
row[w.name] = unit.isDateTime ? format(value, 'dd-MM-yyyy') : value;
```

`format(null, …)` throws `RangeError: Invalid time value`, and this runs inside the `.map()` that builds `this.table.data`, so a single unset DateTime cell throws while building the row array and the **whole table fails to render**.

It's reachable on a shipped page: the base `DisplayService` gives `Organisation` the display columns `[Name, Owner, IncorporationDate]` (a `DateTime`), and the **person-overview Employment panel** includes the Employer organisation — so an employer with no `IncorporationDate` crashes the panel.

## Fix

Guard the value before formatting at both sites (mirrors the panel's existing period-date handling at lines 334/338):

```ts
row[w.name] =
  unit.isDateTime && value != null ? format(value, 'dd-MM-yyyy') : value;
```

An unset DateTime falls through to the raw value (null) — like the loop already treats non-DateTime unit columns — and renders as a blank cell.

## Test (RED → GREEN)

New `PersonTest.EmploymentExtentWithUnsetIncorporationDate` (base e2e) seeds an employer organisation **without** an `IncorporationDate` and a current employment for John, opens the person-overview Employment edit panel, and asserts the row renders. It's pushed as a **separate first commit so CI shows it red** (the panel throws and renders no rows, and the console-error TearDown trips); the fix commit turns it green. This is a genuine exception (not Playwright-vacuous), so the test fails without the fix.

Gate: `CiTypescriptE2EAngularBaseTest`.
