### PR TITLE
fix(apps-intranet): save the added To email to ToEmail in emailcommunication form [BUG-08/09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,9 @@ under a dated version heading.
   every edit). `onPostPull` now initializes `previousShipToparty` to the loaded `ShipToParty`, so a load is no
   longer treated as a party change. (The customershipment instance was an unflagged sibling of the reported
   purchasereturn defect.)
+- The email-communication form's "add a To email" inline card saved the new address to `FromEmail` instead
+  of `ToEmail` (`toEmailAdded`), overwriting the From address and never setting the recipient. It now assigns
+  `ToEmail`. (The sibling `fromEmailAdded` was already correct.)
 - The bill-to-end-customer autocomplete on the sales-invoice (create + edit) and sales-order (edit) forms now
   fires `billToEndCustomerSelected` instead of `billToCustomerSelected`. The autocomplete binds the
   `BillToEndCustomer` role correctly, but its `(changed)` handler ran the bill-to-*customer* side-effect

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/emailcommunication/form/emailcommunication-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/emailcommunication/form/emailcommunication-form.component.ts
@@ -254,7 +254,7 @@ export class EmailCommunicationFormComponent extends AllorsFormComponent<EmailCo
     const emailAddress = partyContactMechanism.ContactMechanism as EmailAddress;
 
     this.toEmails.push(emailAddress);
-    this.object.FromEmail = emailAddress;
+    this.object.ToEmail = emailAddress;
   }
 
   public fromPartyAdded(fromParty: Person): void {


### PR DESCRIPTION
## Bug
`toEmailAdded` — the `(saved)` handler of the email-communication form's "add a To email" inline card — assigns the new address to `this.object.FromEmail` instead of `this.object.ToEmail` (`:257`). Adding a To recipient therefore **overwrites the From address** and never sets the recipient. Every other line of the handler already targets the To side (`ToParty`, `toEmails`), and the sibling `fromEmailAdded` correctly sets `FromEmail`, so the wrong role is a copy/paste slip.

`#08` and `#09` are the same defect reported twice (both cite `:257`) — fixed once.

## Fix
```ts
this.object.ToEmail = emailAddress;   // was this.object.FromEmail
```

## Test tier — fix-only
The handler fires from an add-inline-card flow (open form → add a To email via the inline EmailAddress sub-form → save); an e2e RB assertion needs that heavy driver, disproportionate to a one-identifier role swap whose correctness is self-evident from the adjacent correct `fromEmailAdded` and the rest of `toEmailAdded`. Same tier as the merged #18/#19/#20 and the add-card cluster. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.