### PR TITLE
fix(workspace): remove session-origin one-to-many role item instead of adding [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ under a dated version heading.
 
 ### Fixed
 
+- Removing an item from a session-origin one-to-many role now removes it.
+  `SessionOriginState.removeCompositesRoleOne2Many` used `ranges.add` instead of `ranges.remove`, so the item
+  was left in place; it now calls `ranges.remove`, matching the many-to-many case.
 - Removing an item from a session-origin many-valued role now removes it. `Strategy.removeCompositesRole`
   routed the `Origin.Session` case to `sessionOriginState.addCompositesRole`, so the item was re-added instead
   of removed; it now calls `removeCompositesRole`, matching the `Origin.Database` case.

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
@@ -120,3 +120,21 @@ test('removeCompositesRoleSession', async () => {
   // the bug routes it to sessionOriginState.addCompositesRole, leaving c1b in place.
   expect(c1a.SessionC1Many2Manies).toEqual([c1c]);
 });
+
+test('removeCompositesRoleSessionOne2Many', async () => {
+  const { workspace, m } = fixture;
+  const session = workspace.createSession();
+
+  const c1a = session.create<C1>(m.C1);
+  const c1b = session.create<C1>(m.C1);
+  const c1c = session.create<C1>(m.C1);
+
+  c1a.addSessionC1One2Many(c1b);
+  c1a.addSessionC1One2Many(c1c);
+
+  c1a.removeSessionC1One2Many(c1b);
+
+  // removeCompositesRoleOne2Many must remove the role from the association:
+  // the bug used ranges.add, leaving c1b in place.
+  expect(c1a.SessionC1One2Manies).toEqual([c1c]);
+});

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
@@ -342,7 +342,7 @@ export class SessionOriginState {
 
     // A ----> R
     let roleIds = this.getCompositesRole(association, roleType);
-    roleIds = this.ranges.add(roleIds, role);
+    roleIds = this.ranges.remove(roleIds, role);
     this.propertyByObjectByPropertyType.set(association, roleType, roleIds);
   }
 


### PR DESCRIPTION
> **Stacked on #87** (BUG-07). Base is the `fix/ts-foundation-07-…` branch so this PR shows only BUG-05's diff. Merge #87 first; GitHub then auto-retargets this PR to `main`.

## Problem
`SessionOriginState.removeCompositesRoleOne2Many` ended with `roleIds = this.ranges.add(roleIds, role)` — it **added** the role back instead of removing it, so removing an item from a session-origin one-to-many role left it in place. The sibling `removeCompositesRoleMany2Many` correctly uses `ranges.remove`.

This is reachable from the public API only once BUG-07 is fixed: the only path into `removeCompositesRoleOne2Many` is `Strategy.removeCompositesRole` (Origin.Session) → `SessionOriginState.removeCompositesRole`, which on `main` (pre-#87) wrongly called `addCompositesRole`.

## Fix
`session-origin-state.ts`: `ranges.add` → `ranges.remove` in `removeCompositesRoleOne2Many`.

## Test
New `removeCompositesRoleSessionOne2Many` in `runtime/strategy.spec.ts`, using the session-origin one-to-many `SessionC1One2Manies`: create three session `C1`s, add `c1b` + `c1c`, remove `c1b`, expect `[c1c]`. (Asserts the role side, so it is independent of BUG-06, which corrupts the inverse direction.)

- RED (unfixed, on the #87 base): received `[c1c, c1b]` — `c1b` was re-added.
- GREEN (fixed): 1 passed.

Gated by `CiTypescriptWorkspaceAdaptersJsonTest`.