### PR TITLE
fix(apps-intranet): only set BasePrice FromDate/PricedBy defaults on create [BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,10 @@ under a dated version heading.
   party's `CurrentContacts` were assigned to `shipToContacts` (leaving the declared `shipFromContacts`
   unused), so the ship-from contact picker stayed empty and the ship-to contact options were overwritten
   with the ship-from party's contacts. Both forms now assign `shipFromContacts`.
+- The base-price form's create-time defaults are no longer applied on edit. `onPostPull` unconditionally set
+  `FromDate = new Date()` and `PricedBy = internalOrganisation`, so editing an existing BasePrice reset its
+  effective-from date to today and its priced-by (persisted on save). Both are now guarded by
+  `this.createRequest`, so a loaded BasePrice keeps its own values.
 - The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
   reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/baseprice/form/baseprice-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/baseprice/form/baseprice-form.component.ts
@@ -67,7 +67,9 @@ export class BasepriceFormComponent extends AllorsFormComponent<BasePrice> {
     this.internalOrganisation =
       this.fetcher.getInternalOrganisation(pullResult);
 
-    this.object.FromDate = new Date();
-    this.object.PricedBy = this.internalOrganisation;
+    if (this.createRequest) {
+      this.object.FromDate = new Date();
+      this.object.PricedBy = this.internalOrganisation;
+    }
   }
 }


### PR DESCRIPTION
## Bug (data corruption on edit)
`baseprice-form` is a combined create/edit form, but `onPostPull` ends with, **unconditionally**:
```ts
this.object.FromDate = new Date();
this.object.PricedBy = this.internalOrganisation;
```
On **edit** this overwrites the loaded BasePrice's effective-from `FromDate` with today and resets `PricedBy` to the internal organisation, and those overwrites persist on save. So editing a base price (e.g. to change the amount) silently resets its from-date and priced-by. These are *create-time* defaults; a loaded BasePrice already has them.

This is the documented sibling of `#01` (employment-form FromDate-overwrite-on-load) and the same shape as the merged `#16` (clearing-on-load).

## Fix
Guard the create-time defaults:
```ts
if (this.createRequest) {
  this.object.FromDate = new Date();
  this.object.PricedBy = this.internalOrganisation;
}
```
A new BasePrice still gets `FromDate = today` + `PricedBy = internalOrganisation`; a loaded one keeps its own.

## Test tier — fix-only
Nested dialog form (opened from a good's pricing panel) with no edit-open page-object harness — same situation as the merged #12/#22. The overwrite-on-load → data-loss idiom is e2e-proven by #16, and its executed base-side e2e comes with the sibling #01. Validated by `npx nx build apps-intranet-workspace-angular-material-app --skipNxCache` (clean) + inspection; CI `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` is the regression gate.