### PR TITLE
feat(apps-worktask): add WorkEffortPurpose to WorkRequirement (default Repair, copy to WorkTask, versioned)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ under a dated version heading.
 
 ### Added
 
+- `WorkRequirement.WorkEffortPurpose` (enumeration Refurbishment / Maintenance / Repair): defaults to
+  **Repair** on init, is copied onto the `WorkTask` created by `CreateWorkTask`, and is mirrored into
+  `WorkRequirementVersion` for version history.
 - New **Identity** domain track at `dotnet/Identity`: an orthogonal domain that extends `Core` and
   encapsulates all Microsoft ASP.NET Identity integration (identity properties on `User`, `Login`,
   `UserPasswordReset`, normalization/password rules, `PasswordHasher`, `AllorsUserStore`/`AllorsRoleStore`,

--- a/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
@@ -6,7 +6,9 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System.Linq;
     using Xunit;
+    using TestPopulation;
 
     public class WorkRequirementTests : DomainTest, IClassFixture<Fixture>
     {
@@ -47,6 +49,40 @@ namespace Allors.Database.Domain.Tests
             builder.Build();
 
             Assert.False(this.Derive().HasErrors);
+        }
+
+        [Fact]
+        public void GivenWorkRequirement_WhenBuild_ThenWorkEffortPurposeDefaultsToRepair()
+        {
+            var requirement = new WorkRequirementBuilder(this.Transaction).WithDescription("WorkRequirement").Build();
+
+            this.Transaction.Derive();
+
+            Assert.Equal(new WorkEffortPurposes(this.Transaction).Repair, requirement.WorkEffortPurpose);
+        }
+
+        [Fact]
+        public void GivenWorkRequirementWithPurpose_WhenCreateWorkTask_ThenWorkEffortPurposeIsCopied()
+        {
+            var internalOrganisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
+            var maintenance = new WorkEffortPurposes(this.Transaction).Maintenance; // non-default, proves copy
+
+            var requirement = new WorkRequirementBuilder(this.Transaction)
+                .WithDescription("desc")
+                .WithFixedAsset(serialisedItem)
+                .WithWorkEffortPurpose(maintenance)
+                .Build();
+
+            this.Transaction.Derive();
+
+            requirement.CreateWorkTask();
+
+            this.Transaction.Derive(false);
+
+            var workTask = (WorkTask)requirement.WorkRequirementFulfillmentWhereFullfilledBy.FullfillmentOf;
+
+            Assert.Equal(maintenance, workTask.WorkEffortPurpose);
         }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkRequirement.cs
+++ b/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkRequirement.cs
@@ -29,6 +29,11 @@ namespace Allors.Database.Domain
             {
                 this.ServicedBy = internalOrganisations[0];
             }
+
+            if (!this.ExistWorkEffortPurpose)
+            {
+                this.WorkEffortPurpose = new WorkEffortPurposes(this.Strategy.Transaction).Repair;
+            }
         }
 
         public void AppsDelete(DeletableDelete method)
@@ -73,6 +78,7 @@ namespace Allors.Database.Domain
                 .WithDescription(this.Reason)
                 .WithTakenBy(this.ServicedBy)
                 .WithCustomer(this.Originator)
+                .WithWorkEffortPurpose(this.WorkEffortPurpose)
                 .Build();
 
             new WorkEffortFixedAssetAssignmentBuilder(transaction).WithAssignment(workTask).WithFixedAsset(this.FixedAsset).Build();

--- a/dotnet/Apps/Repository/Domain/Apps/WorkRequirement.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/WorkRequirement.cs
@@ -149,6 +149,14 @@ namespace Allors.Repository
         [Workspace(Default)]
         public bool UnServiceable{ get; set; }
 
+        #region Allors
+        [Id("9f8049e4-1bc6-4ef8-bb9f-de1ee4c17362")]
+        #endregion
+        [Multiplicity(Multiplicity.ManyToOne)]
+        [Indexed]
+        [Workspace(Default)]
+        public WorkEffortPurpose WorkEffortPurpose { get; set; }
+
         #region inherited methods
 
         public void OnBuild() { }

--- a/dotnet/Apps/Repository/Domain/Apps/WorkRequirementVersion.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/WorkRequirementVersion.cs
@@ -63,6 +63,13 @@ namespace Allors.Repository
         [Workspace(Default)]
         public bool UnServiceable { get; set; }
 
+        #region Allors
+        [Id("c7f2a934-8b15-4d62-a0e7-3f9b6d1c8e54")]
+        #endregion
+        [Multiplicity(Multiplicity.ManyToOne)]
+        [Workspace(Default)]
+        public WorkEffortPurpose WorkEffortPurpose { get; set; }
+
         #region inherited methods
 
         public void OnBuild() { }


### PR DESCRIPTION
## Summary

`WorkEffort` already carried a `WorkEffortPurpose` (Refurbishment / Maintenance / Repair), but `WorkRequirement` — the thing a `WorkTask` is created from — had none. This adds the purpose to `WorkRequirement`, defaults it to **Repair**, and carries it onto the `WorkTask` created by `CreateWorkTask`, keeping the requirement and its resulting work effort aligned.

## Changes

- **Repository** — declare `WorkRequirement.WorkEffortPurpose` (`ManyToOne`, `[Indexed]`, `[Workspace(Default)]`, not `[Required]`).
- **Versioning** — mirror the role onto `WorkRequirementVersion` so purpose changes appear in version history (consistent with the sibling `FixedAsset`/`ServicedBy` roles and with `WorkEffort.WorkEffortPurpose`).
- **Behavior** — `AppsOnInit` defaults the purpose to `Repair` when unset; `AppsCreateWorkTask` copies it onto the created `WorkTask`.
- **Tests** — two new facts in `WorkRequirementTests`: default-to-Repair on build, and copy-on-`CreateWorkTask`.
- **Changelog** — entry under `[Unreleased] → Added`.

## Testing

- New tests: `Passed: 5, Failed: 0` (confirmed red → green — both failed on the assertion before the behavior was added).
- Regression (`~WorkRequirement|~Worktask`): `Passed: 63, Failed: 0`.
- `./build.sh Generate` succeeds.

## Notes

- No generated files are committed (they are git-ignored); `./build.sh Generate` is a local prerequisite so the new `ExistX`/`WithX`/`M.` members compile.
- No UI/form change — the role is `[Workspace(Default)]` for consistency but rendered nowhere.
