### PR TITLE
fix(workspace): stop double base64-encoding Binary units on pull [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ under a dated version heading.
 
 ### Fixed
 
+- Binary unit values are no longer double base64-encoded when pulled. `unitFromJson` returned `btoa(value)` for
+  a `Binary` unit, but the wire value is already base64 and the push path (`unitToJson`) sends it through
+  unchanged, so the round-trip produced a doubly-encoded value. It now returns the value as-is, matching the
+  other units.
 - Missing-revocation detection now checks the cached revocations instead of the permissions.
   `ResponseContext.checkForMissingRevocations` tested `database.permissions` rather than
   `database.revocationById`, so it flagged the wrong ids as missing (cached revocations were re-requested and

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/procedure.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/procedure.spec.ts
@@ -50,7 +50,7 @@ test('testUnitSamplesWithValues', async () => {
 
   const unitSample = result.object<UnitSample>(m.UnitSample);
 
-  expect(unitSample.AllorsBinary).toEqual('QVFJRA==');
+  expect(unitSample.AllorsBinary).toEqual('AQID');
   expect(unitSample.AllorsBoolean).toBeTruthy();
   expect(new Date(unitSample.AllorsDateTime)).toEqual(
     new Date('Tue Mar 27 1973 00:00:00 GMT+0000')

--- a/typescript/modules/libs/system/workspace/adapters-json/src/lib/json/from-json.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/lib/json/from-json.ts
@@ -20,7 +20,7 @@ export function unitFromJson(tag: string, value: unknown): IUnit {
 
     case UnitTags.Binary:
       if (typeof value === 'string') {
-        return btoa(value);
+        return value;
       }
       break;
 


### PR DESCRIPTION
## Problem
`unitFromJson` returned `btoa(value)` for a `Binary` unit, but the wire value is already base64 and the push path (`unitToJson`) passes strings through unchanged. So a pull/push round-trip produced a **doubly-encoded** value (e.g. `'AQID'` became `'QVFJRA=='`). Every other unit type returns the value as-is.

## Fix
`from-json.ts`: `return btoa(value)` → `return value` for `UnitTags.Binary`.

## Test (BUG-D — baked-in assertion)
`runtime/procedure.spec.ts:53` asserted the doubly-encoded `'QVFJRA=='` (= `btoa('AQID')`), so it couldn't catch the bug. Corrected to the real value `'AQID'` (the server's base64) in the same PR.

- RED (assertion corrected, source unfixed): `Expected "AQID"`, `Received "QVFJRA=="` — confirms the double-encode and that the server sends `'AQID'`.
- GREEN (source fixed): `testUnitSamplesWithValues` passes.

Gated by `CiTypescriptWorkspaceAdaptersJsonTest`. Mirror of the dotnet-base #03+D1 pair.