### PR TITLE
fix(apps-intranet): gate the UnifiedGood ProductNumber input on the setting that creates it [BUG-30]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ under a dated version heading.
   `AssignedShipToCustomerAddress`, matching the adjacent `ShipToCustomerContactPerson` clear.
 - Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
   (latent; both hooks are empty today).
+- The UnifiedGood create form showed its manual ProductNumber input based on `settings.UseGlobalProductNumber`,
+  but the bound `ProductNumber` is created (and added to the good) based on `settings.UseProductNumberCounter`.
+  With the settings disagreeing, the field could be hidden while an empty product-number identification was
+  attached, or shown bound to `undefined`. The input is now gated on `!settings.UseProductNumberCounter`,
+  matching its creation.
 - SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`
   statement, so databases named after reserved T-SQL keywords (e.g. `Identity`) provision correctly.
 - The NonUnifiedGood edit form no longer drops product categories on save. `onPostPull` assigned the same

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/create/unifiedgood-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/create/unifiedgood-create-form.component.html
@@ -2,7 +2,7 @@
   <div class="row pt-3">
     <a-mat-input
       class="col-md"
-      *ngIf="!settings.UseGlobalProductNumber"
+      *ngIf="!settings.UseProductNumberCounter"
       [object]="productNumber"
       [roleType]="m.ProductNumber.Identification"
     ></a-mat-input>


### PR DESCRIPTION
## Bug
The UnifiedGood **create** form shows its manual ProductNumber input with `*ngIf="!settings.UseGlobalProductNumber"` (`html:5`), bound to `[object]="productNumber"`. But `this.productNumber` is created — and attached to the good via `this.object.addProductIdentification(...)` — only `if (!this.settings.UseProductNumberCounter)` (`ts:79-86`). The visibility guard and the creation guard use **different** Settings flags, so they can disagree:
- counter off + global on → a `ProductNumber` is created and added to the good, but the input is **hidden** → the good is saved with an empty product-number identification;
- counter on + global off → the input is **shown** bound to `productNumber === undefined` → broken/blank input.

## Fix
Gate the input on the same setting that creates its model object:
```html
*ngIf="!settings.UseProductNumberCounter"   <!-- was !settings.UseGlobalProductNumber -->
```

## Test tier — fix-only
Visibility/binding-guard mismatch; the correct condition is fixed by the TS (`addProductIdentification` is guarded by `!UseProductNumberCounter`). Visibility isn't a saved role the e2e harness asserts, and a meaningful e2e would need a Settings fixture toggling both flags — disproportionate to a one-attribute alignment. No scaffold page-object regen (the input's `[roleType]` selector is unchanged; only its runtime `*ngIf` changes). Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (compiles the template) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.