### PR TITLE
fix(apps-intranet): clear the ShipToCustomer's own address on change in purchaseinvoice forms [BUG-15/27]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,12 @@ under a dated version heading.
   PositionType, which the second loop then set to `PositionTypeRate = null`. Editing a rate with two or more
   assigned position types and saving unassigned roughly half of them. `originalPositionTypes` is now an
   independent copy (`[...(selectedPositionTypes ?? [])]`), so all assignments are preserved.
+- The purchase-invoice create + edit forms no longer clear the wrong assigned ship-to address when the
+  ShipToCustomer changes. `updateShipToCustomer`'s change-guard nulled `AssignedShipToEndCustomerAddress`
+  (the *end*-customer's field, correctly owned by `updateShipToEndCustomer`) instead of the ship-to-customer's
+  own `AssignedShipToCustomerAddress` — so changing the ShipToCustomer left its stale address in place (saved
+  against the new customer) while wiping the end-customer's chosen address. It now nulls
+  `AssignedShipToCustomerAddress`, matching the adjacent `ShipToCustomerContactPerson` clear.
 - Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
   (latent; both hooks are empty today).
 - SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
@@ -458,7 +458,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
 
     this.allors.context.pull(pulls).subscribe((loaded) => {
       if (this.object.ShipToCustomer !== this.previousShipToCustomer) {
-        this.object.AssignedShipToEndCustomerAddress = null;
+        this.object.AssignedShipToCustomerAddress = null;
         this.object.ShipToCustomerContactPerson = null;
         this.previousShipToCustomer = this.object.ShipToCustomer;
       }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
@@ -479,7 +479,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
 
     this.allors.context.pull(pulls).subscribe((loaded) => {
       if (this.object.ShipToCustomer !== this.previousShipToCustomer) {
-        this.object.AssignedShipToEndCustomerAddress = null;
+        this.object.AssignedShipToCustomerAddress = null;
         this.object.ShipToCustomerContactPerson = null;
         this.previousShipToCustomer = this.object.ShipToCustomer;
       }


### PR DESCRIPTION
## Bug
In the purchase-invoice **edit** (`#15`, `:482`) and **create** (`#27`, `:461`) forms, `updateShipToCustomer`'s change-guard (`ShipToCustomer !== previousShipToCustomer`) nulls `AssignedShipToEndCustomerAddress` — the **end-customer's** field — instead of the ship-to-customer's own `AssignedShipToCustomerAddress`. The adjacent line correctly nulls `ShipToCustomerContactPerson`, and the end-customer's own `updateShipToEndCustomer` (edit:558/:587) legitimately owns the `…EndCustomerAddress` clear, confirming the `…EndCustomer…` name here is a copy/paste slip.

Consequences when the user changes the ShipToCustomer:
- the now-stale `AssignedShipToCustomerAddress` is **not** cleared → the previous customer's address persists and is saved against the new ShipToCustomer;
- the unrelated `AssignedShipToEndCustomerAddress` is wrongly nulled → the end-customer's chosen address is lost.

## Fix
Both forms now null the ship-to-customer's **own** assigned address:
```ts
this.object.AssignedShipToCustomerAddress = null;   // was AssignedShipToEndCustomerAddress
```

## Test tier — fix-only
The defect only fires on a ShipToCustomer *change* (the guard never fires on load — `previousShipToCustomer` is set synchronously in the `(changed)` handler before the async subscribe). A RED would need a bespoke 4-role PurchaseInvoice fixture (`ShipToCustomer` + `AssignedShipToCustomerAddress` + `ShipToEndCustomer` + `AssignedShipToEndCustomerAddress`) plus the fiddly autocomplete-reselect flow — disproportionate to a one-identifier rename whose correctness is evident from the adjacent `ShipToCustomerContactPerson` clear and the correct `updateShipToEndCustomer` sibling. Same tier as the merged #07/#18. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.

First of the purchaseinvoice cluster (8 findings); the remaining add-card findings get their own tier call.