### PR TITLE
fix(apps-intranet): read descriptionByObjectType in DisplayService.description() [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The intranet `DisplayService.description()` read the `nameByObjectType` map instead of
+  `descriptionByObjectType`, so the dynamic summary panel showed an object's name as both its name and its
+  description. It now reads `descriptionByObjectType`, falling back to `nameByObjectType` when no description
+  role is configured for a type (the map is not yet populated, so behaviour is unchanged until it is).
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/display.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/display.service.ts
@@ -541,7 +541,10 @@ export class AppDisplayService implements DisplayService {
   }
 
   description(objectType: Composite): RoleType {
-    return this.nameByObjectType.get(objectType);
+    return (
+      this.descriptionByObjectType.get(objectType) ??
+      this.nameByObjectType.get(objectType)
+    );
   }
 
   primary(objectType: Composite): RoleType[] {


### PR DESCRIPTION
## BUG-09 — `DisplayService.description()` reads the name map

`description()` read `nameByObjectType` instead of `descriptionByObjectType`, returning the same RoleType as `name()`. It's consumed by the base dynamic summary panel (`dynamic-summary-panel.component.ts`) alongside `name()`, so the panel showed an object's name as **both** its name and its description.

`descriptionByObjectType` already exists (declared `display.service.ts:12`) but is initialised empty (`:185`).

### Fix
`description()` now reads its intended map, falling back to the name map when a type has no description role configured:

```ts
description(objectType: Composite): RoleType {
  return (
    this.descriptionByObjectType.get(objectType) ??
    this.nameByObjectType.get(objectType)
  );
}
```

This is non-regressive: with `descriptionByObjectType` empty, every lookup falls back to `nameByObjectType` (today's behaviour). Populating the map per object type — which removes the visible name/description duplication — is a product/UX decision, tracked as a follow-up (D3), not part of this PR.

### Verification
Fix-only (a display lookup, no saved role). Verified by inspection; CI compiles the service via `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`.