### PR TITLE
fix(apps-intranet): correct purchaseinvoice add-card wiring and contact-org assignments [BUG-13/14/25/26/28/31 + D4/D5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,15 @@ under a dated version heading.
 
 ### Fixed
 
+- The purchase-invoice create and edit forms had several mis-wired "add new …" inline cards and
+  contact-added handlers, now corrected: the ShipToCustomer add-person card ran
+  `billedFromContactPersonAdded` (now `shipToCustomerContactPersonAdded`); the ShipToEndCustomer
+  add-customer card ran `billToEndCustomerAdded` (now `shipToEndCustomerAdded`); the BillToEndCustomer
+  add-customer card was shown by `*ngIf="addShipToCustomer"` instead of `addBillToEndCustomer`; and two
+  contact-added handlers linked the new `OrganisationContactRelationship` to the wrong organisation —
+  `billToEndCustomerContactPersonAdded` used `ShipToEndCustomer` (now `BillToEndCustomer`) and
+  `shipToCustomerContactPersonAdded` used `BilledFrom` (now `ShipToCustomer`). Each defect was present on
+  both the create and edit forms.
 - Editing a CustomerShipment or PurchaseReturn no longer silently clears its `ShipToAddress` and
   `ShipToContactPerson` on load. `onPostPull` called `updateShipToParty` without first setting
   `previousShipToparty`, so the `ShipToParty !== previousShipToparty` guard inside it was true on the initial

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.html
@@ -283,7 +283,7 @@
           <person-inline
             (cancelled)="addShipToCustomerContactPerson = false"
             (saved)="
-              billedFromContactPersonAdded($event);
+              shipToCustomerContactPersonAdded($event);
               addShipToCustomerContactPerson = false
             "
           >
@@ -318,7 +318,7 @@
       </div>
     </div>
     <div class="col-md-12">
-      <mat-card *ngIf="addShipToCustomer">
+      <mat-card *ngIf="addBillToEndCustomer">
         <mat-card-header>Add a new customer</mat-card-header>
         <mat-card-content>
           <party-party
@@ -471,7 +471,7 @@
         <mat-card-content>
           <party-party
             (saved)="
-              billToEndCustomerAdded($event); addShipToEndCustomer = false
+              shipToEndCustomerAdded($event); addShipToEndCustomer = false
             "
             (cancelled)="addShipToEndCustomer = false"
           >

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
@@ -260,7 +260,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .BilledFrom as Organisation;
+      .ShipToCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.shipToCustomerContacts.push(person);
@@ -273,7 +273,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .ShipToEndCustomer as Organisation;
+      .BillToEndCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.billToEndCustomerContacts.push(person);

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.html
@@ -294,7 +294,7 @@
               <person-inline
                 (cancelled)="addShipToCustomerContactPerson = false"
                 (saved)="
-                  billedFromContactPersonAdded($event);
+                  shipToCustomerContactPersonAdded($event);
                   addShipToCustomerContactPerson = false
                 "
               >
@@ -329,7 +329,7 @@
           </div>
         </div>
         <div class="col-md-12">
-          <mat-card *ngIf="addShipToCustomer">
+          <mat-card *ngIf="addBillToEndCustomer">
             <mat-card-header>Add a new customer</mat-card-header>
             <mat-card-content>
               <party-party
@@ -489,7 +489,7 @@
             <mat-card-content>
               <party-party
                 (saved)="
-                  billToEndCustomerAdded($event); addShipToEndCustomer = false
+                  shipToEndCustomerAdded($event); addShipToEndCustomer = false
                 "
                 (cancelled)="addShipToEndCustomer = false"
               >

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
@@ -287,7 +287,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .BilledFrom as Organisation;
+      .ShipToCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.shipToCustomerContacts.push(person);
@@ -300,7 +300,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .ShipToEndCustomer as Organisation;
+      .BillToEndCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.billToEndCustomerContacts.push(person);


### PR DESCRIPTION
## Bug — purchaseinvoice add-card cluster
The purchase-invoice **create** and **edit** forms share several mis-wired "add new …" inline cards and contact-added handlers. Each defect is present on **both** forms; the correct target in every case is an adjacent sibling handler/card.

| Finding | create / edit | Defect → fix |
|---|---|---|
| **#13 / #14** | html :286 / :297 | ShipToCustomer add-**person** card `(saved)` ran `billedFromContactPersonAdded` → **`shipToCustomerContactPersonAdded`** |
| **#25** (+ **D4**, edit twin) | html :474 / :492 | ShipToEndCustomer add-**customer** card `(saved)` ran `billToEndCustomerAdded` → **`shipToEndCustomerAdded`** |
| **#26 / #28** | html :321 / :332 | BillToEndCustomer add-customer card shown by `*ngIf="addShipToCustomer"` → **`addBillToEndCustomer`** (its toggle button + saved handler both use `addBillToEndCustomer`) |
| **#31** (+ edit twin :303) | ts :276 / :303 | `billToEndCustomerContactPersonAdded` set `OrganisationContactRelationship.Organisation = ShipToEndCustomer` → **`BillToEndCustomer`** |
| **D5** (discovered) | ts :262 / :290 | `shipToCustomerContactPersonAdded` set the relationship org to `BilledFrom` → **`ShipToCustomer`** |

### Discovered siblings
The backlog under-counted two findings and missed one — all folded into this PR (per agreed grouping):
- **D4** — #25's edit-side twin (`:492`), same defect/fix.
- **#31** also exists on the edit form (`:303`); fixed alongside the flagged create instance.
- **D5** — `shipToCustomerContactPersonAdded` linked the new contact to `BilledFrom` (the supplier) instead of `ShipToCustomer`. Tightly coupled to #13/#14, which route the ShipToCustomer contact card *to* this handler.

## Tier — fix-only
All are add-inline-card flows (open card → fill sub-form → save); an e2e RB assertion needs the heavy add-card driver, disproportionate to one-identifier swaps whose correctness is evident from the adjacent correct siblings (e.g. `billedFromContactPersonAdded` correctly uses `BilledFrom`; `shipToEndCustomerContactPersonAdded` correctly uses `ShipToEndCustomer`). Same tier as the merged #18/#19/#20. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.

Diff: 10 one-identifier swaps (5 per form) + CHANGELOG.