### PR TITLE
fix(apps-intranet): join party DisplayPhone numbers instead of seeded reduce [BUG-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The party `DisplayPhone` workspace derivation prefixed its output with a spurious `", "`. It joined the
+  telecommunications-number display names with `.reduce((acc, cur) => acc + ', ' + cur, '')` seeded with an
+  empty string, so the seed contributed a leading separator (e.g. `", Office, Mobile"`). It now uses
+  `.join(', ')`.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/party-display-phone.rule.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/party-display-phone.rule.ts
@@ -40,7 +40,7 @@ export class PartyDisplayPhoneRule implements IRule<Party> {
             v.ContactMechanism as TelecommunicationsNumber;
           return telecommunicationsNumber.DisplayName;
         })
-        .reduce((acc: string, cur: string) => acc + ', ' + cur, '');
+        .join(', ');
     }
 
     return '';


### PR DESCRIPTION
## BUG-16 — party `DisplayPhone` has a spurious leading `", "`

`PartyDisplayPhoneRule.derive()` mapped the party's telecommunications numbers to their `DisplayName`s (a `string[]`) and folded them with `reduce((acc, cur) => acc + ', ' + cur, '')`. The `''` seed contributed a leading separator, so every non-empty `DisplayPhone` was prefixed with `", "` (e.g. `", Office, Mobile"`).

### Fix
The `.map(...)` already yields a `string[]`, so the seeded `reduce` is replaced with `.join(', ')` → `"Office, Mobile"`. (`.join` also renders a missing `DisplayName` as an empty string rather than the literal `"undefined"` that `acc + ', ' + cur` would concatenate.)

### Verification
Fix-only, verified by inspection. The `apps-intranet-workspace-derivations` Jest project is not run by any CI gate; CI compiles the changed rule via the intranet e2e gate (the app's `app.config.ts` imports this `ruleBuilder`). Completes the derivations cluster (#04 #123 / #05 #124 / #16).