### PR TITLE
fix(apps-intranet): show CustomerReference in the purchase-order list, not Description [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet purchase-order list's `customerReference` column showed the order's `Description` instead of
+  its `CustomerReference`. The row-builder read `v.Description`; it now reads `v.CustomerReference` (the role
+  the column is named for and the list already sorts by).
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseorder/list/purchaseorder-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseorder/list/purchaseorder-list-page.component.ts
@@ -244,7 +244,7 @@ export class PurchaseOrderListPageComponent implements OnInit, OnDestroy {
                 v.PurchaseOrderShipmentState &&
                 v.PurchaseOrderShipmentState.Name
               }`,
-              customerReference: `${v.Description || ''}`,
+              customerReference: `${v.CustomerReference || ''}`,
               invoice: v.PurchaseInvoicesWherePurchaseOrder?.map(
                 (w) => w.InvoiceNumber
               ).join(', '),


### PR DESCRIPTION
## BUG-03 — purchase-order list `customerReference` column shows `Description`

The purchase-order list's row-builder populated the `customerReference` column from the wrong role:

```js
customerReference: `${v.Description || ''}`,
```

`PurchaseOrder` has a distinct `CustomerReference` role — the column is named for it and the list already sorts `customerReference` by `m.PurchaseOrder.CustomerReference` — so the cell rendered the order's `Description` instead. It now reads `v.CustomerReference`.

### Verification
Fix-only (row-builder display value, no saved role to assert). Verified by inspection; CI compiles the component via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.