### PR TITLE
fix(base): dispose markdown EasyMDE editor on destroy [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The markdown field no longer leaks its EasyMDE/CodeMirror editor. The component created an EasyMDE editor
+  (with a CodeMirror `change` listener) in `ngAfterViewInit` but never tore it down, so destroying the component
+  left the editor and its listeners dangling (EasyMDE's `toTextArea` teardown never ran). It now overrides
+  `ngOnDestroy` — `super.ngOnDestroy()` then `easyMDE.toTextArea()` — disposing the editor and restoring the
+  original textarea.
 - The localised-markdown field no longer leaks its EasyMDE/CodeMirror editor. The component created an EasyMDE
   editor (with a CodeMirror `change` listener) in `ngOnInit` but never tore it down, so destroying the component
   left the editor and its listeners dangling (EasyMDE's `toTextArea` teardown never ran). It now implements

--- a/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/markdown/markdown.component.ts
+++ b/typescript/modules/libs/base/workspace/angular-material/foundation/src/lib/field/role/markdown/markdown.component.ts
@@ -49,4 +49,9 @@ export class AllorsMaterialMarkdownComponent
 
     this.elementRef.nativeElement.easyMDE = this.easyMDE;
   }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.easyMDE?.toTextArea();
+  }
 }


### PR DESCRIPTION
## What

The markdown field (`a-mat-markdown`) builds an EasyMDE editor and attaches a CodeMirror `change` listener in `ngAfterViewInit`, but the component has **no `ngOnDestroy`** — so on destroy the editor and its listeners are never torn down and EasyMDE's `toTextArea` teardown (which restores the original `<textarea>` and detaches its handlers) never runs. A resource/listener leak. Identical twin of #BUG-09 (`localised-markdown.component.ts`, PR #82).

## Fix

The base `Field` already `implements OnDestroy` (form-control cleanup), so override it and dispose the editor:

```ts
override ngOnDestroy(): void {
  super.ngOnDestroy();
  this.easyMDE?.toTextArea();
}
```

## Validation

Fix-only: prettier-clean; `npx nx lint base-workspace-angular-material-foundation` → 0 errors. A listener/memory leak has no clean behavioral symptom, so no new assertion is added; the existing `MarkdownTest` (on the `/fields` page) exercises rendering/editing and regression-guards the new teardown. Gate: `CiTypescriptE2EAngularBaseTest`.
