### PR TITLE
fix(apps-intranet): stop clearing ShipTo address/contact on load in customershipment + purchasereturn edit [BUG-16/D3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ under a dated version heading.
 
 ### Fixed
 
+- Editing a CustomerShipment or PurchaseReturn no longer silently clears its `ShipToAddress` and
+  `ShipToContactPerson` on load. `onPostPull` called `updateShipToParty` without first setting
+  `previousShipToparty`, so the `ShipToParty !== previousShipToparty` guard inside it was true on the initial
+  load and nulled `ShipToAddress` + `ShipToContactPerson` — which then persisted on save (silent data loss on
+  every edit). `onPostPull` now initializes `previousShipToparty` to the loaded `ShipToParty`, so a load is no
+  longer treated as a party change. (The customershipment instance was an unflagged sibling of the reported
+  purchasereturn defect.)
 - The bill-to-end-customer autocomplete on the sales-invoice (create + edit) and sales-order (edit) forms now
   fires `billToEndCustomerSelected` instead of `billToCustomerSelected`. The autocomplete binds the
   `BillToEndCustomer` role correctly, but its `(changed)` handler ran the bill-to-*customer* side-effect

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
@@ -1,0 +1,52 @@
+// <copyright file="CustomerShipmentTest.cs" company="Allors bvba">
+// Copyright (c) Allors bvba. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Tests.E2E.Objects
+{
+    using System.Linq;
+    using Allors.Database.Domain;
+    using Allors.E2E.Angular;
+    using Allors.E2E.Angular.Html;
+    using Allors.E2E.Angular.Material.Factory;
+    using Allors.E2E.Test;
+    using NUnit.Framework;
+    using Task = System.Threading.Tasks.Task;
+
+    public class CustomerShipmentTest : Test
+    {
+        [SetUp]
+        public async Task Setup() => await this.LoginAsync("jane@example.com");
+
+        [Test]
+        public async Task EditCustomerShipmentPreservesShipToContactPerson()
+        {
+            var shipment = new CustomerShipments(this.Transaction).Extent()
+                .First(v => v.ExistShipToContactPerson);
+            var shipToContactPerson = shipment.ShipToContactPerson;
+
+            var @class = this.M.CustomerShipment;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{shipment.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new CustomershipmentOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new CustomershipmentEditFormComponent(this.AppRoot);
+            await editForm.HandlingInstructionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            ClassicAssert.AreEqual(shipToContactPerson, shipment.ShipToContactPerson, "ShipToContactPerson was cleared on edit/save");
+        }
+    }
+}

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
@@ -130,6 +130,7 @@ export class CustomerShipmentEditFormComponent extends AllorsFormComponent<Custo
     );
 
     if (this.object.ShipToParty) {
+      this.previousShipToparty = this.object.ShipToParty;
       this.updateShipToParty(this.object.ShipToParty);
     }
 

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
@@ -123,6 +123,7 @@ export class PurchaseReturnEditFormComponent extends AllorsFormComponent<Purchas
     );
 
     if (this.object.ShipToParty) {
+      this.previousShipToparty = this.object.ShipToParty;
       this.updateShipToParty(this.object.ShipToParty);
     }
 


### PR DESCRIPTION
## Bug (data loss)
The customershipment-edit (**D3**, discovered) and purchasereturn-edit (**#16**) forms' `onPostPull` call `updateShipToParty(this.object.ShipToParty)` on load without first setting `previousShipToparty`. Inside `updateShipToParty`, the guard `if (this.object.ShipToParty !== this.previousShipToparty)` is meant to clear the address/contact when the user *changes* the party — but on the initial load `previousShipToparty` is `undefined`, so it's **true**, nulling `ShipToAddress` + `ShipToContactPerson`. Those nulls persist on save → **every edit silently wipes the ship-to address + contact.**

## Fix
`onPostPull` now initializes `previousShipToparty` to the loaded `ShipToParty`, so a load is not treated as a party change:
```ts
if (this.object.ShipToParty) {
  this.previousShipToparty = this.object.ShipToParty;
  this.updateShipToParty(this.object.ShipToParty);
}
```

## Tests (e2e, executed RED→GREEN)
`CustomerShipmentTest.EditCustomerShipmentPreservesShipToContactPerson`: edit the populated CustomerShipment → dirty an unrelated field → save → assert `ShipToContactPerson` preserved. **RED** on the unfixed code (`Expected <Person> But was: null`), **GREEN** after the fix. Tested via customershipment because the populated `CustomerShipment` has a `ShipToContactPerson` and there is no `PurchaseReturn` in the population; the shared fix is applied to both forms.

## Note
The customershipment instance (D3) is an unflagged sibling of the reported purchasereturn defect (#16), found while fixing #16.