### PR TITLE
fix(base): pull the Person, not Organisation, in the person overview [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
+  Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
+  breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were
+  unaffected because they drive off `scoped.id` directly.)
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/person/overview/person-overview-page.component.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/person/overview/person-overview-page.component.ts
@@ -59,7 +59,7 @@ export class PersonOverviewPageComponent extends AllorsOverviewPageComponent {
     } = this;
 
     pulls.push(
-      p.Organisation({
+      p.Person({
         name: prefix,
         objectId: this.scoped.id,
       })


### PR DESCRIPTION
## BUG-01 — Person overview pulls the wrong object (overview `object` is null)

`PersonOverviewPageComponent` is `tags.Person` with `object: Person`, but `onPreSharedPull` pushed a pull for the wrong composite:

```js
p.Organisation({ name: prefix, objectId: this.scoped.id })
```

`scoped.id` is the Person's id, so it requested an `Organisation` with a Person's id — no object came back, and `onPostSharedPull` set `this.object` to null. The only `object`-bound element in the overview HTML, the breadcrumb `/ {{ object?.FirstName }}`, therefore rendered blank. (The dynamic panels — `a-mat-dyn-*` — drive off `scoped.id` directly, so they and the existing base `PersonTest` were unaffected, which is how this slipped through.)

### Fix
Pull the composite the overview represents:

```js
p.Person({ name: prefix, objectId: this.scoped.id })
```

### Verification
Fix-only (Pause 1 decision — the only object-bound symptom is the breadcrumb FirstName, which the existing PersonTest doesn't assert; the fix is self-evident). CI's `CiTypescriptE2EAngularBaseTest` builds + smoke-runs the base application app (which contains this overview).

> Note: this is the ts-apps-lists-derivations area's row #01 (person overview), distinct from the already-merged ts-apps-forms `[BUG-01]` (employment FromDate).