### PR TITLE
fix(apps-intranet): keep product categories when editing a UnifiedGood [BUG-21]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The UnifiedGood edit form no longer drops product categories on save — the same alias + splice-during-
+  iteration defect as the NonUnifiedGood/NonUnifiedPart edit forms. `onPostPull` set `selectedCategories` to
+  the *same array reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while
+  `splice`-ing the aliased `originalCategories`, skipping every other `ProductCategory`, which the second
+  loop then `removeProduct`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`),
+  so all categories are preserved.
 - The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
   reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/UnifiedGoodTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/UnifiedGoodTest.cs
@@ -98,5 +98,41 @@ namespace Tests.E2E.Objects
             ClassicAssert.AreEqual(productType, unifiedGood.ProductType);
         }
 
+        [Test]
+        public async Task EditUnifiedGoodPreservesCategories()
+        {
+            var good = new UnifiedGoods(this.Transaction).Extent()
+                .First(v => v.ProductCategoriesWhereProduct.Count() >= 2);
+            var originalCategories = good.ProductCategoriesWhereProduct.ToArray();
+
+            var @class = this.M.UnifiedGood;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new UnifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new UnifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.NameInput.SetValueAsync("Edited UnifiedGood");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            var after = good.ProductCategoriesWhereProduct.ToArray();
+            foreach (var category in originalCategories)
+            {
+                ClassicAssert.Contains(category, after, $"category '{category.Name}' was dropped on save");
+            }
+
+            ClassicAssert.AreEqual(originalCategories.Length, after.Length);
+        }
+
     }
 }

--- a/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
@@ -314,6 +314,7 @@ namespace Tests
                 .WithName("Best selling gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Meest verkochte gizmo's").WithLocale(dutchLocale).Build())
                 .WithProduct(good_3)
+                .WithProduct(good_4)
                 .Build();
 
             var productCategory_2 = new ProductCategoryBuilder(this.Transaction)
@@ -321,6 +322,7 @@ namespace Tests
                 .WithName("Big Gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Grote Gizmo's").WithLocale(dutchLocale).Build())
                 .WithProduct(good_3)
+                .WithProduct(good_4)
                 .Build();
 
             var productCategory_3 = new ProductCategoryBuilder(this.Transaction)

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/edit/unifiedgood-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/edit/unifiedgood-edit-form.component.ts
@@ -161,7 +161,7 @@ export class UnifiedGoodEditFormComponent extends AllorsFormComponent<UnifiedGoo
 
     this.originalCategories =
       pullResult.collection<ProductCategory>('OriginalCategories') ?? [];
-    this.selectedCategories = this.originalCategories;
+    this.selectedCategories = [...this.originalCategories];
 
     this.inventoryItemKinds = pullResult.collection<InventoryItemKind>(
       this.m.InventoryItemKind


### PR DESCRIPTION
## Bug
Third instance of the splice-during-iteration / array-alias idiom (after #104 NonUnifiedGood, #105 NonUnifiedPart). `UnifiedGoodEditFormComponent.onPostPull` set `selectedCategories` to the **same array reference** as `originalCategories`. `onSave()` then iterated `selectedCategories.forEach(...)` while `splice`-ing the aliased `originalCategories` *inside that loop*, skipping every other element, which the second loop `removeProduct`s. **Editing a UnifiedGood with ≥2 categories and saving dropped roughly half of them.**

## Fix
```ts
this.selectedCategories = [...this.originalCategories];   // copy, not alias
```
(`onPostPull` already had `?? []`, so no zero-category NPE to guard.)

## Tests (e2e, local RED→GREEN)
`EditUnifiedGoodPreservesCategories` (edit-open `good_4` → dirty `NameInput` → save → assert `ProductCategoriesWhereProduct` preserved): RED on the unfixed code (`'Big Gizmo's' dropped`), GREEN after the fix. `IntranetPopulation` additively links `good_4` to two more `ProductCategory`s.

## Validation
Local: 1/1 green against the LocalDB stack. CI gate: `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.