### PR TITLE
fix(apps-intranet): compute purchase-order-item VAT on the net unit price [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The purchase-order-item `TotalIncVat` workspace derivation computed unit VAT on the gross base price
+  instead of the net unit price — the order-side sibling of the purchase-invoice-item fix. `unitVat` was
+  `unitBasePrice * vatRate`, so the line's discounts and surcharges (accumulated into
+  `unitDiscount`/`unitSurcharge` just above) were excluded from the VAT base, and `TotalIncVat` was left
+  inconsistent with the sibling `UnitVat` rule. It now applies the rate to
+  `unitBasePrice - unitDiscount + unitSurcharge`.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-order-item-total-inc-vat.rule.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-order-item-total-inc-vat.rule.ts
@@ -65,7 +65,10 @@ export class PurchaseOrderItemTotalIncVatRule
             : parseFloat(v.Amount ?? '0');
       });
 
-      unitVat = (unitBasePrice * parseFloat(vatRate?.Rate ?? '0')) / 100;
+      unitVat =
+        ((unitBasePrice - unitDiscount + unitSurcharge) *
+          parseFloat(vatRate?.Rate ?? '0')) /
+        100;
     }
 
     const unitPrice = unitBasePrice - unitDiscount + unitSurcharge;


### PR DESCRIPTION
## BUG-05 — purchase-order-item VAT computed on the gross base price

Order-side sibling of #123 (BUG-04). `PurchaseOrderItemTotalIncVatRule.derive()` computed `unitVat = unitBasePrice * vatRate`, charging VAT on the **gross** base price and excluding the line's discounts/surcharges (already accumulated into `unitDiscount`/`unitSurcharge` just above) from the VAT base. This overstated VAT on discounted lines and understated it on surcharged ones, and left `TotalIncVat` inconsistent with the sibling `UnitVat` rule — which already applies the rate to the net price.

### Fix
`unitVat` now applies the VAT rate to the net price `unitBasePrice - unitDiscount + unitSurcharge`, matching `purchase-order-item-unit-vat.rule.ts:65-67`.

### Verification
Fix-only, verified by inspection against the in-repo `UnitVat` oracle. Worked example: price 100, 10% discount, 20% VAT, qty 2 → was `220.00`, now `216.00`. The `apps-intranet-workspace-derivations` Jest project is not run by any CI gate; CI compiles the changed rule via the intranet e2e gate (the app's `app.config.ts` imports this `ruleBuilder`).

### Follow-up
The four VAT rules' unassigned `this.dependencies` gap is tracked separately as BUG-D1 (its own PR).