### PR TITLE
fix(apps-intranet): correct ProductCategory and WorkRequirement sorter role types [BUG-02/10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,15 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet ProductCategory list could not be sorted: its sorter was a copy of the Catalogue sorter, so
+  its keys pointed at the foreign `m.Catalogue.*` / `m.Scope.*` roleTypes (which a `ProductCategory` pull has
+  no business sorting by) rather than ProductCategory's own roles. It now sorts by `m.ProductCategory.Name`.
+  (Sorting the `scope` / parent columns would need derived `<Composite>Name` roles on ProductCategory — a
+  dotnet-domain change tracked separately.)
+- The intranet WorkRequirement list's `priority` column sorted by the requirement number, not the priority.
+  Its sort key was `m.WorkRequirement.SortableRequirementNumber` — the same roleType the `number` column uses
+  — so sorting by priority reproduced the number order. It now sorts by `m.WorkRequirement.PriorityName`
+  (mirroring how the `state` column uses `RequirementStateName`).
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
@@ -180,9 +180,7 @@ export class AppSorterService implements SorterService {
     define(
       m.ProductCategory,
       new Sorter({
-        name: m.Catalogue.Name,
-        description: m.Catalogue.Description,
-        scope: m.Scope.Name,
+        name: m.ProductCategory.Name,
       })
     );
 
@@ -334,7 +332,7 @@ export class AppSorterService implements SorterService {
       new Sorter({
         number: [m.WorkRequirement.SortableRequirementNumber],
         state: [m.WorkRequirement.RequirementStateName],
-        priority: [m.WorkRequirement.SortableRequirementNumber],
+        priority: [m.WorkRequirement.PriorityName],
         equipment: [m.WorkRequirement.FixedAssetName],
         location: [m.WorkRequirement.Location],
         lastModifiedDate: m.WorkRequirement.LastModifiedDate,


### PR DESCRIPTION
Two defects in the intranet `AppSorterService` (`sorter.service.ts`).

## BUG-02 — ProductCategory list cannot be sorted
The `define(m.ProductCategory, …)` block was a verbatim copy of the `define(m.Catalogue, …)` block, so its keys referenced the foreign `m.Catalogue.*` / `m.Scope.*` roleTypes. `Sorter.create()` maps a column to a scalar roleType **on the sorted composite**, and a `ProductCategory` pull cannot sort by Catalogue/Scope roleTypes. It now sorts by `m.ProductCategory.Name`.

Of the list's sortable columns (name / primaryParent / secondaryParents / scope), only `name` maps to a real ProductCategory scalar; `scope` shows `CatScope?.Name` but there is no derived `CatScopeName` scalar to sort by (the parent columns already had no sort key). Making those columns sortable needs derived `<Composite>Name` roles on ProductCategory in the dotnet domain — out of this area's scope, tracked separately.

## BUG-10 — WorkRequirement `priority` sorted by requirement number
The `priority` key was `m.WorkRequirement.SortableRequirementNumber` — the same roleType the `number` column uses — so sorting by priority reproduced the number order. It now uses `m.WorkRequirement.PriorityName` (the sortable name of the `Priority` composite, mirroring how `state` uses `RequirementStateName`).

## Verification
Fix-only (view-model sort-key mappings, no saved role to assert). Verified by inspection against the Sorter API and the two list components; CI compiles the service via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.