### PR TITLE
fix(base): add missing CreateService/EditDialogService to prod APP_INITIALIZER deps [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ under a dated version heading.
 
 ### Fixed
 
+- The base application's **production** bootstrap no longer crashes. The `environment.prod.ts`
+  `APP_INITIALIZER` factory (`appInitFactory`) takes four parameters and assigns
+  `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but its `deps`
+  listed only `[WorkspaceService, HttpClient]` — so Angular injected `undefined` for the third and fourth
+  arguments and the initializer threw a `TypeError` during bootstrap. This is production-only: the dev
+  `environment.ts` already lists all four deps (and the e2e harness serves the dev configuration, so it
+  never exercised the prod file). `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`, matching the factory's parameters.
 - The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
   domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
   price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],


### PR DESCRIPTION
## Bug
`environment.prod.ts`'s `APP_INITIALIZER` factory `appInitFactory` takes **four** parameters (`workspaceService`, `httpClient`, `createService`, `editService`) and its initializer assigns `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but the provider's `deps` listed only `[WorkspaceService, HttpClient]`. Angular resolves factory arguments positionally from `deps`, so `createService`/`editService` are `undefined` and the first assignment throws a `TypeError` while Angular runs `APP_INITIALIZER`s — **the production app fails to bootstrap**.

Production-only: the dev `environment.ts` already lists all four deps, and the e2e harness serves the dev configuration, so the prod file was never exercised. `app.module.ts` spreads `...environment.providers`, so the broken provider is registered.

## Fix
Add the two missing deps so the array matches the factory's parameters. Both tokens are already imported in the file and provided in `app.module.ts` — `AllorsMaterialCreateService` / `AllorsMaterialEditDialogService` via `useClass` (and aliased to `CreateService` / `EditDialogService` via `useExisting`).

## Validation
Production build compiles `environment.prod.ts` clean (no build error references the changed file). No CI job compiles the prod configuration (the e2e gate serves the dev build), so `CiTypescriptE2EAngularBaseTest` runs as a dev-path regression check.