### PR TITLE
fix(workspace): call lowercase strategy.toJSON() in object factory [BUG-14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ under a dated version heading.
 
 ### Fixed
 
+- Workspace objects are JSON-serializable again. `PrototypeObjectFactory` built each object's `toJSON` to call
+  the non-existent `this.strategy.ToJSON()` (PascalCase), so `object.toJSON()` / `JSON.stringify(object)` threw
+  `TypeError: this.strategy.ToJSON is not a function`. It now calls the real lowercase `this.strategy.toJSON()`
+  (matching the sibling `toString`), so an object serializes to its `{ id }` projection instead of throwing.
 - The workspace `nodeLeafs` pointer helper now returns the tree's leaf `Node`s instead of `undefined`.
   `resolveLeafs` is a standalone function, so `results.add(this)` added `this` (`undefined`, not a method
   receiver) for every leaf instead of the leaf `node`; `nodeLeafs` therefore returned a set containing

--- a/typescript/modules/libs/system/workspace/adapters-tests/src/lib/prototype-object-factory.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-tests/src/lib/prototype-object-factory.spec.ts
@@ -1,0 +1,25 @@
+import { PrototypeObjectFactory } from '@allors/system/workspace/adapters';
+
+// Regression for prototype-object-factory.ts: an object's `toJSON` must delegate to the strategy's
+// (lowercase) `toJSON()`, not the non-existent PascalCase `ToJSON()`. PrototypeObjectFactory only reads
+// metaPopulation.classes[].{roleTypes,associationTypes,methodTypes} and ObjectBase.init() is a no-op, so a
+// minimal mock class + strategy stub suffices (no workspace/session).
+describe('PrototypeObjectFactory toJSON', () => {
+  it('serializes an object via the strategy toJSON()', () => {
+    const cls = { roleTypes: [], associationTypes: [], methodTypes: [] } as any;
+    const factory = new PrototypeObjectFactory({ classes: [cls] } as any);
+
+    const object = factory.create({
+      cls,
+      id: 42,
+      toJSON() {
+        return { id: this.id };
+      },
+    } as any);
+
+    // Before the fix this calls strategy.ToJSON() (undefined) and throws TypeError.
+    // (`toJSON` is added to the prototype dynamically, so it isn't on the IObject type — cast.)
+    expect((object as any).toJSON()).toEqual({ id: 42 });
+    expect(JSON.parse(JSON.stringify(object))).toEqual({ id: 42 });
+  });
+});

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/prototype-object-factory.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/prototype-object-factory.ts
@@ -37,7 +37,7 @@ export class PrototypeObjectFactory implements IObjectFactory {
       };
 
       prototype.toJSON = function () {
-        return this.strategy.ToJSON();
+        return this.strategy.toJSON();
       };
 
       objectType.roleTypes.forEach((roleType) => {


### PR DESCRIPTION
## What

`PrototypeObjectFactory` builds each workspace object's `toJSON`:
```ts
prototype.toJSON = function () { return this.strategy.ToJSON(); };   // PascalCase — no such method
```
`this` is an untyped function so `this.strategy` is `any` (the typo isn't type-checked), but at runtime `strategy.ToJSON` is `undefined` → `object.toJSON()` / `JSON.stringify(object)` throws `TypeError: this.strategy.ToJSON is not a function`. The real method is `Strategy.toJSON()` (`strategy.ts:577`, lowercase, returns `{ id }`); the sibling `toString` (line 36) already calls `this.strategy.toString()` correctly.

(The method is currently unused, but it's the intended graceful `{id}` projection that makes the otherwise-circular strategy/object serializable, and its `toString` twin already works — so we fix it rather than remove it.)

## Fix

`prototype-object-factory.ts:40`: `this.strategy.ToJSON()` → `this.strategy.toJSON()`.

## Test

New `system-workspace-adapters-tests/src/lib/prototype-object-factory.spec.ts` (the adapters lib's existing, CI-gated test project). `ObjectBase.init()` is a no-op and the factory only reads `metaPopulation.classes[].{roleTypes,associationTypes,methodTypes}`, so a minimal mock class + strategy stub suffices — no workspace/session. Asserts `toJSON()` / `JSON.stringify(object)` → `{ id }`.

Local RED→GREEN (fast jest): RED = `TypeError` at `prototype-object-factory.ts:40`; GREEN = 1 passed after the fix. Gate: `CiTypescriptWorkspaceTest`.
