### PR TITLE
fix(apps-intranet): establish workEffort before the purchaseOrders filter uses it [BUG-22]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,10 @@ under a dated version heading.
   `splice`-ing the aliased `originalCategories`, skipping every other `ProductCategory`, which the second
   loop then `removeProduct`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`),
   so all categories are preserved.
+- The work-effort / purchase-order-item assignment form no longer crashes on open. `onPostPull` filtered the
+  available purchase orders using `this.workEffort.TakenBy` before `workEffort` was assigned (it was set only
+  afterwards), throwing a `TypeError` whenever a candidate order existed. `workEffort` is now established
+  before the filter runs.
 - The customer-shipment create + edit forms now populate the ship-from contact dropdown with the ship-from
   party's contacts instead of overwriting the ship-to contact options. `updateShipFromParty` assigned the
   ship-from party's `CurrentContacts` to `shipToContacts` (leaving the declared `shipFromContacts` unused),

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/workeffortpoiassignment/form/workeffortpoiassignment-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/workeffortpoiassignment/form/workeffortpoiassignment-form.component.ts
@@ -86,6 +86,16 @@ export class WorkEffortPurchaseOrderItemAssignmentFormComponent extends AllorsFo
       ? pullResult.object('_object')
       : this.context.create(this.createRequest.objectType);
 
+    if (this.createRequest) {
+      this.workEffort = pullResult.object<WorkEffort>(this.m.WorkEffort);
+
+      this.object.Assignment = this.workEffort;
+      this.object.Quantity = 1;
+    } else {
+      this.selectedPurchaseOrder = this.object.PurchaseOrder;
+      this.workEffort = this.object.Assignment;
+    }
+
     const purchaseOrders = pullResult.collection<PurchaseOrder>(
       this.m.PurchaseOrder
     );
@@ -100,15 +110,7 @@ export class WorkEffortPurchaseOrderItemAssignmentFormComponent extends AllorsFo
       )
     );
 
-    if (this.createRequest) {
-      this.workEffort = pullResult.object<WorkEffort>(this.m.WorkEffort);
-
-      this.object.Assignment = this.workEffort;
-      this.object.Quantity = 1;
-    } else {
-      this.selectedPurchaseOrder = this.object.PurchaseOrder;
-      this.workEffort = this.object.Assignment;
-
+    if (this.editRequest) {
       this.purchaseOrders.push(this.selectedPurchaseOrder);
       this.purchaseOrderSelected(this.selectedPurchaseOrder);
     }


### PR DESCRIPTION
## Bug (crash on load)
`onPostPull` builds the available-purchase-orders list by filtering on `i.PurchaseOrderWherePurchaseOrderItem.OrderedBy === this.workEffort.TakenBy` (`:99`), but `this.workEffort` is assigned only **after** the filter — at `:104` (`pullResult.object<WorkEffort>` for create) or `:110` (`this.object.Assignment` for edit). So `this.workEffort` is `undefined` when the filter runs, and `this.workEffort.TakenBy` throws `TypeError: Cannot read properties of undefined (reading 'TakenBy')` on every open where a candidate item exists (zero existing assignments + no Part — the `&&` short-circuit only reaches `.TakenBy` then). The dialog crashes on load.

## Fix
Reorder `onPostPull` (behavior-preserving): the create/edit branch that establishes `this.workEffort` (and create's `Assignment`/`Quantity`, edit's `selectedPurchaseOrder`) now runs **before** the filter; the edit-branch `purchaseOrders.push(...)` + `purchaseOrderSelected(...)` stay **after** it, consuming the filtered list (the post-filter block guards on `this.editRequest`). A null-guard alone (`this.workEffort?.TakenBy`) would avoid the throw but silently drop every matching purchase order, so `workEffort` is established first instead.

## Test tier — fix-only
Nested dialog form (opened from a WorkEffort with an initializer) with no edit-open harness — same situation as the merged #12 (positiontyperate dialog). An e2e would need a bespoke WorkEffort + PurchaseOrder + qualifying PurchaseOrderItem fixture plus a dialog-open driver, and could only assert "opens without NPE" (not the harness's saved-role pattern) — disproportionate to a self-evident data-flow reorder. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.