### PR TITLE
fix(base): keep WaitForAngular polling when navigation destroys context

### DIFF
--- a/typescript/e2e/Base/E2E/Base/Angular/PageExtensions.cs
+++ b/typescript/e2e/Base/E2E/Base/Angular/PageExtensions.cs
@@ -45,8 +45,23 @@ namespace Allors.E2E.Angular
             var factor = 1;
             while (!isStable && timeOut > DateTime.Now)
             {
-                var value = await @this.EvaluateAsync<bool?>(expression);
-                isStable = value ?? false;
+                try
+                {
+                    var value = await @this.EvaluateAsync<bool?>(expression);
+                    isStable = value ?? false;
+                }
+                catch (PlaywrightException) when (!@this.IsClosed)
+                {
+                    // A navigation (router redirect / post-login redirect) swapped or tore down the JS
+                    // execution context mid-poll. That settling navigation is exactly what WaitForAngular
+                    // is waiting for, not a defect, so keep polling until Angular re-stabilises in the new
+                    // context. We gate on @this.IsClosed (a structural signal) rather than matching the
+                    // exception message, so a Playwright wording change can't silently break this; a real
+                    // page/browser teardown sets IsClosed and lets the exception propagate. A persistent
+                    // failure is still bounded by the one-minute timeOut above.
+                    isStable = false;
+                }
+
                 Thread.Sleep(Math.Min(10 * factor++, 100));
             }
         }


### PR DESCRIPTION
## Problem

Headless on Linux CI, every e2e test fails deterministically during login with:

```
Microsoft.Playwright.PlaywrightException : Execution context was destroyed, most likely because of a navigation
   at Allors.E2E.Angular.PageExtensions.WaitForAngular(IPage this)
   at Allors.E2E.LoginComponent.Login(...)
```

`WaitForAngular` polls Angular's testability with `EvaluateAsync` in a loop. It runs right after actions that trigger SPA navigation (the post-login redirect, `NavigateAsync`'s `router.navigateByUrl`, etc.). When a navigation lands *during* a poll, Chromium tears down the JS execution context and Playwright throws "Execution context was destroyed". The exception escaped the loop and failed the test.

It only surfaced **headless on Linux** because the timing reliably loses the race there; a headed browser on Windows won it, so the bug stayed latent.

## Fix

The settling navigation is exactly what `WaitForAngular` is waiting for, so treat that exception as transient and keep polling. The retry is gated on the **structural `IPage.IsClosed` signal**, not the exception message text:

- A navigation destroys the JS *execution context* but does **not** close the *page*, so `IsClosed` stays `false` through exactly the event we want to retry.
- A genuine page/browser teardown sets `IsClosed == true`, so that exception propagates immediately — fast-fail preserved.
- No dependency on Playwright's internal message wording, so a future re-wording can't silently reintroduce the bug.
- The existing one-minute `timeOut` still bounds a persistent failure, and `WaitForAngular` keeps its current return-on-timeout behaviour.

`WaitForAngular` is the shared chokepoint behind ~65 call sites (login, navigation, every component interaction), so this single change covers every flow.

## Verification

- ✅ `Allors.E2E.csproj` and `Tests.csproj` build with 0 errors.
- ⏳ Definitive proof is this PR's headless Linux CI run going green — the only environment where the race reliably reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
