### PR TITLE
fix(apps-intranet): add missing CreateService/EditDialogService to prod APP_INITIALIZER deps [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The apps-intranet application's **production** bootstrap no longer crashes — the same `environment.prod.ts`
+  `APP_INITIALIZER` defect as the base app. The four-parameter `appInitFactory` had only
+  `deps: [WorkspaceService, HttpClient]`, so `createService`/`editService` were injected as `undefined` and
+  the initializer threw a `TypeError` at bootstrap. `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`. Production-only: the dev `environment.ts` was already correct.
 - The base application's **production** bootstrap no longer crashes. The `environment.prod.ts`
   `APP_INITIALIZER` factory (`appInitFactory`) takes four parameters and assigns
   `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but its `deps`

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],


### PR DESCRIPTION
## Bug
`apps-intranet`'s `environment.prod.ts` `APP_INITIALIZER` factory `appInitFactory` takes **four** parameters (`workspaceService`, `httpClient`, `createService`, `editService`) and its initializer assigns `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but the provider's `deps` listed only `[WorkspaceService, HttpClient]`. Angular resolves factory arguments positionally from `deps`, so `createService`/`editService` are `undefined` and the first assignment throws a `TypeError` while Angular runs `APP_INITIALIZER`s — **the production app fails to bootstrap**.

Production-only: the dev `environment.ts` already lists all four deps, and the e2e harness serves the dev configuration, so the prod file was never exercised. `app.module.ts` spreads `...environment.providers`, so the broken provider is registered.

Same defect as the base app, fixed in #100.

## Fix
Add the two missing deps so the array matches the factory's parameters. Both tokens are already imported in the file and provided in `app.module.ts` — `AllorsMaterialCreateService` / `AllorsMaterialEditDialogService` via `useClass` (and aliased to `CreateService` / `EditDialogService` via `useExisting`).

## Validation
Production build of the app (`nx build apps-intranet-workspace-angular-material-app`, production config → compiles `environment.prod.ts` via `fileReplacements`) succeeds. No CI job compiles the prod configuration (the e2e gate serves the dev build), so `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` runs as a dev-path regression check.