### PR TITLE
fix(base): dispose localised-markdown EasyMDE editor on destroy [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The localised-markdown field no longer leaks its EasyMDE/CodeMirror editor. The component created an EasyMDE
+  editor (with a CodeMirror `change` listener) in `ngOnInit` but never tore it down, so destroying the component
+  left the editor and its listeners dangling (EasyMDE's `toTextArea` teardown never ran). It now implements
+  `ngOnDestroy` — `super.ngOnDestroy()` then `easyMDE.toTextArea()` — disposing the editor and restoring the
+  original textarea.
 - The filter-field dialog no longer saves a non-Between field as a Between range. `apply()` decided
   single-vs-Between solely from whether the `value2` control was truthy, but `value2` is never reset — so a
   value entered for a Between field leaked into a subsequently-selected non-Between field (whose `value2` input

--- a/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/localisedmarkdown/localised-markdown.component.ts
+++ b/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/localisedmarkdown/localised-markdown.component.ts
@@ -44,4 +44,9 @@ export class AllorsMaterialLocalisedMarkdownComponent
 
     this.elementRef.nativeElement.easyMDE = this.easyMDE;
   }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.easyMDE?.toTextArea();
+  }
 }


### PR DESCRIPTION
## What

The localised-markdown field (`a-mat-localised-markdown`) builds an EasyMDE editor and attaches a CodeMirror `change` listener in `ngOnInit`:

```ts
this.easyMDE = new EasyMDE({ element: this.elementRef.nativeElement });
this.easyMDE.codemirror.on('change', () => { this.localisedText = this.easyMDE.value(); });
```

…but the component has **no `ngOnDestroy`**, so on destroy the EasyMDE editor and its listeners are never torn down and EasyMDE's own teardown (`toTextArea`, which restores the original `<textarea>` and detaches its handlers) never runs — a resource/listener leak.

## Fix

The base `Field` already `implements OnDestroy` (form-control cleanup), so override it and dispose the editor:

```ts
override ngOnDestroy(): void {
  super.ngOnDestroy();
  this.easyMDE?.toTextArea();
}
```

`toTextArea()` is EasyMDE's documented teardown. (`markdown.component.ts` has the identical omission — a separate follow-up PR.)

## Validation

Fix-only: prettier-clean; `npx nx lint base-workspace-angular-material-foundation` → 0 errors. A listener/memory leak has no clean behavioral symptom (Angular removes the component DOM on destroy regardless), so no new assertion is added; the existing `LocalisedMarkdownTest` (on the `/fields` page) navigates away + back — destroying and re-creating the component — so it exercises and regression-guards the new teardown. Gate: `CiTypescriptE2EAngularBaseTest`.
