### PR TITLE
fix(workspace): store association on session one-to-many role back-pointer [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ under a dated version heading.
 
 ### Fixed
 
+- Reassigning a session-origin one-to-many role to a new association now detaches it from the old one.
+  `SessionOriginState.addCompositesRoleOne2Many` set the role's association back-pointer to the role itself
+  instead of the association, so the "remove from previous association" step targeted the wrong object and the
+  role stayed in both associations (violating the one-to-many). It now stores the association.
 - Binary unit values are no longer double base64-encoded when pulled. `unitFromJson` returned `btoa(value)` for
   a `Binary` unit, but the wire value is already base64 and the push path (`unitToJson`) sends it through
   unchanged, so the round-trip produced a doubly-encoded value. It now returns the value as-is, matching the

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
@@ -138,3 +138,21 @@ test('removeCompositesRoleSessionOne2Many', async () => {
   // the bug used ranges.add, leaving c1b in place.
   expect(c1a.SessionC1One2Manies).toEqual([c1c]);
 });
+
+test('addCompositesRoleSessionOne2ManyReassigns', async () => {
+  const { workspace, m } = fixture;
+  const session = workspace.createSession();
+
+  const c1a = session.create<C1>(m.C1);
+  const c1d = session.create<C1>(m.C1);
+  const c1b = session.create<C1>(m.C1);
+
+  c1a.addSessionC1One2Many(c1b);
+  c1d.addSessionC1One2Many(c1b);
+
+  // One2Many: reassigning the role to a new association must detach it from the
+  // old one. The bug set the role's association to itself, so the detach targeted
+  // the wrong object and c1b stayed in c1a.
+  expect(c1a.SessionC1One2Manies).toEqual([]);
+  expect(c1d.SessionC1One2Manies).toEqual([c1b]);
+});

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
@@ -282,7 +282,7 @@ export class SessionOriginState {
     }
 
     // A <---- R
-    this.propertyByObjectByPropertyType.set(role, associationType, role);
+    this.propertyByObjectByPropertyType.set(role, associationType, association);
 
     // A ----> R
     let roleIds = this.getCompositesRole(association, roleType);


### PR DESCRIPTION
> **Stacked: #87 ← #88 ← this.** Base is the `fix/ts-foundation-05-…` (#88) branch so this PR shows only BUG-06's diff. Merge #87, then #88; GitHub then auto-retargets this PR to `main`.

## Problem
`SessionOriginState.addCompositesRoleOne2Many` wrote the role's association back-pointer as `set(role, associationType, role)` — the role itself instead of the association. That back-pointer is read by the one-to-many reassignment guard (`previousAssociationId = getCompositeRole(role, associationType)`) to detach the role from its previous association. With the wrong value, reassigning a role to a new association detached the wrong object, so the role stayed in **both** associations — violating the one-to-many multiplicity.

## Fix
`session-origin-state.ts`: `set(role, associationType, role)` → `set(role, associationType, association)` (matches the `// A <---- R` intent and the many-to-many sibling).

## Test
New `addCompositesRoleSessionOne2ManyReassigns` in `runtime/strategy.spec.ts`: create two associations (`c1a`, `c1d`) and a role (`c1b`) as session objects, `c1a.addSessionC1One2Many(c1b)` then `c1d.addSessionC1One2Many(c1b)`, and assert `c1a.SessionC1One2Manies` is `[]` and `c1d.SessionC1One2Manies` is `[c1b]`. (Reads the forward role side only.)

- RED (unfixed, on the #88 base): `c1a.SessionC1One2Manies` was `[c1b]` — the role stayed in both.
- GREEN (fixed): `c1a` empty, `c1d` holds `c1b`.

The GREEN reassignment path runs `removeCompositesRoleOne2Many`, which is BUG-05's fix — hence the stack.

Gated by `CiTypescriptWorkspaceAdaptersJsonTest`.