### PR TITLE
fix(base): preserve an employment's FromDate on edit [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The employment form no longer overwrites an existing employment's FromDate on edit. `onPostPull` set
+  `this.object.FromDate = new Date()` unconditionally, so opening an employment to edit it reset its start
+  date to today (persisted on save). The default is now guarded by `this.createRequest`, so only a new
+  employment gets today's date; a loaded one keeps its own.
 - The purchase-invoice create and edit forms had several mis-wired "add new …" inline cards and
   contact-added handlers, now corrected: the ShipToCustomer add-person card ran
   `billedFromContactPersonAdded` (now `shipToCustomerContactPersonAdded`); the ShipToEndCustomer

--- a/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
+++ b/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
@@ -228,5 +228,55 @@ namespace Tests.E2E.Objects
             // throws); without the fix the table is empty and the console-error TearDown trips.
             ClassicAssert.Contains(employment.Strategy.ObjectId.ToString(), objectIds);
         }
+
+        [Test]
+        public async Task EditEmploymentPreservesFromDate()
+        {
+            // Build a dedicated employment with a known FromDate (well in the past, not today), so editing
+            // it must not silently reset FromDate. Self-contained: independent of population/order.
+            var person = new People(this.Transaction).FindBy(this.M.Person.FirstName, "John");
+            var employer = new OrganisationBuilder(this.Transaction).WithName("Employer For FromDate E2E").Build();
+            var fromDate = this.Transaction.Now().AddDays(-30);
+
+            var employment = new EmploymentBuilder(this.Transaction)
+                .WithEmployee(person)
+                .WithEmployer(employer)
+                .WithFromDate(fromDate)
+                .Build();
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
+            var @class = this.M.Person;
+
+            var overview = this.Application.GetOverview(@class);
+            var url = overview.RouteInfo.FullPath.Replace(":id", $"{person.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var personOverview = new PersonOverviewPageComponent(this.AppRoot);
+
+            await personOverview.ViewEmployment.Locator.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var edit = personOverview.EditEmployment;
+            await edit.Table.DefaultAction(employment);
+            await this.Page.WaitForAngular();
+
+            var form = new EmploymentFormComponent(this.OverlayContainer);
+
+            // The form's onPostPull is the suspect; dirty an unrelated field (ThroughDate) so SAVE enables
+            // even after the fix (which no longer touches FromDate on load).
+            await form.ThroughDateDatepicker.SetAsync(this.Transaction.Now());
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.OverlayContainer);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            ClassicAssert.AreEqual(fromDate.Date, employment.FromDate.Date, "FromDate was overwritten on edit");
+        }
     }
 }

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/employment/form/employment-form.component.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/employment/form/employment-form.component.ts
@@ -68,6 +68,8 @@ export class EmploymentFormComponent extends AllorsFormComponent<Employment> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.object.FromDate = new Date();
+    if (this.createRequest) {
+      this.object.FromDate = new Date();
+    }
   }
 }


### PR DESCRIPTION
## Bug (critical — HR-data corruption on edit)
`employment-form` is a combined create/edit form, but `onPostPull` ends with, **unconditionally**:
```ts
this.object.FromDate = new Date();
```
On **edit** this overwrites the loaded Employment's start date with today, and the change persists on save — editing an employment (e.g. to change Employer) silently resets its `FromDate`. Same overwrite-on-load idiom as D1 (baseprice) and the merged #16 (clearing-on-load).

## Fix
Guard the create-time default:
```ts
if (this.createRequest) {
  this.object.FromDate = new Date();
}
```

## Test — e2e(base), executed RED→GREEN locally
New self-contained `PersonTest.EditEmploymentPreservesFromDate`: build an Employment for "John" with a `FromDate` 30 days ago + `Commit` → open the Person overview → employment panel → open the edit dialog → set `ThroughDate` (dirties the form so SAVE enables after the fix) → SAVE → `Rollback` → assert `FromDate.Date` unchanged.

Edit-open detail: the `a-mat-dyn-edit-extent-panel` exposes only add+delete row actions (no `data-allors-action='edit'`), so the dialog is opened via `Table.DefaultAction(employment)` (clicks the row cell), not `Action(…, "edit")`.

Verified locally on the base stack (Base server + `application-app` serve + `config/sqlclient` DB "Base", headless):
- **RED** (unfixed): `Expected: 2026-05-16 But was: 2026-06-15` (FromDate reset to today).
- **GREEN** (fixed): `Passed! 1/1`.

Gate: `CiTypescriptE2EAngularBaseTest`. (#01 touches no intranet code, so it's unaffected by the CustomerShipment fixture flake fixed in the de-flake PR.)