### PR TITLE
fix(apps-intranet): keep product categories when editing a NonUnifiedGood [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ under a dated version heading.
 
 ### Fixed
 
+- The NonUnifiedGood edit form no longer drops product categories on save. `onPostPull` assigned the same
+  array reference to both `selectedCategories` and `originalCategories`, so `save()` iterated
+  `selectedCategories` while `splice`-ing the aliased `originalCategories` inside that loop — a
+  splice-during-iteration that skipped every other category, which the second loop then `removeProduct`-ed
+  from the good. Editing a good with two or more categories and saving dropped roughly half of them.
+  `selectedCategories` is now an independent copy (`[...originalCategories]`, with the source `?? []`-guarded
+  for the spread), so all categories are preserved.
 - Effects watching composites roles (or derived list roles) no longer rerun on every unrelated session
   write. Those signals rebuild their list on every recompute, and the default reference-equality comparer
   counted each fresh array as a change. `ISignalFactory.Computed` now accepts an optional

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedGoodTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedGoodTest.cs
@@ -99,5 +99,87 @@ namespace Tests.E2E.Objects
             ClassicAssert.AreEqual("Dit is een test description", nonUnifiedGood.Description);
         }
 
+        [Test]
+        public async Task EditNonUnifiedGoodPreservesCategories()
+        {
+            var good = new NonUnifiedGoods(this.Transaction).Extent()
+                .First(v => v.ProductCategoriesWhereProduct.Count() >= 2);
+            var originalCategories = good.ProductCategoriesWhereProduct.ToArray();
+
+            var @class = this.M.NonUnifiedGood;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new NonunifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new NonunifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.DescriptionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            var after = good.ProductCategoriesWhereProduct.ToArray();
+            foreach (var category in originalCategories)
+            {
+                ClassicAssert.Contains(category, after, $"category '{category.Name}' was dropped on save");
+            }
+
+            ClassicAssert.AreEqual(originalCategories.Length, after.Length);
+        }
+
+        [Test]
+        public async Task EditNonUnifiedGoodWithoutCategoriesDoesNotThrow()
+        {
+            // A freshly-created good has no product categories; editing+saving it must not throw.
+            var part = new NonUnifiedParts(this.Transaction).Extent().First();
+
+            var @class = this.M.NonUnifiedGood;
+
+            var list = this.Application.GetList(@class);
+            await this.Page.GotoAsync(list.RouteInfo.FullPath);
+            await this.Page.WaitForAngular();
+
+            var factory = new FactoryFabComponent(this.AppRoot);
+            await factory.Create(@class);
+            await this.Page.WaitForAngular();
+
+            var createForm = new NonunifiedgoodCreateFormComponent(this.OverlayContainer);
+            await createForm.NameInput.SetValueAsync("CategorylessGood");
+            await createForm.PartAutocomplete.SelectAsync(part.DisplayName);
+            await new Button(createForm, "text=SAVE").ClickAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+            var good = new NonUnifiedGoods(this.Transaction).Extent().First(v => v.Name == "CategorylessGood");
+            ClassicAssert.IsEmpty(good.ProductCategoriesWhereProduct);
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new NonunifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new NonunifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.DescriptionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+            ClassicAssert.IsEmpty(good.ProductCategoriesWhereProduct);
+        }
+
     }
 }

--- a/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
@@ -313,12 +313,14 @@ namespace Tests
                 .WithInternalOrganisation(allors)
                 .WithName("Best selling gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Meest verkochte gizmo's").WithLocale(dutchLocale).Build())
+                .WithProduct(good_3)
                 .Build();
 
             var productCategory_2 = new ProductCategoryBuilder(this.Transaction)
                 .WithInternalOrganisation(allors)
                 .WithName("Big Gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Grote Gizmo's").WithLocale(dutchLocale).Build())
+                .WithProduct(good_3)
                 .Build();
 
             var productCategory_3 = new ProductCategoryBuilder(this.Transaction)

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedgood/edit/nonunifiedgood-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedgood/edit/nonunifiedgood-edit-form.component.ts
@@ -124,8 +124,8 @@ export class NonUnifiedGoodEditFormComponent extends AllorsFormComponent<NonUnif
     this.onPostPullInitialize(pullResult);
 
     this.originalCategories =
-      pullResult.collection<ProductCategory>('OriginalCategories');
-    this.selectedCategories = this.originalCategories;
+      pullResult.collection<ProductCategory>('OriginalCategories') ?? [];
+    this.selectedCategories = [...this.originalCategories];
 
     this.categories = pullResult.collection<ProductCategory>(
       this.m.ProductCategory


### PR DESCRIPTION
## Bug
`NonUnifiedGoodEditFormComponent.onPostPull` assigned the **same array reference** to both `selectedCategories` and `originalCategories`. `save()` then iterated `selectedCategories.forEach(...)` while `splice`-ing the aliased `originalCategories` *inside that loop* — a splice-during-iteration that skips every other element. For a good with categories `[A, B, C]`, A and C are kept but **B is skipped**, and the second loop `removeProduct`s the leftover. **Editing a good with ≥2 categories and saving dropped roughly half of them.** (Single-category goods were unaffected, hence unnoticed.)

## Fix
`selectedCategories` is now an independent copy, so the `splice` on `originalCategories` no longer corrupts the iteration and every selected category is preserved:
```ts
this.originalCategories =
  pullResult.collection<ProductCategory>('OriginalCategories') ?? [];
this.selectedCategories = [...this.originalCategories];
```

## Tests (e2e, local RED→GREEN)
Extended `NonUnifiedGoodTest` (edit-open pattern: overview route → view-detail-panel → edit form → save):
- **`EditNonUnifiedGoodPreservesCategories`** — the failing test for this bug. RED on the unfixed code (`category 'Big Gizmo's' was dropped on save`), GREEN after the fix.
- **`EditNonUnifiedGoodWithoutCategoriesDoesNotThrow`** — zero-category edit. This **documents that the pre-documented "D2" zero-category NPE does not reproduce**: `pullResult.collection(...)` returns `[]` (not `undefined`), so there is no NPE (the test passes on the unfixed code). The `?? []` above is kept as defensive null-safety for the introduced spread.

`IntranetPopulation` additively links `good_3` to two more categories so the multi-category scenario exists (no other test references those categories).

## Validation
Local: `dotnet test …/AppsIntranet/Tests --filter "FullyQualifiedName~NonUnifiedGoodTest.EditNonUnifiedGood"` → **2/2 green**. CI gate: `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.