### PR TITLE
fix(apps-intranet): fire billToEndCustomerSelected for the bill-to-end-customer autocomplete [BUG-18/19/20]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The bill-to-end-customer autocomplete on the sales-invoice (create + edit) and sales-order (edit) forms now
+  fires `billToEndCustomerSelected` instead of `billToCustomerSelected`. The autocomplete binds the
+  `BillToEndCustomer` role correctly, but its `(changed)` handler ran the bill-to-*customer* side-effect
+  (`updateBillToCustomer`), so selecting a bill-to-end-customer loaded the wrong party's contacts and
+  contact-mechanisms into the dependent dropdowns. It now runs `updateBillToEndCustomer`.
 - The UnifiedGood edit form no longer drops product categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood/NonUnifiedPart edit forms. `onPostPull` set `selectedCategories` to
   the *same array reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/create/salesinvoice-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/create/salesinvoice-create-form.component.html
@@ -423,7 +423,7 @@
           [roleType]="m.SalesInvoice.BillToEndCustomer"
           [filter]="customersFilter.create(allors.context)"
           display="DisplayName"
-          (changed)="billToCustomerSelected($event)"
+          (changed)="billToEndCustomerSelected($event)"
           label="Bill to end customer"
         ></a-mat-autocomplete>
         <button

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/edit/salesinvoice-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/edit/salesinvoice-edit-form.component.html
@@ -430,7 +430,7 @@
               [roleType]="m.SalesInvoice.BillToEndCustomer"
               [filter]="customersFilter.create(allors.context)"
               display="DisplayName"
-              (changed)="billToCustomerSelected($event)"
+              (changed)="billToEndCustomerSelected($event)"
               label="Bill to end customer"
             ></a-mat-autocomplete>
             <button

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesorder/edit/salesorder-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesorder/edit/salesorder-edit-form.component.html
@@ -494,7 +494,7 @@
               [roleType]="m.SalesOrder.BillToEndCustomer"
               [filter]="customersFilter.create(allors.context)"
               display="DisplayName"
-              (changed)="billToCustomerSelected($event)"
+              (changed)="billToEndCustomerSelected($event)"
               label="Bill to end customer"
             ></a-mat-autocomplete>
             <button


### PR DESCRIPTION
## Bug (×3, same defect)
On three sales forms — salesinvoice **create** (#18), salesinvoice **edit** (#19), salesorder **edit** (#20) — the **"Bill to end customer"** `a-mat-autocomplete` binds `[roleType]="…BillToEndCustomer"` (so the role saves correctly) but its `(changed)` calls `billToCustomerSelected` → `updateBillToCustomer` (the **wrong side-effect**). Selecting a bill-to-end-customer therefore loaded the bill-to-*customer*'s contacts/contact-mechanisms into the dependent dropdowns instead of the end-customer's.

## Fix
`(changed)="billToEndCustomerSelected($event)"` on each EndCustomer autocomplete (the matching handler exists in all three components and calls `updateBillToEndCustomer`). The separate **BillToCustomer** autocompletes (label "Bill to"), which correctly use `billToCustomerSelected`, are untouched.

## Test tier: fix-only
The primary role binds correctly, so there is no clean saved-role assertion — the only e2e-observable is a fiddly dependent-dropdown/derived side-effect, disproportionate to a one-identifier handler rename. Validated by production compile (`nx build apps-intranet-workspace-angular-material-app`) + inspection.

## Batching
One PR for the three identical-defect forms (approved deviation from one-PR-per-bug).