### PR TITLE
fix(workspace): check revocationById in checkForMissingRevocations [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ under a dated version heading.
 
 ### Fixed
 
+- Missing-revocation detection now checks the cached revocations instead of the permissions.
+  `ResponseContext.checkForMissingRevocations` tested `database.permissions` rather than
+  `database.revocationById`, so it flagged the wrong ids as missing (cached revocations were re-requested and
+  genuinely missing ones were not). It now checks `revocationById`, matching `checkForMissingGrants`.
 - Removing an item from a session-origin one-to-many role now removes it.
   `SessionOriginState.removeCompositesRoleOne2Many` used `ranges.add` instead of `ranges.remove`, so the item
   was left in place; it now calls `ranges.remove`, matching the many-to-many case.

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/database/security/response-context.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/database/security/response-context.spec.ts
@@ -1,0 +1,17 @@
+import { ResponseContext } from '@allors/system/workspace/adapters-json';
+
+test('checkForMissingRevocations flags ids absent from revocationById', () => {
+  const database = {
+    ranges: { enumerate: (value: number[]) => value },
+    grantById: new Map<number, unknown>(),
+    revocationById: new Map<number, unknown>([[1, {}]]), // revocation 1 is cached
+    permissions: new Set<number>([2]), // decoy: id 2 is a permission, not a revocation
+  } as any;
+
+  const context = new ResponseContext(database);
+  context.checkForMissingRevocations([1, 2] as any);
+
+  // Only 2 is an uncached revocation; 1 is already in revocationById. The bug checked
+  // `permissions` instead, so it would flag 1 (absent from permissions) and miss 2.
+  expect([...context.missingRevocationIds]).toEqual([2]);
+});

--- a/typescript/modules/libs/system/workspace/adapters-json/src/index.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/database/database-connection';
+export * from './lib/database/security/response-context';
 
 export * from './lib/json/from-json';
 export * from './lib/json/to-json';

--- a/typescript/modules/libs/system/workspace/adapters-json/src/lib/database/security/response-context.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/lib/database/security/response-context.ts
@@ -23,7 +23,7 @@ export class ResponseContext {
 
   checkForMissingRevocations(value: IRange<number>): IRange<number> {
     for (const id of this.database.ranges.enumerate(value)) {
-      if (!this.database.permissions.has(id)) {
+      if (!this.database.revocationById.has(id)) {
         this.missingRevocationIds.add(id);
       }
     }


### PR DESCRIPTION
## Problem
`ResponseContext.checkForMissingRevocations` records the response's revocation ids that the client hasn't cached (so they can be re-fetched), but it tested `this.database.permissions.has(id)` — the permission set — instead of `this.database.revocationById` (the cached revocations). The parallel `checkForMissingGrants` correctly checks `grantById`. So cached revocations were treated as missing (re-requested) and genuinely missing revocations whose id happened to be a known permission were treated as present — corrupting the security sync.

## Fix
`response-context.ts`: `this.database.permissions.has(id)` → `this.database.revocationById.has(id)`.

## Test
`ResponseContext` only reads `database.{ranges, grantById, revocationById, permissions}`, so a stub `database` exercises it with no server. New `database/security/response-context.spec.ts`: stub with `revocationById = {1}`, `permissions = {2}`; `checkForMissingRevocations([1, 2])` must flag only `[2]` (the uncached revocation).

- RED (unfixed): received `[1]` — flagged id 1 (absent from `permissions`) and missed id 2.
- GREEN (fixed): `[2]`.

A one-line additive, non-breaking export (`export * from './lib/database/security/response-context'`) lets the test import the class. Gated by `CiTypescriptWorkspaceAdaptersJsonTest`.