### PR TITLE
fix(apps-intranet): drop the proposal list's unpopulated origin/destination columns [BUG-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet proposal (quote) list declared `origin` and `destination` columns that were never populated —
+  a Proposal has no such roles, and they were absent from the row interface, the row-builder, and the Proposal
+  sorter — so they rendered permanently blank (and their `sort: true` was dead). Both columns are removed.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/proposal/list/proposal-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/proposal/list/proposal-list-page.component.ts
@@ -101,8 +101,6 @@ export class ProposalListPageComponent
         { name: 'number', sort: true },
         { name: 'to' },
         { name: 'state' },
-        { name: 'origin', sort: true },
-        { name: 'destination', sort: true },
         { name: 'description', sort: true },
         { name: 'validThroughDate', sort: true },
         { name: 'lastModifiedDate', sort: true },


### PR DESCRIPTION
## BUG-12 — proposal list has unpopulated `origin` / `destination` columns

The proposal (quote) list declared `{ name: 'origin', sort: true }` and `{ name: 'destination', sort: true }`, but a `Proposal` (a sales `Quote`) has no such roles — they were absent from the `Row` interface, the row-builder, and the `m.Proposal` sorter. So the columns rendered permanently blank and their `sort: true` was dead.

### Fix
Both columns are removed (populate is impossible — there are no such roles). The remaining columns (number/to/state/description/validThroughDate/lastModifiedDate) all map to real row-builder fields.

The list renders via the generic `<a-mat-table [table]="table">` (columns come from the TS `columns` config; no per-column `matColumnDef`), so no HTML change or page-object regeneration is needed.

### Verification
Fix-only (table column config, nothing saved to assert). Verified by inspection; CI compiles the component via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.