### PR TITLE
fix(apps-intranet): guard currencySelected against a missing Supplier [BUG-29]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,10 @@ under a dated version heading.
   own `AssignedShipToCustomerAddress` — so changing the ShipToCustomer left its stale address in place (saved
   against the new customer) while wiping the end-customer's chosen address. It now nulls
   `AssignedShipToCustomerAddress`, matching the adjacent `ShipToCustomerContactPerson` clear.
+- The supplier-offering form's `currencySelected` no longer throws when a currency is picked before a
+  supplier. Its condition optional-chained `this.object.Supplier?.PreferredCurrency`, but the body assigned
+  `this.object.Supplier.PreferredCurrency` unguarded, so with no supplier selected (the `== null` branch
+  true) it raised a `TypeError`. The assignment is now guarded by `this.object.Supplier`.
 - Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
   (latent; both hooks are empty today).
 - SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/supplieroffering/form/supplieroffering-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/supplieroffering/form/supplieroffering-form.component.ts
@@ -145,7 +145,10 @@ export class SupplierOfferingFormComponent extends AllorsFormComponent<SupplierO
   }
 
   public currencySelected(currency: IObject) {
-    if (this.supplierIsNew || this.object.Supplier?.PreferredCurrency == null) {
+    if (
+      this.object.Supplier &&
+      (this.supplierIsNew || this.object.Supplier.PreferredCurrency == null)
+    ) {
       this.object.Supplier.PreferredCurrency = currency as Currency;
     }
   }


### PR DESCRIPTION
## Bug
`currencySelected` guards its **condition** with `this.object.Supplier?.PreferredCurrency == null` (optional chaining — the author knew `Supplier` can be null), but its **body** assigns `this.object.Supplier.PreferredCurrency` with no guard (`:149`). When a currency is picked **before** a supplier is selected, `this.object.Supplier` is `undefined`, so `this.object.Supplier?.PreferredCurrency == null` is `true` → the condition passes → the unguarded assignment throws `TypeError: Cannot set properties of undefined (setting 'PreferredCurrency')`.

## Fix
Guard the assignment on a present supplier (you can't assign through `?.`):
```ts
if (
  this.object.Supplier &&
  (this.supplierIsNew || this.object.Supplier.PreferredCurrency == null)
) {
  this.object.Supplier.PreferredCurrency = currency as Currency;
}
```
`currencySelected` only propagates the chosen currency to the *supplier's* `PreferredCurrency`; with no supplier there's nothing to propagate to. All behaviour with a supplier present (`supplierIsNew` → set; existing supplier with no preferred currency → set; with one → leave) is unchanged.

## Test tier — fix-only
Ordering-dependent NPE-on-action (currency before supplier); an e2e would have to drive that exact mis-order and could only assert "no crash" (the harness asserts saved roles after save) — disproportionate to a one-token null-guard whose intent is self-evident from the adjacent `?.`. Same tier as #22/#12. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.