### PR TITLE
fix(apps-intranet): populate shipFromContacts in customershipment updateShipFromParty [BUG-07/23/24]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@ under a dated version heading.
   `splice`-ing the aliased `originalCategories`, skipping every other `ProductCategory`, which the second
   loop then `removeProduct`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`),
   so all categories are preserved.
+- The customer-shipment create + edit forms now populate the ship-from contact dropdown with the ship-from
+  party's contacts instead of overwriting the ship-to contact options. `updateShipFromParty` assigned the
+  ship-from party's `CurrentContacts` to `shipToContacts` (leaving the declared `shipFromContacts` unused),
+  so on load — where `updateShipToParty` runs first and `updateShipFromParty` overwrites — the ship-to
+  contact dropdown was clobbered with the ship-from party's contacts. It now assigns `shipFromContacts`.
 - The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
   reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/create/customershipment-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/create/customershipment-create-form.component.ts
@@ -261,7 +261,7 @@ export class CustomerShipmentCreateFormComponent extends AllorsFormComponent<Cus
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
@@ -266,7 +266,7 @@ export class CustomerShipmentEditFormComponent extends AllorsFormComponent<Custo
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);
     });
   }
 }


### PR DESCRIPTION
## Bug (#07 ≡ #24 edit, #23 create)
Both customer-shipment forms declare `shipFromContacts: Person[] = []` but never assign it. `updateShipFromParty` populates `shipFromAddresses` correctly, then sets `this.shipToContacts = …CurrentContacts` (edit `:269`, create `:264`) instead of `this.shipFromContacts`. On load `updateShipToParty` runs first (setting `shipToContacts` to the **ship-to** party's contacts), then `updateShipFromParty` **overwrites** it with the **ship-from** party's contacts — so the ShipToContactPerson dropdown shows the wrong party's contacts and the ship-from contact dropdown stays empty.

## Fix
`this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);` in each `updateShipFromParty`. (#07 and #24 are the same edit-form line.)

## Test tier: fix-only
The defect is a component-field (dropdown-options) side-effect, not a saved role — no clean saved-role assertion; an e2e RED would be a fiddly dropdown-contents check, disproportionate to a one-field rename. Validated by production compile (`nx build apps-intranet-workspace-angular-material-app`) + inspection.

One PR for the 3 rows (#07≡#24 dup + #23; user-approved batching).