### PR TITLE
fix(apps-intranet): navigate purchase-invoice summary cards to their own party [BUG-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The purchase-invoice summary panel's "ship to" and "Bill to End Customer" cards both navigated to the
+  `BilledFrom` party on click (copied from the "Billed from" card) instead of the party each card shows. They
+  now navigate to `ShipToCustomer` and `BillToEndCustomer` respectively.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/summary/purchaseinvoice-summary-panel.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/summary/purchaseinvoice-summary-panel.component.html
@@ -30,7 +30,7 @@
       *ngIf="
         invoice.ShipToCustomer && invoice.ShipToCustomer !== invoice.BilledTo
       "
-      (click)="navigation.overview(invoice.BilledFrom)"
+      (click)="navigation.overview(invoice.ShipToCustomer)"
       style="cursor: pointer"
     >
       <div style="color: grey">ship to</div>
@@ -41,7 +41,7 @@
 
     <div
       *ngIf="invoice.BillToEndCustomer"
-      (click)="navigation.overview(invoice.BilledFrom)"
+      (click)="navigation.overview(invoice.BillToEndCustomer)"
       style="cursor: pointer"
     >
       <div style="color: grey">Bill to End Customer</div>


### PR DESCRIPTION
## BUG-13 — purchase-invoice summary cards navigate to the wrong party

The purchase-invoice summary panel has three clickable party cards. The "ship to" and "Bill to End Customer" cards both copied the "Billed from" card's click handler:

```html
(click)="navigation.overview(invoice.BilledFrom)"
```

So clicking either opened the **billed-from** party's overview instead of the party the card shows.

### Fix
- "ship to" card → `navigation.overview(invoice.ShipToCustomer)`
- "Bill to End Customer" card → `navigation.overview(invoice.BillToEndCustomer)`

Each card now navigates to the party it displays.

### Verification
Fix-only (navigation handlers on a display summary panel; no saved role). Verified by inspection; CI compiles the component via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`. No scaffold/page-object regeneration — only `(click)` targets changed, not form structure.