### PR TITLE
fix(apps-extranet): add missing CreateService/EditDialogService to prod APP_INITIALIZER deps [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ under a dated version heading.
   `environment.ts` already lists all four deps (and the e2e harness serves the dev configuration, so it
   never exercised the prod file). `deps` now also lists `AllorsMaterialCreateService` and
   `AllorsMaterialEditDialogService`, matching the factory's parameters.
+- The apps-extranet application's **production** bootstrap no longer crashes — the same `environment.prod.ts`
+  `APP_INITIALIZER` defect as the base and intranet apps. The four-parameter `appInitFactory` had only
+  `deps: [WorkspaceService, HttpClient]`, so `createService`/`editService` were injected as `undefined` and
+  the initializer threw a `TypeError` at bootstrap. `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`. Production-only: the dev `environment.ts` was already correct.
 - The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
   domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
   price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so

--- a/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],


### PR DESCRIPTION
## Bug
`apps-extranet`'s `environment.prod.ts` `APP_INITIALIZER` factory `appInitFactory` takes **four** parameters (`workspaceService`, `httpClient`, `createService`, `editService`) and its initializer assigns `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but the provider's `deps` listed only `[WorkspaceService, HttpClient]`. Angular resolves factory arguments positionally from `deps`, so `createService`/`editService` are `undefined` and the first assignment throws a `TypeError` while Angular runs `APP_INITIALIZER`s — **the production app fails to bootstrap**.

Production-only: the dev `environment.ts` already lists all four deps, and `app.module.ts` spreads `...environment.providers`, so the broken provider is registered. Same defect as the base app (#100) and apps-intranet.

## Fix
Add the two missing deps so the array matches the factory's parameters. Both tokens are already imported in the file and provided in `app.module.ts` — `AllorsMaterialCreateService` / `AllorsMaterialEditDialogService` via `useClass` (and aliased to `CreateService` / `EditDialogService` via `useExisting`).

## Validation
Production build compiles `environment.prod.ts` (via `fileReplacements`) and bundles successfully; the build's only failure is a **pre-existing** bundle-size budget overrun (1.83 MB > 1 MB `maximumError`), unrelated to this ~0-byte change (both tokens are already bundled via `app.module.ts`). No CI job compiles the prod configuration.