### PR TITLE
test(apps-intranet): make the CustomerShipment e2e self-contained (deterministic ShipToContactPerson)

### DIFF
--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
@@ -7,6 +7,7 @@ namespace Tests.E2E.Objects
 {
     using System.Linq;
     using Allors.Database.Domain;
+    using Allors.Database.Domain.TestPopulation;
     using Allors.E2E.Angular;
     using Allors.E2E.Angular.Html;
     using Allors.E2E.Angular.Material.Factory;
@@ -22,8 +23,21 @@ namespace Tests.E2E.Objects
         [Test]
         public async Task EditCustomerShipmentPreservesShipToContactPerson()
         {
-            var shipment = new CustomerShipments(this.Transaction).Extent()
-                .First(v => v.ExistShipToContactPerson);
+            // Build a dedicated shipment with a guaranteed ShipToContactPerson, independent of the shared
+            // population (whose single WithDefaults shipment takes its contact from a random customer that
+            // may be a B2C person with no CurrentContacts). Repoint ShipTo to a B2B customer that has a
+            // contact — done post-build via direct role assignment, not on the builder.
+            var internalOrganisation = new Organisations(this.Transaction).FindBy(this.M.Organisation.Name, "Allors BV");
+            var customer = internalOrganisation.ActiveCustomers.OfType<Organisation>().First(v => v.CurrentContacts.Any());
+
+            var shipment = new CustomerShipmentBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
+            this.Transaction.Derive();
+
+            shipment.ShipToParty = customer;
+            shipment.ShipToContactPerson = customer.CurrentContacts.First();
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
             var shipToContactPerson = shipment.ShipToContactPerson;
 
             var @class = this.M.CustomerShipment;


### PR DESCRIPTION
## Why
`CustomerShipmentTest.EditCustomerShipmentPreservesShipToContactPerson` (added in #110 for BUG-16/D3) intermittently failed the intranet e2e gate with `System.InvalidOperationException: Sequence contains no matching element` at `First(v => v.ExistShipToContactPerson)`. It passed on #110/#113/#114/#115/#116 and flaked on **#117** and **#119**.

**Root cause:** the test queried the shared population for *any* CustomerShipment with a `ShipToContactPerson`. The population builds a single shipment via `WithDefaults`, whose `ShipToContactPerson` is `randomCustomer.CurrentContacts.FirstOrDefault()` — `null` when the random customer is a B2C **person** (no `CurrentContacts`). So some seeds had no contact-bearing shipment → the query threw.

## Fix (test-only)
The test now builds **its own** shipment, independent of population/order:
```csharp
var internalOrganisation = new Organisations(this.Transaction).FindBy(this.M.Organisation.Name, "Allors BV");
var customer = internalOrganisation.ActiveCustomers.OfType<Organisation>().First(v => v.CurrentContacts.Any());
var shipment = new CustomerShipmentBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
this.Transaction.Derive();
shipment.ShipToParty = customer;
shipment.ShipToContactPerson = customer.CurrentContacts.First();
this.Transaction.Derive();
this.Transaction.Commit();
```
`ShipToParty`/`ShipToContactPerson` are set **post-build by direct role assignment** — *not* on the builder: calling `WithShipToParty` on a builder that `WithDefaults` already set throws `ArgumentException: One multiplicity`. The shared `IntranetPopulation` is **untouched** (an earlier attempt to fix it there hit exactly that builder error and is reverted).

## Verification
Run locally against the AppsIntranet stack (sqlclient/LocalDB, headless): **`Passed! 1/1, 43s`**. Once merged, #117 (BUG-30) and #119 (BUG-D1) will be rebased onto it so their intranet gates are deterministic.