### PR TITLE
fix(apps-intranet): sort the product-characteristic list by its own (Type) sorter [BUG-07/15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet product-characteristic list never sorted: it fetched `sorterService.sorter(m.Brand)`, and the
+  matching sorter — whose values are `SerialisedItemCharacteristicType` roles — was registered under the wrong
+  composite key `m.SerialisedItemCharacteristic` while the list pulls `SerialisedItemCharacteristicType`. The
+  sorter is now registered under `m.SerialisedItemCharacteristicType` and the list fetches it, so the name /
+  active columns sort. (No other component fetched the old key.)
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
@@ -278,7 +278,7 @@ export class AppSorterService implements SorterService {
     );
 
     define(
-      m.SerialisedItemCharacteristic,
+      m.SerialisedItemCharacteristicType,
       new Sorter({
         name: m.SerialisedItemCharacteristicType.Name,
         uom: m.UnitOfMeasure.Name,

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditemcharacteristictype/list/serialiseditemcharacteristic-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditemcharacteristictype/list/serialiseditemcharacteristic-list-page.component.ts
@@ -136,7 +136,9 @@ export class SerialisedItemCharacteristicListPageComponent
               pull.SerialisedItemCharacteristicType({
                 predicate: this.filter.definition.predicate,
                 sorting: sort
-                  ? this.sorterService.sorter(m.Brand)?.create(sort)
+                  ? this.sorterService
+                      .sorter(m.SerialisedItemCharacteristicType)
+                      ?.create(sort)
                   : null,
                 include: {
                   UnitOfMeasure: x,


### PR DESCRIPTION
## BUG-07 (≡ BUG-15) — product-characteristic list never sorts

The product-characteristic list pulls `pull.SerialisedItemCharacteristicType(...)` and reads `collection<SerialisedItemCharacteristicType>(m.SerialisedItemCharacteristicType)`, displaying Type fields, but its sort fetched the sorter for the wrong composite:

```js
sorting: sort ? this.sorterService.sorter(m.Brand)?.create(sort) : null,
```

`m.Brand` is not registered in `AppSorterService`, so `sorter(...)` returned `undefined` and the list never sorted. The matching sorter **does** exist, but was registered under the wrong key `m.SerialisedItemCharacteristic` — even though its values are `SerialisedItemCharacteristicType` roleTypes — so `sorter(m.SerialisedItemCharacteristicType)` also returned `undefined`.

### Fix
- The sorter is re-registered under `define(m.SerialisedItemCharacteristicType, …)` (its values already are Type's roles; a repo-wide grep confirmed **no** component fetched the old key, so the rename is safe).
- The list now fetches `sorter(m.SerialisedItemCharacteristicType)`.

`name` (`Type.Name`) and `active` (`Type.IsActive`) now sort. The pre-existing foreign `uom: m.UnitOfMeasure.Name` key is left untouched (it can't sort a Type pull — same class as the ProductCategory `scope` case) and noted for the broader Characteristic/Type cleanup (#20).

### Verification
Fix-only (view-model sort, no saved role). Verified by inspection; CI compiles both files via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.

Closes the true duplicate **#15** (same file/line).