### PR TITLE
test(workspace): assert canWrite in deniedPermissions [BUG-12]

### DIFF
--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/security.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/security.spec.ts
@@ -89,7 +89,7 @@ test('deniedPermissions', async () => {
         expect(denied.strategy.canWrite(roleType)).toBeFalsy();
       } else {
         expect(denied.strategy.canRead(roleType)).toBeTruthy();
-        expect(denied.strategy.canRead(roleType)).toBeTruthy();
+        expect(denied.strategy.canWrite(roleType)).toBeTruthy();
       }
     }
   }


### PR DESCRIPTION
## Problem
In `deniedPermissions`, the non-Database-origin branch asserted `canRead` **twice**:

```ts
expect(denied.strategy.canRead(roleType)).toBeTruthy();
expect(denied.strategy.canRead(roleType)).toBeTruthy();   // copy-paste — should be canWrite
```

so `canWrite` was never checked for session/workspace-origin roles on a `Denied` object. The parallel `accessControl` test does `canRead` then `canWrite`.

## Fix
Second assertion `canRead` → `canWrite`. Test-only (TV carve-out); no production change — session/workspace-origin roles are always writable, so `canWrite` is truthy.

Verified GREEN against the running server. Gated by `CiTypescriptWorkspaceAdaptersJsonTest`.