### PR TITLE
test(apps-intranet): exercise an optional field in CreatePurchaseReturnMaximal [BUG-19]

### DIFF
--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/PurchaseReturnTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/PurchaseReturnTest.cs
@@ -55,6 +55,11 @@ namespace Tests.E2E.Objects
         {
             var before = new PurchaseReturns(this.Transaction).Extent().ToArray();
 
+            var shipToParty = new Organisations(this.Transaction)
+                .Extent()
+                .First(v => v.Name == "Allors BV")
+                .ActiveSuppliers.First();
+
             var @class = this.M.Shipment;
 
             var list = this.Application.GetList(@class);
@@ -67,6 +72,9 @@ namespace Tests.E2E.Objects
 
             var form = new PurchasereturnCreateFormComponent(this.OverlayContainer);
 
+            await form.ShipToPartyAutocomplete.SelectAsync(shipToParty.DisplayName);
+            await this.Page.WaitForAngular();
+
             var saveComponent = new Button(form, "text=SAVE");
             await saveComponent.ClickAsync();
 
@@ -78,7 +86,9 @@ namespace Tests.E2E.Objects
 
             ClassicAssert.AreEqual(before.Length + 1, after.Length);
 
-            //var productType = after.Except(before).First();
+            var purchaseReturn = after.Except(before).First();
+
+            ClassicAssert.AreEqual(shipToParty, purchaseReturn.ShipToParty);
         }
     }
 }


### PR DESCRIPTION
## BUG-19 — `CreatePurchaseReturnMaximal` was identical to `…Minimal`

The "maximal" PurchaseReturn create test was byte-for-byte identical to the minimal one — both created a `PurchaseReturn` with no fields and asserted only the extent count — so it exercised nothing extra.

### Fix
`CreatePurchaseReturnMaximal` now selects a supplier in the `ShipToParty` autocomplete before SAVE and asserts `purchaseReturn.ShipToParty` after rollback, mirroring the supplier-autocomplete pattern already proven in `PurchaseOrderTest` / `PurchaseInvoiceTest`.

Scope is the single `ShipToParty` field (Pause-1 decision): the create form auto-defaults `ShipFromParty` (internal org) and `ShipFromFacility` (`facilities[0]`), and the dependent `ShipToAddress`/`ShipToContactPerson` selects only populate after a supplier is chosen, so `ShipToParty` is the field that meaningfully differentiates "maximal".

### Verification
Editing this existing test was explicitly authorized. Validation is `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` (the page object is scaffold-generated, not buildable locally).