### PR TITLE
fix(testpopulation): generate unique organisation names by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ under a dated version heading.
 
 ### Fixed
 
+- Test-population organisation builders now generate unique `Organisation.Name` values by construction.
+  `OrganisationBuilderExtensions.WithDefaults`, `WithManufacturerDefaults` and `WithInternalOrganisationDefaults`
+  used Bogus `Company.CompanyName()`, which is not unique, so a population occasionally produced two organisations
+  with the same name — invisible in allors3 core (no name-uniqueness rule) but an intermittent `DerivationException`
+  ("Company with this name already exists") in downstream apps that enforce it. Each generated name now carries a
+  monotonic `Interlocked.Increment` suffix, removing the collisions at the source. (Bogus' `faker.UniqueIndex`
+  only advances inside the `Faker<T>.Generate()` pipeline, which these builders do not use, so a dedicated counter
+  is required.)
 - Reassigning a session-origin one-to-many role to a new association now detaches it from the old one.
   `SessionOriginState.addCompositesRoleOne2Many` set the role's association back-pointer to the role itself
   instead of the association, so the "remove from previous association" step targeted the wrong object and the

--- a/dotnet/Apps/Database/TestPopulation.Tests/SetupConfigurationTests.cs
+++ b/dotnet/Apps/Database/TestPopulation.Tests/SetupConfigurationTests.cs
@@ -5,7 +5,9 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System.Collections.Generic;
     using System.Linq;
+    using Allors.Database.Domain.TestPopulation;
     using Xunit;
 
     public class SetupConfigurationTests : DomainTest, IClassFixture<Fixture>
@@ -19,6 +21,23 @@ namespace Allors.Database.Domain.Tests
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "dutchInternalOrganisation");
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "Ned. Belastingdienst");
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "Federale OverheidsDienst FINANCIËN");
+        }
+
+        [Fact]
+        public void OrganisationDefaultsGenerateUniqueNames()
+        {
+            const int countPerMethod = 500;
+            var faker = this.Transaction.Faker();
+            var names = new List<string>(countPerMethod * 3);
+
+            for (var i = 0; i < countPerMethod; i++)
+            {
+                names.Add(new OrganisationBuilder(this.Transaction).WithDefaults().Build().Name);
+                names.Add(new OrganisationBuilder(this.Transaction).WithManufacturerDefaults(faker).Build().Name);
+                names.Add(new OrganisationBuilder(this.Transaction).WithInternalOrganisationDefaults().Build().Name);
+            }
+
+            Assert.Equal(names.Count, names.Distinct().Count());
         }
     }
 }

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Relation/OrganisationBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Relation/OrganisationBuilderExtensions.cs
@@ -6,12 +6,18 @@
 namespace Allors.Database.Domain.TestPopulation
 {
     using System.Linq;
+    using System.Threading;
     using Bogus;
     using Meta;
     using LegalForm = LegalForm;
 
     public static partial class OrganisationBuilderExtensions
     {
+        // Monotonic suffix that makes generated organisation names unique by construction.
+        // Bogus' faker.UniqueIndex/IndexGlobal only advance inside the Faker<T>.Generate() pipeline,
+        // which these builders do not use, so a dedicated counter is required.
+        private static int uniqueNameIndex;
+
         public static OrganisationBuilder WithDefaults(this OrganisationBuilder @this)
         {
             var m = @this.Transaction.Database.Services.Get<MetaPopulation>();
@@ -19,7 +25,7 @@ namespace Allors.Database.Domain.TestPopulation
 
             var euCountry = new Countries(@this.Transaction).FindBy(m.Country.IsoCode, faker.PickRandom(Countries.EuMemberStates));
 
-            @this.WithName(faker.Company.CompanyName())
+            @this.WithName($"{faker.Company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithEuListingState(euCountry)
                 .WithLegalForm(faker.Random.ListItem(@this.Transaction.Extent<LegalForm>()))
                 .WithLocale(faker.Random.ListItem(@this.Transaction.GetSingleton().Locales.ToArray()))
@@ -33,7 +39,7 @@ namespace Allors.Database.Domain.TestPopulation
         {
             var company = faker.Company;
 
-            @this.WithName(company.CompanyName())
+            @this.WithName($"{company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithIsManufacturer(true);
 
             return @this;
@@ -47,7 +53,7 @@ namespace Allors.Database.Domain.TestPopulation
             var company = faker.Company;
             var euCountry = new Countries(@this.Transaction).FindBy(m.Country.IsoCode, faker.PickRandom(Countries.EuMemberStates));
 
-            @this.WithName(company.CompanyName())
+            @this.WithName($"{company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithEuListingState(euCountry)
                 .WithLegalForm(faker.Random.ListItem(@this.Transaction.Extent<LegalForm>()))
                 .WithLocale(faker.Random.ListItem(@this.Transaction.GetSingleton().Locales.ToArray()))


### PR DESCRIPTION
## Summary
Make test-population `Organisation.Name` values unique by construction, removing a source of intermittent duplicate-name failures in downstream apps that enforce name uniqueness.

## Problem
`OrganisationBuilderExtensions.WithDefaults`, `WithManufacturerDefaults` and `WithInternalOrganisationDefaults` generated names with Bogus `Company.CompanyName()`, which is not unique. A population occasionally produced two organisations with the same name — invisible in allors3 core (no name-uniqueness rule) but an intermittent `DerivationException: Company with this name already exists` in downstream apps that enforce it. It only surfaced on unlucky random draws, so downstream CI was flaky.

## Fix
Append a monotonic `Interlocked.Increment` suffix to each generated organisation name, so uniqueness is guaranteed by construction rather than by chance.

> Note: Bogus' `faker.UniqueIndex` / `IndexGlobal` only advances inside the `Faker<T>.Generate()` pipeline, which these builders do not use — on bare reads it stays constant, so a dedicated counter is required. The new test demonstrated this directly (appending `UniqueIndex` left the duplicate count essentially unchanged).

## Verification
- New `SetupConfigurationTests.OrganisationDefaultsGenerateUniqueNames` builds 1500 organisations across the three methods and asserts all names are distinct. **Fails before the fix** (1435/1500 distinct), **passes after** (1500/1500), deterministically.
- `TestPopulation.Tests` run 5×: green every time.
- Full `Domain.Tests`: **2299 passed, 0 failed, 1 skipped** — no regressions.

## Scope
Test-population only — the diff touches `OrganisationBuilderExtensions.cs`, `SetupConfigurationTests.cs`, and `CHANGELOG.md`. No domain-model, rule, or production changes.