### PR TITLE
test(workspace): assert id changes in pushShouldUpdateId [BUG-11]

### DIFF
--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/push.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/push.spec.ts
@@ -138,13 +138,13 @@ test('pushShouldUpdateId', async () => {
   person.FirstName = 'Johny';
   person.LastName = 'Doey';
 
-  expect(person.id < 0);
+  expect(person.id).toBeLessThan(0);
 
   const pushResult = await session.push();
 
   expect(pushResult.hasErrors).toBeFalsy();
 
-  expect(person.id > 0);
+  expect(person.id).toBeGreaterThan(0);
 });
 
 test('pushShouldNotUpdateVersion', async () => {


### PR DESCRIPTION
## Problem
`pushShouldUpdateId` is meant to assert that a new object's id flips from a negative workspace id to a positive database id on push, but both checks called `expect(...)` with **no matcher**:

```ts
expect(person.id < 0);   // evaluates a boolean, asserts nothing
...
expect(person.id > 0);   // same no-op
```

So the test passed regardless of whether push updated the id.

## Fix
Give the assertions matchers:

```ts
expect(person.id).toBeLessThan(0);     // workspace id before push
...
expect(person.id).toBeGreaterThan(0);  // database id after push
```

Test-only (TV carve-out — correcting the vacuous assertions is the task); no production change. Verified GREEN against the running server; the assertions now have teeth. Gated by `CiTypescriptWorkspaceAdaptersJsonTest`.