### PR TITLE
test(invoice): de-flake SalesInvoiceItemState partial-payment test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
+  domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
+  price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so
+  `SalesInvoiceStateRule` correctly derived `NotPaid` instead of the asserted `PartiallyPaid`. The test-data
+  builders now floor the random unit price at `2`, and a deterministic regression test pins the minimal price
+  so the "one unit short of full payment" boundary is always covered.
 - Test-population organisation builders now generate unique `Organisation.Name` values by construction.
   `OrganisationBuilderExtensions.WithDefaults`, `WithManufacturerDefaults` and `WithInternalOrganisationDefaults`
   used Bogus `Company.CompanyName()`, which is not unique, so a population occasionally produced two organisations

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -2090,6 +2090,39 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedSalesInvoiceItemAmountPaidAtMinimalUnitPriceDeriveSalesInvoiceItemStatePartiallyPaid()
+        {
+            // Regression for a flaky CI failure: WithDefaults() draws a random unit price; a price of 1 made the
+            // `TotalIncVat - 1` payment 0, deriving NotPaid. Pin the minimal sensible price (qty 1 from defaults)
+            // so the boundary (one unit short of full payment) is covered deterministically instead of ~1% of the time.
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithDefaultsWithoutItems(this.InternalOrganisation).Build();
+
+            this.Transaction.Derive();
+
+            var invoiceItem = new SalesInvoiceItemBuilder(this.Transaction).WithDefaults().Build();
+            invoiceItem.AssignedUnitPrice = 2M;
+            invoice.AddSalesInvoiceItem(invoiceItem);
+            this.Transaction.Derive();
+
+            invoice.Send();
+            this.Transaction.Derive();
+
+            var partialAmount = invoiceItem.TotalIncVat - 1;
+            new ReceiptBuilder(this.Transaction)
+                .WithAmount(partialAmount)
+                .WithEffectiveDate(this.Transaction.Now())
+                .WithPaymentApplication(new PaymentApplicationBuilder(this.Transaction)
+                                            .WithAmountApplied(partialAmount)
+                                            .WithInvoiceItem(invoiceItem)
+                                            .Build())
+                .Build();
+
+            this.Transaction.Derive();
+
+            Assert.Equal(invoiceItem.SalesInvoiceItemState, new SalesInvoiceItemStates(this.Transaction).PartiallyPaid);
+        }
+
+        [Fact]
         public void ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePaid()
         {
             var invoice = new SalesInvoiceBuilder(this.Transaction).WithDefaultsWithoutItems(this.InternalOrganisation).Build();

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
@@ -29,7 +29,10 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithInvoiceItemType(faker.Random.ListItem(otherInvoiceItemTypes))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                // Floor 2, not 1: several invoice tests form a partial payment as `TotalIncVat - 1`,
+                // which must stay > 0. A unit price of 1 makes it 0, so the derivation yields NotPaid
+                // instead of PartiallyPaid and flakes those tests (this Faker is unseeded/random).
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -53,7 +56,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -73,7 +76,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -98,7 +101,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }


### PR DESCRIPTION
## Problem
The latest `main` CI run failed in `CiDotnetAppsDatabaseTest (sqlclient)` on a single test (2298 passed, 1 failed) — and the **same commit passed in its PR run**, the classic flakiness signature:

`SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`

`SalesInvoiceItemBuilder.WithDefaults()` assigns a random unit price `faker.Random.UInt(1, 100)` from an unseeded `Faker`. For the default (VAT-free, single-item) invoice, `TotalIncVat == price`. The test pays `partialAmount = TotalIncVat - 1`; when the price rolls **1**, that payment is **0**, so `SalesInvoiceStateRule` correctly derives `NotPaid` instead of the asserted `PartiallyPaid` (~1% of runs). Production code is correct — this is test-data fragility shared by several single-item invoice tests, all drawing their price from the same generator.

## Fix
- Floor the random unit price at `2` in the `SalesInvoiceItemBuilder` test-data builders (4 sites) so `TotalIncVat - 1` is always a strictly-positive partial payment. De-flakes the failing test and its siblings at the root, with no production change.
- Add a deterministic regression test that pins the minimal unit price, covering the "one unit short of full payment" boundary on every run.
- CHANGELOG entry.

## Verification
- `dotnet build` Domain.Tests: 0 errors.
- `SalesInvoiceStateRuleTests`: 16/16 pass (incl. the new regression test).
- SalesInvoice / InvoiceItem / PaymentApplication / SalesOrderItem suites: 538/538 pass.
