### PR TITLE
fix(workspace): resolveLeafs adds the leaf node, not `this` [BUG-15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The workspace `nodeLeafs` pointer helper now returns the tree's leaf `Node`s instead of `undefined`.
+  `resolveLeafs` is a standalone function, so `results.add(this)` added `this` (`undefined`, not a method
+  receiver) for every leaf instead of the leaf `node`; `nodeLeafs` therefore returned a set containing
+  `undefined`. It now adds `node`.
 - The markdown field no longer leaks its EasyMDE/CodeMirror editor. The component created an EasyMDE editor
   (with a CodeMirror `change` listener) in `ngAfterViewInit` but never tore it down, so destroying the component
   left the editor and its listeners dangling (EasyMDE's `toTextArea` teardown never ran). It now overrides

--- a/build/Typescript/Modules/Build.cs
+++ b/build/Typescript/Modules/Build.cs
@@ -42,6 +42,16 @@ partial class Build
             .SetProcessWorkingDirectory(Paths.TypescriptModules)
             .SetCommand("system-workspace-adapters:test")));
 
+    private Target TypescriptSystemWorkspaceDomain => _ => _
+        .After(TypescriptInstall)
+        .DependsOn(DotnetCoreGenerate)
+        .DependsOn(EnsureDirectories)
+        .Executes(() => NpmRun(s => s
+            .AddProcessEnvironmentVariable("npm_config_loglevel", "error")
+            .AddProcessEnvironmentVariable("ALLORS_TRX_OUTPUT_FILE", Paths.ArtifactsTests / "SystemWorkspaceDomainTests.trx")
+            .SetProcessWorkingDirectory(Paths.TypescriptModules)
+            .SetCommand("system-workspace-domain:test")));
+
     private Target TypescriptSystemWorkspaceAdaptersJson => _ => _
         .After(TypescriptInstall)
         .DependsOn(EnsureDirectories)
@@ -65,7 +75,8 @@ partial class Build
          .After(TypescriptInstall)
          .DependsOn(TypescriptSystemWorkspaceMeta)
          .DependsOn(TypescriptSystemWorkspaceMetaJson)
-         .DependsOn(TypescriptSystemWorkspaceAdapters);
+         .DependsOn(TypescriptSystemWorkspaceAdapters)
+         .DependsOn(TypescriptSystemWorkspaceDomain);
 
     private Target TypescriptWorkspaceAdaptersJsonTest => _ => _
         .After(TypescriptInstall)

--- a/typescript/modules/libs/system/workspace/domain-tests/.babelrc
+++ b/typescript/modules/libs/system/workspace/domain-tests/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/typescript/modules/libs/system/workspace/domain-tests/.eslintrc.json
+++ b/typescript/modules/libs/system/workspace/domain-tests/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/typescript/modules/libs/system/workspace/domain-tests/jest.config.ts
+++ b/typescript/modules/libs/system/workspace/domain-tests/jest.config.ts
@@ -1,0 +1,25 @@
+/* eslint-disable */
+const trxFile = process.env.ALLORS_TRX_OUTPUT_FILE;
+
+export default {
+  displayName: 'system-workspace-domain-tests',
+  preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  ...(trxFile
+    ? {
+        reporters: [
+          'default',
+          ['jest-trx-results-processor', { outputFile: trxFile }],
+        ],
+      }
+    : {}),
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/system/workspace/domain-tests',
+};

--- a/typescript/modules/libs/system/workspace/domain-tests/project.json
+++ b/typescript/modules/libs/system/workspace/domain-tests/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "system-workspace-domain-tests",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/system/workspace/domain-tests/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/system/workspace/domain-tests/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/system/workspace/domain-tests"],
+      "options": {
+        "jestConfig": "libs/system/workspace/domain-tests/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/typescript/modules/libs/system/workspace/domain-tests/src/lib/pointer/node.spec.ts
+++ b/typescript/modules/libs/system/workspace/domain-tests/src/lib/pointer/node.spec.ts
@@ -1,0 +1,37 @@
+import { Node, nodeLeafs } from '@allors/system/workspace/domain';
+
+// Regression for resolveLeafs (pointer/node.ts): it is a standalone function, so it must add the
+// leaf `node` to the result set — not `this` (undefined). resolveLeafs only reads `node.nodes`, so
+// the tree can be built from minimal Node literals. Leaves use `nodes: []`.
+describe('nodeLeafs', () => {
+  it('returns the leaf nodes of a tree (not undefined)', () => {
+    const leafA = { nodes: [] } as unknown as Node;
+    const leafB = { nodes: [] } as unknown as Node;
+    const root = { nodes: [leafA, leafB] } as unknown as Node;
+
+    const leafs = nodeLeafs(root);
+
+    expect(leafs.has(leafA)).toBe(true);
+    expect(leafs.has(leafB)).toBe(true);
+    expect(leafs.size).toBe(2);
+    expect(leafs.has(undefined as unknown as Node)).toBe(false);
+  });
+
+  it('returns a childless root as its own single leaf', () => {
+    const root = { nodes: [] } as unknown as Node;
+
+    const leafs = nodeLeafs(root);
+
+    expect([...leafs]).toEqual([root]);
+  });
+
+  it('descends nested branches to the deepest leaves', () => {
+    const deepLeaf = { nodes: [] } as unknown as Node;
+    const branch = { nodes: [deepLeaf] } as unknown as Node;
+    const root = { nodes: [branch] } as unknown as Node;
+
+    const leafs = nodeLeafs(root);
+
+    expect([...leafs]).toEqual([deepLeaf]);
+  });
+});

--- a/typescript/modules/libs/system/workspace/domain-tests/tsconfig.json
+++ b/typescript/modules/libs/system/workspace/domain-tests/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    // "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/typescript/modules/libs/system/workspace/domain-tests/tsconfig.lib.json
+++ b/typescript/modules/libs/system/workspace/domain-tests/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts"]
+}

--- a/typescript/modules/libs/system/workspace/domain-tests/tsconfig.spec.json
+++ b/typescript/modules/libs/system/workspace/domain-tests/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/typescript/modules/libs/system/workspace/domain/src/lib/pointer/node.ts
+++ b/typescript/modules/libs/system/workspace/domain/src/lib/pointer/node.ts
@@ -108,7 +108,7 @@ function resolveLeafs(node: Node, results: Set<Node>): void {
       resolveLeafs(child, results);
     }
   } else {
-    results.add(this);
+    results.add(node);
   }
 }
 

--- a/typescript/modules/package.json
+++ b/typescript/modules/package.json
@@ -14,8 +14,9 @@
     "system-workspace-meta:test": "npx nx test system-workspace-meta-tests --skipNxCache",
     "system-workspace-meta-json:test": "npx nx test system-workspace-meta-json-tests --skipNxCache",
     "system-workspace-adapters:test": "npx nx test system-workspace-adapters-tests --skipNxCache",
+    "system-workspace-domain:test": "npx nx test system-workspace-domain-tests --skipNxCache",
     "system-workspace-adapters-json:test": "npx nx test system-workspace-adapters-json-tests --skipNxCache",
-    "test:all": "npm run system-workspace-meta:test && npm run system-workspace-meta-json:test && npm run system-workspace-adapters:test && npm run system-workspace-adapters-json:test"
+    "test:all": "npm run system-workspace-meta:test && npm run system-workspace-meta-json:test && npm run system-workspace-adapters:test && npm run system-workspace-domain:test && npm run system-workspace-adapters-json:test"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## What

`resolveLeafs` (`libs/system/workspace/domain/src/lib/pointer/node.ts`) is a standalone function, so `this` is `undefined`:

```ts
function resolveLeafs(node: Node, results: Set<Node>): void {
  if (node.nodes.length > 0) {
    for (const child of node.nodes) { resolveLeafs(child, results); }
  } else {
    results.add(this);   // bug: should be results.add(node)
  }
}
```

So `nodeLeafs(node)` returns a `Set` containing `undefined` instead of the tree's leaf `Node`s. Latent — `nodeLeafs`/`resolveLeafs` has no internal callers (it's exported via `@allors/system/workspace/domain`), which is why it was never caught.

## Fix

`node.ts`: `results.add(this)` → `results.add(node)`.

## Test — new `system-workspace-domain-tests` project

The `domain` lib had no sibling `*-tests` project (the convention everywhere else in `system/workspace`), so this adds one (mirroring `system-workspace-meta-tests`) with `src/lib/pointer/node.spec.ts` covering `nodeLeafs`. It's wired into `CiTypescriptWorkspaceTest` via a new `TypescriptSystemWorkspaceDomain` Nuke target (`build/Typescript/Modules/Build.cs`) + a `package.json` script.

Pushed **RED-first** (this commit adds the project + wiring + spec **without** the one-token fix) so CI proves the new project actually gates: `CiTypescriptWorkspaceTest` should fail on `system-workspace-domain-tests` (locally: 3 failed → 3 passed after the fix). The fix commit follows.

Gate: `CiTypescriptWorkspaceTest`.
