### PR TITLE
test(workspace): convert Core workspace async void tests to async Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The Core workspace test suite no longer intermittently crashes its test host after passing. Its 188 `[Fact]`
+  methods were declared `async void` (xUnit1048); on xUnit v3 an `async void` test whose continuation throws
+  after the run is considered complete escapes as an unobserved exception, failing the job *after* a green
+  summary (observed as a flaky `CiDotnetCoreWorkspaceLocalTest`). All Core workspace tests are now `async Task`
+  so xUnit awaits them; this covers the Local and both Remote workspace jobs (the methods live in shared
+  abstract base classes inherited by each adapter's runner).
 - The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
   domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
   price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so

--- a/dotnet/Core/Workspace/Tests/Tests/AssociationTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/AssociationTests.cs
@@ -6,6 +6,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void Database_GetOne2Many()
+        public async Task Database_GetOne2Many()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -58,7 +59,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void Database_GetOne2One()
+        public async Task Database_GetOne2One()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();

--- a/dotnet/Core/Workspace/Tests/Tests/ChangeSetTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/ChangeSetTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         protected ChangeSetTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void CreatingChangeSetAfterCreatingSession()
+        public async Task CreatingChangeSetAfterCreatingSession()
         {
             await this.Login("administrator");
 
@@ -30,7 +31,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void Instantiated()
+        public async Task Instantiated()
         {
             await this.Login("administrator");
 
@@ -50,7 +51,7 @@ namespace Tests.Workspace
 
 
         [Fact]
-        public async void ChangeSetAfterPush()
+        public async Task ChangeSetAfterPush()
         {
             await this.Login("administrator");
 
@@ -70,7 +71,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetPushChangeNoPush()
+        public async Task ChangeSetPushChangeNoPush()
         {
             await this.Login("administrator");
 
@@ -98,7 +99,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetPushChangePush()
+        public async Task ChangeSetPushChangePush()
         {
             await this.Login("administrator");
 
@@ -128,7 +129,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushWithNoChanges()
+        public async Task ChangeSetAfterPushWithNoChanges()
         {
             await this.Login("administrator");
 
@@ -147,7 +148,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushWithPull()
+        public async Task ChangeSetAfterPushWithPull()
         {
             await this.Login("administrator");
 
@@ -169,7 +170,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushWithPullWithNoChanges()
+        public async Task ChangeSetAfterPushWithPullWithNoChanges()
         {
             await this.Login("administrator");
 
@@ -195,7 +196,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetOne2One()
+        public async Task ChangeSetOne2One()
         {
             await this.Login("administrator");
 
@@ -227,7 +228,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushOne2One()
+        public async Task ChangeSetAfterPushOne2One()
         {
             await this.Login("administrator");
 
@@ -257,7 +258,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushOne2OneRemove()
+        public async Task ChangeSetAfterPushOne2OneRemove()
         {
             await this.Login("administrator");
 
@@ -285,7 +286,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushMany2One()
+        public async Task ChangeSetAfterPushMany2One()
         {
             await this.Login("administrator");
 
@@ -315,7 +316,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushMany2OneRemove()
+        public async Task ChangeSetAfterPushMany2OneRemove()
         {
             await this.Login("administrator");
 
@@ -354,7 +355,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushOne2Many()
+        public async Task ChangeSetAfterPushOne2Many()
         {
             await this.Login("administrator");
 
@@ -384,7 +385,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushOne2ManyRemove()
+        public async Task ChangeSetAfterPushOne2ManyRemove()
         {
             await this.Login("administrator");
 
@@ -418,7 +419,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetMany2Many()
+        public async Task ChangeSetMany2Many()
         {
             await this.Login("administrator");
 
@@ -449,7 +450,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushMany2Many()
+        public async Task ChangeSetAfterPushMany2Many()
         {
             await this.Login("administrator");
 
@@ -479,7 +480,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPushMany2ManyRemove()
+        public async Task ChangeSetAfterPushMany2ManyRemove()
         {
             await this.Login("administrator");
 
@@ -521,7 +522,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterPullInNewSessionButNoPush()
+        public async Task ChangeSetAfterPullInNewSessionButNoPush()
         {
             await this.Login("administrator");
 
@@ -537,7 +538,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterDoubleDatabaseReset()
+        public async Task ChangeSetAfterDoubleDatabaseReset()
         {
             await this.Login("administrator");
 
@@ -574,7 +575,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangeSetAfterDoubleWorkspaceReset()
+        public async Task ChangeSetAfterDoubleWorkspaceReset()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/Database/ManyToManyTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Database/ManyToManyTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRoleOld()
+        public async Task SetRoleOld()
         {
             // Single session
             #region No push before add
@@ -326,7 +326,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -364,7 +364,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRoleToNull()
+        public async Task SetRoleToNull()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -406,7 +406,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -449,7 +449,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveNullRole()
+        public async Task RemoveNullRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Database/ManyToOneTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Database/ManyToOneTests.cs
@@ -39,7 +39,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -78,7 +78,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Database/OneToManyTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Database/OneToManyTests.cs
@@ -39,7 +39,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -76,7 +76,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRoleToNull()
+        public async Task SetRoleToNull()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -122,7 +122,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -163,7 +163,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveNullRole()
+        public async Task RemoveNullRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Database/OneToOneTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Database/OneToOneTests.cs
@@ -37,7 +37,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -73,7 +73,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation.DatabaseRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Database/UnitTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Database/UnitTests.cs
@@ -37,7 +37,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -91,7 +91,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation
         }
 
         [Fact]
-        public async void SetRoleNull()
+        public async Task SetRoleNull()
         {
             foreach (DatabaseMode mode in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -233,7 +233,7 @@ namespace Tests.Workspace.DatabaseAssociation.DatabaseRelation
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/DatabaseResetTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/DatabaseResetTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         protected DatabaseResetTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void ResetUnitWithoutPush()
+        public async Task ResetUnitWithoutPush()
         {
             await this.Login("administrator");
 
@@ -43,7 +44,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetUnitAfterPushTest()
+        public async Task ResetUnitAfterPushTest()
         {
             await this.Login("administrator");
 
@@ -65,7 +66,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetUnitAfterDoublePush()
+        public async Task ResetUnitAfterDoublePush()
         {
             await this.Login("administrator");
 
@@ -91,7 +92,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneWithoutPush()
+        public async Task ResetOne2OneWithoutPush()
         {
             await this.Login("administrator");
 
@@ -122,7 +123,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneIncludeWithoutPush()
+        public async Task ResetOne2OneIncludeWithoutPush()
         {
             await this.Login("administrator");
 
@@ -157,7 +158,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneAfterPush()
+        public async Task ResetOne2OneAfterPush()
         {
             await this.Login("administrator");
 
@@ -183,7 +184,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneIncludeAfterPush()
+        public async Task ResetOne2OneIncludeAfterPush()
         {
             await this.Login("administrator");
 
@@ -220,7 +221,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneRemoveAfterPush()
+        public async Task ResetOne2OneRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -251,7 +252,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneWithoutPush()
+        public async Task ResetMany2OneWithoutPush()
         {
             await this.Login("administrator");
 
@@ -271,7 +272,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneAfterPush()
+        public async Task ResetMany2OneAfterPush()
         {
             await this.Login("administrator");
 
@@ -293,7 +294,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneRemoveAfterPush()
+        public async Task ResetMany2OneRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -324,7 +325,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyWithoutPush()
+        public async Task ResetOne2ManyWithoutPush()
         {
             await this.Login("administrator");
 
@@ -344,7 +345,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyAfterPush()
+        public async Task ResetOne2ManyAfterPush()
         {
             await this.Login("administrator");
 
@@ -366,7 +367,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyRemoveAfterPush()
+        public async Task ResetOne2ManyRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -394,7 +395,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyWithoutPush()
+        public async Task ResetMany2ManyWithoutPush()
         {
             await this.Login("administrator");
 
@@ -414,7 +415,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyAfterPush()
+        public async Task ResetMany2ManyAfterPush()
         {
             await this.Login("administrator");
 
@@ -436,7 +437,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyRemoveAfterPush()
+        public async Task ResetMany2ManyRemoveAfterPush()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/DerivationTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/DerivationTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         protected DerivationTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void SessionFullName()
+        public async Task SessionFullName()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/DiffTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/DiffTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
@@ -19,7 +20,7 @@ namespace Tests.Workspace
         protected DiffTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void DatabaseUnitDiffTest()
+        public async Task DatabaseUnitDiffTest()
         {
             await this.Login("administrator");
 
@@ -48,7 +49,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void DatabaseUnitDiffAfterResetTest()
+        public async Task DatabaseUnitDiffAfterResetTest()
         {
             await this.Login("administrator");
 
@@ -74,7 +75,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void DatabaseUnitDiffAfterDoubleResetTest()
+        public async Task DatabaseUnitDiffAfterDoubleResetTest()
         {
             await this.Login("administrator");
 
@@ -103,7 +104,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void DatabaseMultipleUnitDiffTest()
+        public async Task DatabaseMultipleUnitDiffTest()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/LifecycleTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/LifecycleTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PullSameSessionNotPushedException()
+        public async Task PullSameSessionNotPushedException()
         {
             var session = this.Workspace.CreateSession();
 
@@ -48,7 +48,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PullOtherSessionNotPushedException()
+        public async Task PullOtherSessionNotPushedException()
         {
             var session1 = this.Workspace.CreateSession();
 

--- a/dotnet/Core/Workspace/Tests/Tests/MergeTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/MergeTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         protected MergeTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void DatabaseMergeError()
+        public async Task DatabaseMergeError()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/MethodTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/MethodTests.cs
@@ -6,6 +6,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void CallSingle()
+        public async Task CallSingle()
         {
             await this.Login("administrator");
 
@@ -41,7 +42,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void CallMultiple()
+        public async Task CallMultiple()
         {
             await this.Login("administrator");
 
@@ -68,7 +69,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void CallMultipleIsolated()
+        public async Task CallMultipleIsolated()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/PagingTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/PagingTests.cs
@@ -8,6 +8,7 @@
 
 namespace Tests.Workspace
 {
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Xunit;
     using I12 = Allors.Workspace.Domain.I12;
@@ -21,7 +22,7 @@ namespace Tests.Workspace
         // c2D -> c2C -> c1B -> c1A -> c2A -> c2B -> c1D -> c1C
 
         [Fact]
-        public async void Take()
+        public async Task Take()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();

--- a/dotnet/Core/Workspace/Tests/Tests/ProcedureTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/ProcedureTests.cs
@@ -7,6 +7,7 @@ namespace Tests.Workspace
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void TestUnitSamplesWithNulls()
+        public async Task TestUnitSamplesWithNulls()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -45,7 +46,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void TestUnitSamplesWithValues()
+        public async Task TestUnitSamplesWithValues()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -81,7 +82,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void TestValues()
+        public async Task TestValues()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -103,7 +104,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void NonExistingProcedure()
+        public async Task NonExistingProcedure()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/PullTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/PullTests.cs
@@ -10,6 +10,7 @@ namespace Tests.Workspace
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors;
     using Allors.Workspace.Data;
     using Allors.Workspace.Meta;
@@ -25,7 +26,7 @@ namespace Tests.Workspace
         protected PullTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void AndGreaterThanLessThan()
+        public async Task AndGreaterThanLessThan()
         {
             await this.Login("administrator");
 
@@ -82,7 +83,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2ManyContainedIn()
+        public async Task AssociationMany2ManyContainedIn()
         {
             await this.Login("administrator");
 
@@ -155,7 +156,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2ManyContainedInObjects()
+        public async Task AssociationMany2ManyContainedInObjects()
         {
             await this.Login("administrator");
 
@@ -191,7 +192,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2ManyContains()
+        public async Task AssociationMany2ManyContains()
         {
             await this.Login("administrator");
 
@@ -222,7 +223,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2ManyExist()
+        public async Task AssociationMany2ManyExist()
         {
             await this.Login("administrator");
 
@@ -248,7 +249,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2OneContainedIn()
+        public async Task AssociationMany2OneContainedIn()
         {
             await this.Login("administrator");
 
@@ -279,7 +280,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationMany2OneContains()
+        public async Task AssociationMany2OneContains()
         {
             await this.Login("administrator");
 
@@ -310,7 +311,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2ManyContainedIn()
+        public async Task AssociationOne2ManyContainedIn()
         {
             await this.Login("administrator");
 
@@ -341,7 +342,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2ManyEquals()
+        public async Task AssociationOne2ManyEquals()
         {
             await this.Login("administrator");
 
@@ -391,7 +392,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2ManyExists()
+        public async Task AssociationOne2ManyExists()
         {
             await this.Login("administrator");
 
@@ -434,7 +435,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2ManyInstanceOf()
+        public async Task AssociationOne2ManyInstanceOf()
         {
             await this.Login("administrator");
 
@@ -459,7 +460,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2OneContainedIn()
+        public async Task AssociationOne2OneContainedIn()
         {
             await this.Login("administrator");
 
@@ -490,7 +491,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2OneEquals()
+        public async Task AssociationOne2OneEquals()
         {
             await this.Login("administrator");
 
@@ -540,7 +541,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2OneExists()
+        public async Task AssociationOne2OneExists()
         {
             await this.Login("administrator");
 
@@ -582,7 +583,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void AssociationOne2OneInstanceOf()
+        public async Task AssociationOne2OneInstanceOf()
         {
             await this.Login("administrator");
 
@@ -623,7 +624,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ObjectEquals()
+        public async Task ObjectEquals()
         {
             await this.Login("administrator");
 
@@ -650,7 +651,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ExtentInterface()
+        public async Task ExtentInterface()
         {
             await this.Login("administrator");
 
@@ -672,7 +673,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void InstanceOf()
+        public async Task InstanceOf()
         {
             await this.Login("administrator");
 
@@ -700,7 +701,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void NotEquals()
+        public async Task NotEquals()
         {
             await this.Login("administrator");
 
@@ -730,7 +731,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void OrEquals()
+        public async Task OrEquals()
         {
             await this.Login("administrator");
 
@@ -765,7 +766,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void OperatorExcept()
+        public async Task OperatorExcept()
         {
             await this.Login("administrator");
 
@@ -797,7 +798,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void OperatorIntersect()
+        public async Task OperatorIntersect()
         {
             await this.Login("administrator");
 
@@ -829,7 +830,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void OperatorUnion()
+        public async Task OperatorUnion()
         {
             await this.Login("administrator");
 
@@ -858,7 +859,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeBetweenPath()
+        public async Task RoleDateTimeBetweenPath()
         {
             await this.Login("administrator");
 
@@ -886,7 +887,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeBetweenValue()
+        public async Task RoleDateTimeBetweenValue()
         {
             await this.Login("administrator");
 
@@ -918,7 +919,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeGreaterThanPath()
+        public async Task RoleDateTimeGreaterThanPath()
         {
             await this.Login("administrator");
 
@@ -946,7 +947,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeGreaterThanValue()
+        public async Task RoleDateTimeGreaterThanValue()
         {
             await this.Login("administrator");
 
@@ -974,7 +975,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeLessThanPath()
+        public async Task RoleDateTimeLessThanPath()
         {
             await this.Login("administrator");
 
@@ -1002,7 +1003,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeLessThanValue()
+        public async Task RoleDateTimeLessThanValue()
         {
             await this.Login("administrator");
 
@@ -1030,7 +1031,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDateTimeEquals()
+        public async Task RoleDateTimeEquals()
         {
             await this.Login("administrator");
 
@@ -1058,7 +1059,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalBetweenPath()
+        public async Task RoleDecimalBetweenPath()
         {
             await this.Login("administrator");
 
@@ -1086,7 +1087,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalBetweenValue()
+        public async Task RoleDecimalBetweenValue()
         {
             await this.Login("administrator");
 
@@ -1114,7 +1115,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalGreaterThanPath()
+        public async Task RoleDecimalGreaterThanPath()
         {
             await this.Login("administrator");
 
@@ -1142,7 +1143,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalGreaterThanValue()
+        public async Task RoleDecimalGreaterThanValue()
         {
             await this.Login("administrator");
 
@@ -1170,7 +1171,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalLessThanPath()
+        public async Task RoleDecimalLessThanPath()
         {
             await this.Login("administrator");
 
@@ -1198,7 +1199,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalLessThanValue()
+        public async Task RoleDecimalLessThanValue()
         {
             await this.Login("administrator");
 
@@ -1226,7 +1227,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDecimalEquals()
+        public async Task RoleDecimalEquals()
         {
             await this.Login("administrator");
 
@@ -1254,7 +1255,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleBetweenPath()
+        public async Task RoleDoubleBetweenPath()
         {
             await this.Login("administrator");
 
@@ -1282,7 +1283,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleBetweenValue()
+        public async Task RoleDoubleBetweenValue()
         {
             await this.Login("administrator");
 
@@ -1310,7 +1311,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleGreaterThanPath()
+        public async Task RoleDoubleGreaterThanPath()
         {
             await this.Login("administrator");
 
@@ -1338,7 +1339,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleGreaterThanValue()
+        public async Task RoleDoubleGreaterThanValue()
         {
             await this.Login("administrator");
 
@@ -1366,7 +1367,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleLessThanPath()
+        public async Task RoleDoubleLessThanPath()
         {
             await this.Login("administrator");
 
@@ -1394,7 +1395,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleLessThanValue()
+        public async Task RoleDoubleLessThanValue()
         {
             await this.Login("administrator");
 
@@ -1422,7 +1423,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleDoubleEquals()
+        public async Task RoleDoubleEquals()
         {
             await this.Login("administrator");
 
@@ -1450,7 +1451,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerBetweenPath()
+        public async Task RoleIntegerBetweenPath()
         {
             await this.Login("administrator");
 
@@ -1478,7 +1479,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerBetweenValue()
+        public async Task RoleIntegerBetweenValue()
         {
             await this.Login("administrator");
 
@@ -1506,7 +1507,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerGreaterThanPath()
+        public async Task RoleIntegerGreaterThanPath()
         {
             await this.Login("administrator");
 
@@ -1534,7 +1535,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerGreaterThanValue()
+        public async Task RoleIntegerGreaterThanValue()
         {
             await this.Login("administrator");
 
@@ -1562,7 +1563,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerLessThanPath()
+        public async Task RoleIntegerLessThanPath()
         {
             await this.Login("administrator");
 
@@ -1590,7 +1591,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerLessThanValue()
+        public async Task RoleIntegerLessThanValue()
         {
             await this.Login("administrator");
 
@@ -1618,7 +1619,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerEquals()
+        public async Task RoleIntegerEquals()
         {
             await this.Login("administrator");
 
@@ -1646,7 +1647,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleIntegerExist()
+        public async Task RoleIntegerExist()
         {
             await this.Login("administrator");
 
@@ -1671,7 +1672,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleStringEqualsPath()
+        public async Task RoleStringEqualsPath()
         {
             await this.Login("administrator");
 
@@ -1699,7 +1700,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleStringEqualsValue()
+        public async Task RoleStringEqualsValue()
         {
             await this.Login("administrator");
 
@@ -1727,7 +1728,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleStringLike()
+        public async Task RoleStringLike()
         {
             await this.Login("administrator");
 
@@ -1755,7 +1756,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleUniqueEquals()
+        public async Task RoleUniqueEquals()
         {
             await this.Login("administrator");
 
@@ -1783,7 +1784,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleMany2ManyContainedIn()
+        public async Task RoleMany2ManyContainedIn()
         {
             await this.Login("administrator");
 
@@ -1856,7 +1857,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleMany2ManyContains()
+        public async Task RoleMany2ManyContains()
         {
             await this.Login("administrator");
 
@@ -1886,7 +1887,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleOne2ManyContainedIn()
+        public async Task RoleOne2ManyContainedIn()
         {
             await this.Login("administrator");
 
@@ -1917,7 +1918,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleOne2ManyContains()
+        public async Task RoleOne2ManyContains()
         {
             await this.Login("administrator");
 
@@ -1947,7 +1948,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleMany2OneContainedIn()
+        public async Task RoleMany2OneContainedIn()
         {
             await this.Login("administrator");
 
@@ -1978,7 +1979,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void RoleOne2OneContainedIn()
+        public async Task RoleOne2OneContainedIn()
         {
             await this.Login("administrator");
 
@@ -2009,7 +2010,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void WithResultName()
+        public async Task WithResultName()
         {
             await this.Login("administrator");
 
@@ -2043,7 +2044,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PullWithObjectId()
+        public async Task PullWithObjectId()
         {
             await this.Login("administrator");
 
@@ -2065,7 +2066,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PullWithInclude()
+        public async Task PullWithInclude()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -2100,7 +2101,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void SortDirectionDefault()
+        public async Task SortDirectionDefault()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -2125,7 +2126,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void SortDirectionAscending()
+        public async Task SortDirectionAscending()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();
@@ -2151,7 +2152,7 @@ namespace Tests.Workspace
 
 
         [Fact]
-        public async void SortDirectionDescending()
+        public async Task SortDirectionDescending()
         {
             await this.Login("administrator");
             var session = this.Workspace.CreateSession();

--- a/dotnet/Core/Workspace/Tests/Tests/PushTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/PushTests.cs
@@ -6,6 +6,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
@@ -19,7 +20,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushNewObject()
+        public async Task PushNewObject()
         {
             await this.Login("administrator");
 
@@ -52,7 +53,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushAndPullNewObject()
+        public async Task PushAndPullNewObject()
         {
             await this.Login("administrator");
 
@@ -87,7 +88,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushNewObjectWithChangedRoles()
+        public async Task PushNewObjectWithChangedRoles()
         {
             await this.Login("administrator");
 
@@ -105,7 +106,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushExistingObjectWithChangedRoles()
+        public async Task PushExistingObjectWithChangedRoles()
         {
             await this.Login("administrator");
 
@@ -133,7 +134,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ChangesBeforeCheckpointShouldBePushed()
+        public async Task ChangesBeforeCheckpointShouldBePushed()
         {
             await this.Login("administrator");
 
@@ -172,7 +173,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushShouldUpdateId()
+        public async Task PushShouldUpdateId()
         {
             await this.Login("administrator");
 
@@ -190,7 +191,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushShouldNotUpdateVersion()
+        public async Task PushShouldNotUpdateVersion()
         {
             await this.Login("administrator");
 
@@ -208,7 +209,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushShouldDerive()
+        public async Task PushShouldDerive()
         {
             await this.Login("administrator");
 
@@ -231,7 +232,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void PushTwice()
+        public async Task PushTwice()
         {
             await this.Login("administrator");
 

--- a/dotnet/Core/Workspace/Tests/Tests/SandboxTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/SandboxTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void Test()
+        public async Task Test()
         {
             var contextFactory = this.contextFactories[0];
 

--- a/dotnet/Core/Workspace/Tests/Tests/SecurityTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/SecurityTests.cs
@@ -24,7 +24,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void WithGrant()
+        public async Task WithGrant()
         {
             await this.Login("administrator");
 
@@ -49,7 +49,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void WithoutAccessControl()
+        public async Task WithoutAccessControl()
         {
             await this.Login("noacl");
 
@@ -81,7 +81,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void WithoutPermissions()
+        public async Task WithoutPermissions()
         {
             await this.Login("noperm");
 
@@ -113,7 +113,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void DeniedPermissions()
+        public async Task DeniedPermissions()
         {
             var session = this.Workspace.CreateSession();
 

--- a/dotnet/Core/Workspace/Tests/Tests/Session/ManyToManyTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/ManyToManyTests.cs
@@ -39,7 +39,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRoleOld()
+        public async Task SetRoleOld()
         {
             var session1 = this.Workspace.CreateSession();
             var session2 = this.Workspace.CreateSession();
@@ -86,7 +86,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -119,7 +119,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRoleToNull()
+        public async Task SetRoleToNull()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -156,7 +156,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -192,7 +192,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveNullRole()
+        public async Task RemoveNullRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Session/ManyToOneTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/ManyToOneTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -75,7 +75,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -112,7 +112,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void ReplaceRole()
+        public async Task ReplaceRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Session/OneToManyTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/OneToManyTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -69,7 +69,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRoleToNull()
+        public async Task SetRoleToNull()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -105,7 +105,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -141,7 +141,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveNullRole()
+        public async Task RemoveNullRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Session/OneToOneTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/OneToOneTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -71,7 +71,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRole
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode1 in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/Session/UnitTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/Session/UnitTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRelation
         }
 
         [Fact]
-        public async void SetRole()
+        public async Task SetRole()
         {
             foreach (var contextFactory in this.contextFactories)
             {
@@ -92,7 +92,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRelation
         }
 
         [Fact]
-        public async void SetRoleNull()
+        public async Task SetRoleNull()
         {
             foreach (DatabaseMode mode in Enum.GetValues(typeof(DatabaseMode)))
             {
@@ -233,7 +233,7 @@ namespace Tests.Workspace.DatabaseAssociation.SessionRelation
         }
 
         [Fact]
-        public async void RemoveRole()
+        public async Task RemoveRole()
         {
             foreach (DatabaseMode mode in Enum.GetValues(typeof(DatabaseMode)))
             {

--- a/dotnet/Core/Workspace/Tests/Tests/WorkspaceResetTests.cs
+++ b/dotnet/Core/Workspace/Tests/Tests/WorkspaceResetTests.cs
@@ -9,6 +9,7 @@
 namespace Tests.Workspace
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Allors.Workspace.Data;
     using Allors.Workspace.Domain;
     using Xunit;
@@ -18,7 +19,7 @@ namespace Tests.Workspace
         protected WorkspaceResetTests(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public async void ResetUnitWithoutPush()
+        public async Task ResetUnitWithoutPush()
         {
             await this.Login("administrator");
 
@@ -43,7 +44,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetUnitAfterPushTest()
+        public async Task ResetUnitAfterPushTest()
         {
             await this.Login("administrator");
 
@@ -65,7 +66,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetUnitAfterDoublePush()
+        public async Task ResetUnitAfterDoublePush()
         {
             await this.Login("administrator");
 
@@ -91,7 +92,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneWithoutPush()
+        public async Task ResetOne2OneWithoutPush()
         {
             await this.Login("administrator");
 
@@ -122,7 +123,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneIncludeWithoutPush()
+        public async Task ResetOne2OneIncludeWithoutPush()
         {
             await this.Login("administrator");
 
@@ -157,7 +158,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneAfterPush()
+        public async Task ResetOne2OneAfterPush()
         {
             await this.Login("administrator");
 
@@ -183,7 +184,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneIncludeAfterPush()
+        public async Task ResetOne2OneIncludeAfterPush()
         {
             await this.Login("administrator");
 
@@ -220,7 +221,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2OneRemoveAfterPush()
+        public async Task ResetOne2OneRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -251,7 +252,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneWithoutPush()
+        public async Task ResetMany2OneWithoutPush()
         {
             await this.Login("administrator");
 
@@ -271,7 +272,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneAfterPush()
+        public async Task ResetMany2OneAfterPush()
         {
             await this.Login("administrator");
 
@@ -293,7 +294,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2OneRemoveAfterPush()
+        public async Task ResetMany2OneRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -324,7 +325,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyWithoutPush()
+        public async Task ResetOne2ManyWithoutPush()
         {
             await this.Login("administrator");
 
@@ -344,7 +345,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyAfterPush()
+        public async Task ResetOne2ManyAfterPush()
         {
             await this.Login("administrator");
 
@@ -366,7 +367,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetOne2ManyRemoveAfterPush()
+        public async Task ResetOne2ManyRemoveAfterPush()
         {
             await this.Login("administrator");
 
@@ -394,7 +395,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyWithoutPush()
+        public async Task ResetMany2ManyWithoutPush()
         {
             await this.Login("administrator");
 
@@ -414,7 +415,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyAfterPush()
+        public async Task ResetMany2ManyAfterPush()
         {
             await this.Login("administrator");
 
@@ -436,7 +437,7 @@ namespace Tests.Workspace
         }
 
         [Fact]
-        public async void ResetMany2ManyRemoveAfterPush()
+        public async Task ResetMany2ManyRemoveAfterPush()
         {
             await this.Login("administrator");
 


### PR DESCRIPTION
## Problem
`CiDotnetCoreWorkspaceLocalTest` intermittently fails **even though its tests pass** — the run prints `Passed! - Failed: 0, Passed: 176`, then the test host exits non-zero, force-killing orphaned `dotnet` processes. (Observed during PR #96's CI; it passed on a clean re-run.)

Root cause: the Core workspace test suite declares its 188 `[Fact]` methods as **`async void`** (xUnit emits `xUnit1048` — async void support is being removed in v3). On xUnit v3, an `async void` test whose continuation throws *after* the framework considers the run complete escapes as an unobserved exception and crashes the host **after** a green summary.

Follow-up to #96.

## Fix
Convert all 188 `async void` `[Fact]` methods in `dotnet/Core/Workspace/Tests/Tests/**` to **`async Task`** so xUnit awaits them, plus `using System.Threading.Tasks;` in the 12 files that lacked it (`ImplicitUsings` is off here). The methods live in **abstract base classes** the Local/Remote runners subclass, so this covers `CiDotnetCoreWorkspaceLocalTest` and both `CiDotnetCoreWorkspaceRemoteJson*Test` jobs. No production code, `[Fact]`, or test-body changes; also clears 188 `xUnit1048` warnings.

## Verification
- `dotnet build` Tests.Local: 0 errors.
- `Tests.Local` run **5×**: all `Passed! 176/176` and **exit 0 every time** (previously the host crashed post-summary).
- Remote variants share the identical converted base and compile; they need a server (`localhost:5000`) not available locally, so they're proven by CI.

## Out of scope (noted)
~22 other `async void` tests remain in `Core/Database/Server.{Local,Remote}.Tests` and two `Domain.Tests` — same latent issue, a candidate for a later sweep.
