### PR TITLE
fix(apps-intranet): keep PositionType assignments when editing a PositionTypeRate [BUG-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ under a dated version heading.
   aliased `originalCategories` inside the loop, skipping every other `PartCategory`, which the second loop
   then `removePart`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`), so all
   part categories are preserved.
+- The PositionTypeRate form no longer nulls kept PositionType assignments on save. `onPostPull` set
+  `originalPositionTypes` to the *same array reference* as `selectedPositionTypes`; `save()` then iterated
+  `selectedPositionTypes` while `splice`-ing the aliased `originalPositionTypes`, skipping every other
+  PositionType, which the second loop then set to `PositionTypeRate = null`. Editing a rate with two or more
+  assigned position types and saving unassigned roughly half of them. `originalPositionTypes` is now an
+  independent copy (`[...(selectedPositionTypes ?? [])]`), so all assignments are preserved.
 - Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
   (latent; both hooks are empty today).
 - SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/positiontyperate/form/positiontyperate-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/positiontyperate/form/positiontyperate-form.component.ts
@@ -92,7 +92,7 @@ export class PositionTypeRateFormComponent extends AllorsFormComponent<PositionT
     this.selectedPositionTypes = this.positionTypes?.filter(
       (v) => v.PositionTypeRate === this.object
     );
-    this.originalPositionTypes = this.selectedPositionTypes;
+    this.originalPositionTypes = [...(this.selectedPositionTypes ?? [])];
 
     if (this.createRequest) {
       this.object.Frequency = hour;


### PR DESCRIPTION
## Bug
Fourth instance of the array-alias + splice-during-iteration idiom (after #104/#105/#106). `PositionTypeRateFormComponent.onPostPull` set `originalPositionTypes` to the **same array reference** as `selectedPositionTypes`. `save()` then iterated `selectedPositionTypes.forEach(...)` while `splice`-ing the aliased `originalPositionTypes` *inside that loop*, skipping every other element, which the second loop sets to `PositionTypeRate = null`. **Editing a PositionTypeRate with ≥2 assigned PositionTypes and saving unassigned roughly half of them.**

## Fix
```ts
this.originalPositionTypes = [...(this.selectedPositionTypes ?? [])];
```
An independent copy (and never `undefined` — `selectedPositionTypes` is a `?.filter(...)` result), so the `splice` no longer corrupts the `forEach` and no kept assignment is nulled.

## Test tier: fix-only
PositionTypeRate edit has **no e2e edit-open harness** — it's a dialog opened from the list (`app.dialog.ts:137`), there is no overview page/route, and the list page object models no row-edit. The bug only manifests on edit (a new rate's `originalPositionTypes` is empty). Given the idiom is already executed RED→GREEN three times (#104 NonUnifiedGood, #105 NonUnifiedPart, #106 UnifiedGood), this is fixed by the same copy and validated by production compile (`nx build apps-intranet-workspace-angular-material-app`), rather than building a bespoke list-row→edit-dialog driver + population for marginal added confidence.