### PR TITLE
fix(apps-intranet): bind ship-from contacts to shipFromContacts in purchasereturn forms [BUG-17/32]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,10 @@ under a dated version heading.
   ship-from party's `CurrentContacts` to `shipToContacts` (leaving the declared `shipFromContacts` unused),
   so on load — where `updateShipToParty` runs first and `updateShipFromParty` overwrites — the ship-to
   contact dropdown was clobbered with the ship-from party's contacts. It now assigns `shipFromContacts`.
+- The purchase-return create + edit forms had the identical `updateShipFromParty` defect: the ship-from
+  party's `CurrentContacts` were assigned to `shipToContacts` (leaving the declared `shipFromContacts`
+  unused), so the ship-from contact picker stayed empty and the ship-to contact options were overwritten
+  with the ship-from party's contacts. Both forms now assign `shipFromContacts`.
 - The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
   reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/create/purchasereturn-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/create/purchasereturn-create-form.component.ts
@@ -218,7 +218,9 @@ export class PurchaseReturnCreateFormComponent extends AllorsFormComponent<Purch
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(
+        m.Party.CurrentContacts
+      );
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
@@ -259,7 +259,9 @@ export class PurchaseReturnEditFormComponent extends AllorsFormComponent<Purchas
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(
+        m.Party.CurrentContacts
+      );
     });
   }
 }


### PR DESCRIPTION
## Bug
In the purchase-return **create** (`#32`, `:221`) and **edit** (`#17`, `:262`) forms, `updateShipFromParty` pulls the ship-from party's `CurrentContacts` to fill the ship-from contact picker but assigns the result to `this.shipToContacts` instead of `this.shipFromContacts`. The sibling address line in the same `subscribe` correctly assigns `this.shipFromAddresses`, confirming the contacts line is a copy/paste slip. Consequences:
- the ship-from contact `<select>` (bound to `shipFromContacts`) stays empty → no ship-from contact can be picked;
- `shipToContacts` (the ship-to picker options) gets overwritten with the **from**-party's contacts.

This is the same defect already fixed for the customer-shipment forms in #109 (#07/23/24); the correct pattern lives at `customershipment-edit-form.ts:269`.

## Fix
Both forms now assign the ship-from party's contacts to `shipFromContacts`:
```ts
this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);
```

## Test tier — fix-only
Wrong-list/visibility defect: the picker options are a transient view-model array, not a saved role, so the e2e harness (which asserts saved roles after `Rollback`) has nothing clean to assert — same tier as the merged #109. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection against the correct customershipment sibling. CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.

Closes the purchasereturn rows of the `updateShipFromParty → shipToContacts` family (#17 edit, #32 create).