### PR TITLE
fix(apps-extranet): unsubscribe the MainComponent router.events subscription [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The extranet app's `MainComponent` leaked its `router.events` subscription: unlike the sibling
+  toggle/open/close side-nav subscriptions it was neither stored nor unsubscribed, so it survived component
+  teardown. It is now kept in a `routerSubscription` field and unsubscribed in `ngOnDestroy`.
 - The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
   PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
   `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to

--- a/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/app/main/main.component.ts
+++ b/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/app/main/main.component.ts
@@ -29,6 +29,7 @@ export class MainComponent implements OnInit, OnDestroy {
 
   sideMenuItems: SideMenuItem[] = [];
 
+  private routerSubscription: Subscription;
   private toggleSubscription: Subscription;
   private openSubscription: Subscription;
   private closeSubscription: Subscription;
@@ -75,7 +76,7 @@ export class MainComponent implements OnInit, OnDestroy {
     });
 
     this.router.onSameUrlNavigation = 'reload';
-    this.router.events
+    this.routerSubscription = this.router.events
       .pipe(filter((v) => v instanceof NavigationEnd))
       .subscribe(() => {
         if (this.sidenav) {
@@ -97,6 +98,7 @@ export class MainComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.routerSubscription.unsubscribe();
     this.toggleSubscription.unsubscribe();
     this.openSubscription.unsubscribe();
     this.closeSubscription.unsubscribe();


### PR DESCRIPTION
## BUG-08 — extranet `MainComponent` leaks its `router.events` subscription

`ngOnInit` creates four subscriptions. Three — `toggleSubscription` / `openSubscription` / `closeSubscription` — are stored in fields and torn down in `ngOnDestroy`. The `router.events` subscription was neither stored nor unsubscribed, so it outlived the component (and `onSameUrlNavigation = 'reload'` makes it fire on every navigation).

### Fix
Mirror the siblings: add a `routerSubscription` field, assign the `router.events` subscription to it, and unsubscribe it in `ngOnDestroy`.

### Verification
⚠️ The extranet app has **no CI gate** (`CiTypescriptWorkspacesE2EAngularAppsExtranetTest` exists in `build/Build.ci.cs` but is absent from `.github/workflows/ci.yml`), so the CI matrix on this PR does not compile the extranet app. Verified by inspection — this is a verbatim mirror of the three working sibling subscriptions. (The missing extranet gate is the architectural concern tracked separately as #17.)