### PR TITLE
fix(apps-extranet): bind FullfillContactMechanism options to ContactMechanism in worktask forms [BUG-05/06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
+  PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
+  `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to
+  `contactMechanisms: ContactMechanism[]`; it now maps each to its `.ContactMechanism`, so the picker offers
+  the contact mechanisms the `FullfillContactMechanism` role expects.
 - The employment form no longer overwrites an existing employment's FromDate on edit. `onPostPull` set
   `this.object.FromDate = new Date()` unconditionally, so opening an employment to edit it reset its start
   date to today (persisted on save). The default is now guarded by `this.createRequest`, so only a new

--- a/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/create/worktask-create-form.component.ts
+++ b/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/create/worktask-create-form.component.ts
@@ -3,6 +3,7 @@ import { Component, Self } from '@angular/core';
 import {
   Person,
   ContactMechanism,
+  PartyContactMechanism,
   WorkTask,
 } from '@allors/default/workspace/domain';
 import {
@@ -89,8 +90,9 @@ export class WorkTaskCreateFormComponent extends AllorsFormComponent<WorkTask> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.contactMechanisms =
-      pullResult.collection<ContactMechanism>('contactmechanisms');
+    this.contactMechanisms = pullResult
+      .collection<PartyContactMechanism>('contactmechanisms')
+      ?.map((v) => v.ContactMechanism);
     this.contacts = pullResult.collection<Person>('contacts');
   }
 }

--- a/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/edit/worktask-edit-form.component.ts
+++ b/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/edit/worktask-edit-form.component.ts
@@ -10,6 +10,7 @@ import { IPullResult, Pull } from '@allors/system/workspace/domain';
 import { NgForm } from '@angular/forms';
 import {
   ContactMechanism,
+  PartyContactMechanism,
   Person,
   WorkTask,
 } from '@allors/default/workspace/domain';
@@ -97,8 +98,9 @@ export class WorkTaskEditFormComponent extends AllorsFormComponent<WorkTask> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.contactMechanisms =
-      pullResult.collection<ContactMechanism>('contactmechanisms');
+    this.contactMechanisms = pullResult
+      .collection<PartyContactMechanism>('contactmechanisms')
+      ?.map((v) => v.ContactMechanism);
     this.contacts = pullResult.collection<Person>('contacts');
   }
 }


### PR DESCRIPTION
## Bug
The extranet work-task **create** (`#05`, `:92`) and **edit** (`#06`, `:100`) forms pull a `contactmechanisms` result whose `select` is `CurrentPartyContactMechanisms` — a collection of **PartyContactMechanism** (with `include` eager-loading each `.ContactMechanism`). `onPostPull` assigned that collection straight to `contactMechanisms: ContactMechanism[]` (a wrong cast), and the template binds `[options]="contactMechanisms"` to the `m.WorkTask.FullfillContactMechanism` select. `FullfillContactMechanism` is a **ContactMechanism** role, so the options were PartyContactMechanisms — picking one binds the wrong object type.

## Fix
Map the pulled PartyContactMechanisms to their `.ContactMechanism` in `onPostPull` (both forms) + import `PartyContactMechanism`:
```ts
this.contactMechanisms = pullResult
  .collection<PartyContactMechanism>('contactmechanisms')
  ?.map((v) => v.ContactMechanism);
```
Mirrors the intranet `updateShipToParty`/`updateShipFromParty` idiom (`partyContactMechanisms?.map(v => v.ContactMechanism)`).

## Test tier — fix-only (no extranet gate)
There is no extranet e2e gate to RED→GREEN against: `build/Typescript/E2E/AppsExtranet/Build.cs`'s `TypescriptE2EAngularAppsExtranetTest` serves `angular-apps-intranet:serve` (the **intranet** app — copy-paste bug), references `Paths.TypescriptE2EAppsExtranetAngularTests` (a Tests project that **doesn't exist** — only `typescript/e2e/old/apps-extranet/`), and is **absent from `.github/workflows/ci.yml`**. (Repairing that harness is an out-of-scope `ts-apps-lists-derivations` item.) Validated by `npx nx build apps-extranet-workspace-angular-material-app --configuration=development` (clean; the **production** build pre-fails an unrelated bundle-size budget) + inspection against the intranet idiom.