### PR TITLE
fix(base): filter dialog keeps non-Between field single-valued [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The filter-field dialog no longer saves a non-Between field as a Between range. `apply()` decided
+  single-vs-Between solely from whether the `value2` control was truthy, but `value2` is never reset — so a
+  value entered for a Between field leaked into a subsequently-selected non-Between field (whose `value2` input
+  isn't shown, so the stale value survived) and the field was stored as a range (`FilterField.argument` →
+  `[value, value2]`), producing the wrong predicate. `apply()` now takes the Between branch only when the field
+  actually is Between (`this.isBetween && value2`).
 - The Material single-file upload field can re-select a file after it was removed. `onFileInput` read the
   picked file but never reset the hidden `<input type="file">`, so its `value` kept the previous filename;
   after deleting the media, re-picking the **same** file did not fire the input's `change` event (a file input

--- a/typescript/e2e/Base/E2E/Base/Angular/Allors/Material/Filter/AllorsMaterialFilterFieldDialogComponent.cs
+++ b/typescript/e2e/Base/E2E/Base/Angular/Allors/Material/Filter/AllorsMaterialFilterFieldDialogComponent.cs
@@ -1,0 +1,58 @@
+// <copyright file="AllorsMaterialFilterFieldDialogComponent.cs" company="Allors bvba">
+// Copyright (c) Allors bvba. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Allors.E2E.Angular.Material.Filter
+{
+    using Allors.Database.Meta;
+    using Html;
+    using Info;
+    using Microsoft.Playwright;
+    using Task = System.Threading.Tasks.Task;
+
+    /// <summary>
+    /// The filter-field dialog (a vertical stepper: step 0 picks the field, step 1 enters the
+    /// value(s)). Rendered in the CDK overlay, so construct it with the overlay container.
+    /// </summary>
+    public class AllorsMaterialFilterFieldDialogComponent : IComponent
+    {
+        public AllorsMaterialFilterFieldDialogComponent(IComponent container)
+        {
+            this.Container = container;
+            this.Locator = this.Container.Locator.Locator("mat-dialog-container");
+        }
+
+        public IComponent Container { get; }
+
+        public MetaPopulation M => this.Container.M;
+
+        public IPage Page => this.Container.Page;
+
+        public ILocator Locator { get; }
+
+        public ApplicationInfo ApplicationInfo => this.Container.ApplicationInfo;
+
+        public Input Value => new Input(this, "input[formcontrolname='value']");
+
+        public Input Value2 => new Input(this, "input[formcontrolname='value2']");
+
+        public Button ApplyButton => new Button(this, "button:has-text('Apply')");
+
+        /// <summary>Picks a field definition by its (humanized) name on the first stepper step.</summary>
+        public async Task SelectFieldAsync(string name)
+        {
+            await this.Page.WaitForAngular();
+            await new Button(this, $"button:has-text('{name}')").ClickAsync();
+            await this.Page.WaitForAngular();
+        }
+
+        /// <summary>Returns to the field-selection step by clicking the first step header.</summary>
+        public async Task BackAsync()
+        {
+            await this.Page.WaitForAngular();
+            await this.Locator.Locator(".mat-step-header").First.ClickAsync();
+            await this.Page.WaitForAngular();
+        }
+    }
+}

--- a/typescript/e2e/Base/E2E/Base/Angular/Allors/Material/Filter/FilterComponent.cs
+++ b/typescript/e2e/Base/E2E/Base/Angular/Allors/Material/Filter/FilterComponent.cs
@@ -8,6 +8,7 @@ namespace Allors.E2E.Angular.Material.Filter
     using Allors.Database.Meta;
     using Info;
     using Microsoft.Playwright;
+    using Task = System.Threading.Tasks.Task;
 
     public partial class FilterComponent : IComponent
     {
@@ -26,5 +27,16 @@ namespace Allors.E2E.Angular.Material.Filter
         public ILocator Locator { get; }
 
         public ApplicationInfo ApplicationInfo => this.Container.ApplicationInfo;
+
+        /// <summary>The applied filter chips (one per added field).</summary>
+        public ILocator Chips => this.Locator.Locator("mat-chip");
+
+        /// <summary>Clicks the filter toolbar to open the filter-field dialog.</summary>
+        public async Task AddAsync()
+        {
+            await this.Page.WaitForAngular();
+            await this.Locator.Locator("mat-toolbar").ClickAsync();
+            await this.Page.WaitForAngular();
+        }
     }
 }

--- a/typescript/e2e/Base/Tests/Custom/Form/FilterTest.cs
+++ b/typescript/e2e/Base/Tests/Custom/Form/FilterTest.cs
@@ -1,0 +1,60 @@
+// <copyright file="FilterTest.cs" company="Allors bvba">
+// Copyright (c) Allors bvba. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Tests.E2E.Form
+{
+    using Allors.E2E.Angular;
+    using Allors.E2E.Angular.Material.Filter;
+    using Allors.E2E.Test;
+    using E2E;
+    using NUnit.Framework;
+    using Task = System.Threading.Tasks.Task;
+
+    public class FilterTest : Test
+    {
+        public FilterComponent FilterComponent => new FilterComponent(this.AppRoot);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            await this.LoginAsync("jane@example.com");
+            await this.Page.NavigateAsync("/filter");
+        }
+
+        [Test]
+        public async Task NonBetweenFieldDoesNotBecomeBetweenRange()
+        {
+            // Regression for the filter-field dialog: a value2 entered for a Between field must
+            // not leak into a subsequently-selected non-Between field. Pick the Between (Decimal)
+            // field and enter both ends, step back, pick the non-Between (String) field and enter
+            // a single value, then apply. The String field must be saved as a single value, not a
+            // Between range. (/filter is a test-only page that offers both field kinds.)
+            var filter = this.FilterComponent;
+
+            await filter.AddAsync();
+
+            var dialog = new AllorsMaterialFilterFieldDialogComponent(this.OverlayContainer);
+
+            await dialog.SelectFieldAsync("Decimal");
+            await dialog.Value.SetAsync("10");
+            await dialog.Value2.SetAsync("20");
+
+            await dialog.BackAsync();
+
+            await dialog.SelectFieldAsync("String");
+            await dialog.Value.SetAsync("abc");
+
+            await dialog.ApplyButton.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var chipText = await filter.Chips.First.TextContentAsync();
+
+            // Without the fix, the stale "20" makes the String field a Between range ("abc <-> 20").
+            ClassicAssert.IsFalse(
+                chipText.Contains("<->"),
+                $"Expected a single-value filter field, but got a Between range: '{chipText}'");
+        }
+    }
+}

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/app.routes.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { LoginComponent } from './auth/login.component';
 import { MainComponent } from './main/main.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { FieldsComponent } from './fields/fields-form.component';
+import { FilterPageComponent } from './filter/filter-page.component';
 
 import { CountryListPageComponent } from './domain/country/list/country-list-page.component';
 import { OrganisationListPageComponent } from './domain/organisation/list/organisation-list-page.component';
@@ -45,6 +46,10 @@ export const routes: Routes = [
         path: 'fields',
         component: FieldsComponent,
       },
+      {
+        path: 'filter',
+        component: FilterPageComponent,
+      },
     ],
   },
 ];
@@ -54,6 +59,7 @@ export const components: any[] = [
   MainComponent,
   DashboardComponent,
   FieldsComponent,
+  FilterPageComponent,
   CountryListPageComponent,
   OrganisationListPageComponent,
   OrganisationOverviewPageComponent,

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/filter/filter-page.component.html
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/filter/filter-page.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  <a-mat-filter [filter]="filter"></a-mat-filter>
+</div>

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/filter/filter-page.component.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/filter/filter-page.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { M } from '@allors/default/workspace/meta';
+import {
+  Filter,
+  FilterDefinition,
+  WorkspaceService,
+} from '@allors/base/workspace/angular/foundation';
+
+// Test-only page (driven from the base e2e) that hosts the filter component with both a
+// Like (non-Between) and a Between field definition, so the filter-field dialog offers both
+// kinds. No shipped base filter has a Between field, so this is the only way to exercise the
+// dialog's stale-value2 path. See typescript/e2e/Base/Tests/Custom/Form/FilterTest.cs.
+@Component({
+  templateUrl: './filter-page.component.html',
+})
+export class FilterPageComponent {
+  filter: Filter;
+
+  constructor(workspaceService: WorkspaceService) {
+    const m = workspaceService.workspace.configuration.metaPopulation as M;
+
+    this.filter = new Filter(
+      new FilterDefinition({
+        kind: 'And',
+        operands: [
+          {
+            kind: 'Like',
+            roleType: m.Data.String,
+            parameter: 'string',
+          },
+          {
+            kind: 'Between',
+            roleType: m.Data.Decimal,
+            parameter: 'decimal',
+          },
+        ],
+      })
+    );
+  }
+}

--- a/typescript/modules/libs/base/workspace/angular-material/application/src/lib/filter/field/dialog.component.ts
+++ b/typescript/modules/libs/base/workspace/angular-material/application/src/lib/filter/field/dialog.component.ts
@@ -136,7 +136,7 @@ export class AllorsMaterialFilterFieldDialogComponent
       value == null || (objectType.isComposite && value.strategy == null);
 
     if (!inValid) {
-      if (!value2) {
+      if (!this.isBetween || !value2) {
         this.filter.addField(
           new FilterField({
             definition: this.fieldDefinition,


### PR DESCRIPTION
## What

In the filter-field dialog, `apply()` decided single-value vs. Between range **solely** from whether the `value2` control was truthy:

```ts
if (!value2) { /* single */ } else { /* between: value + value2 */ }
```

`value2` is never reset (`selected()` sets only `value`; back-navigation only nulls `fieldDefinition`; the `value2` input renders only when `isBetween`). So: open a filter → pick a **Between** field → enter `value2` → step back → pick a **non-Between** field (its `value2` input isn't shown, so the stale value survives) → Apply. The non-Between field is then stored as a range — `FilterField.argument` emits `[value, value2]` — producing the wrong predicate.

## Fix

Gate the Between branch on the field actually being Between (one line):

```ts
if (!this.isBetween || !value2) { /* single */ } else { /* between */ }
```

Only the buggy path changes; genuine Between and empty-`value2` cases are unchanged.

## Test (RED → GREEN, e2e)

The bug isn't reachable through any shipped base screen (all `AppFilterService` filters are `Like`-only), so a **test-only `/filter` page** (in the base app) hosts `<a-mat-filter>` with a `Like`(String) + `Between`(Decimal) filter. New `FilterTest.NonBetweenFieldDoesNotBecomeBetweenRange` drives the dialog: pick "Decimal", enter `10`/`20`, step **back**, pick "String", enter `abc`, Apply — then asserts the chip is `string: abc`, not a range (`abc <-> 20`). Page-objects added: `FilterComponent.AddAsync`/`Chips` + `AllorsMaterialFilterFieldDialogComponent`.

The test is pushed as a **separate first commit so CI shows it red** (chip = `abc <-> 20`); the fix commit turns it green. Gate: `CiTypescriptE2EAngularBaseTest`.
