### PR TITLE
fix(apps-intranet): sort the serialised-item list by its own sorter, not m.Brand [BUG-06/14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet serialised-item list never sorted: its pull fetched `sorterService.sorter(m.Brand)` — a
+  composite with no entry in the sorter service, so `sorter(...)` returned undefined and no sorting was
+  applied — even though the pull and result are `SerialisedItem`. It now fetches `sorter(m.SerialisedItem)`,
+  so the id / name / categories / availability columns sort.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditem/list/serialiseditem-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditem/list/serialiseditem-list-page.component.ts
@@ -138,7 +138,7 @@ export class SerialisedItemListPageComponent implements OnInit, OnDestroy {
               pull.SerialisedItem({
                 predicate: this.filter.definition.predicate,
                 sorting: sort
-                  ? this.sorterService.sorter(m.Brand)?.create(sort)
+                  ? this.sorterService.sorter(m.SerialisedItem)?.create(sort)
                   : null,
                 arguments: this.filter.parameters(filterFields),
                 skip: pageEvent.pageIndex * pageEvent.pageSize,


### PR DESCRIPTION
## BUG-06 (≡ BUG-14) — serialised-item list never sorts

The serialised-item list pulls `pull.SerialisedItem(...)` and reads `collection<SerialisedItem>(m.SerialisedItem)`, but its sort fetched the sorter for the wrong composite:

```js
sorting: sort
  ? this.sorterService.sorter(m.Brand)?.create(sort)
  : null,
```

`AppSorterService` has no `define(m.Brand, …)`, so `sorter(m.Brand)` returns `undefined`, the optional chain short-circuits, and `sorting` is `undefined` — the list silently never sorts (a copy-paste from a brand list). It now fetches `sorter(m.SerialisedItem)`, which is registered (id / categories / name / availability), so those columns sort.

### Verification
Fix-only (view-model sort, no saved role to assert). Verified by inspection; CI compiles the component via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.

Closes the true duplicate **#14** (same file/line). The sibling `sorter(m.Brand)` defect on the serialiseditemcharacteristic list (#07 ≡ #15) is handled in a separate PR.