### PR TITLE
fix(apps-intranet): populate the non-unified-part list's type column [BUG-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet non-unified-part list's `type` column was always blank: the column is defined (and sortable),
+  but the row-builder never set a `type` key. It now populates `type` from `v.ProductTypeName` (the role the
+  column already sorts by, alongside the sibling `brand`/`model`/`kind` derived-name columns).
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/list/nonunifiedpart-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/list/nonunifiedpart-list-page.component.ts
@@ -283,6 +283,7 @@ export class NonUnifiedPartListPageComponent implements OnInit, OnDestroy {
             object: v,
             name: v.Name,
             partNo: v.ProductNumber,
+            type: v.ProductTypeName,
             qoh: v.QuantityOnHand,
             localQoh:
               facilitySearchId &&


### PR DESCRIPTION
## BUG-11 — non-unified-part list `type` column always blank

The non-unified-part list declares a sortable `type` column (`{ name: 'type', sort: true }`), but the row-builder set only `name`/`partNo`/`qoh`/`localQoh`/`categories`/`brand`/`model`/`kind`/`lastModifiedDate` — there was no `type` key, so the column rendered empty.

### Fix
Populate it from `v.ProductTypeName` — the role the column already sorts by (`sorter.service.ts` maps `type → m.NonUnifiedPart.ProductTypeName`), matching the sibling derived-name columns (`brand: v.BrandName`, `model: v.ModelName`, `kind: v.InventoryItemKindName`).

### Verification
Fix-only (row-builder display value, no saved role). Verified by inspection; CI compiles the component via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.