### PR TITLE
fix(e2e): distinguish role vs association autocompletes in the scaffold [BUG-18]

### DIFF
--- a/typescript/e2e/Scaffold/ComponentModels/AssociationComponentModel.cs
+++ b/typescript/e2e/Scaffold/ComponentModels/AssociationComponentModel.cs
@@ -53,15 +53,19 @@ namespace Scaffold
             {
             }
 
-            public override ComponentModel? Build(IElement element) =>
-                TypeByTag.ContainsKey(element.TagName.ToLowerInvariant())
+            public override ComponentModel? Build(IElement element)
+            {
+                var tag = element.TagName.ToLowerInvariant();
+                return TypeByTag.ContainsKey(tag) &&
+                       element.GetAttribute("[associationType]") != null
                     ? new AssociationComponentModel(element)
                     : base.Build(element);
+            }
         }
 
         public override bool Equals(object? obj)
         {
-            if (obj is RoleComponentModel that)
+            if (obj is AssociationComponentModel that)
             {
                 return string.Equals(this.Property, that.Property) &&
                        string.Equals(this.Type, that.Type) &&

--- a/typescript/e2e/Scaffold/ComponentModels/RoleComponentModel.cs
+++ b/typescript/e2e/Scaffold/ComponentModels/RoleComponentModel.cs
@@ -86,10 +86,15 @@ namespace Scaffold
             {
             }
 
-            public override ComponentModel? Build(IElement element) =>
-                TypeByTag.ContainsKey(element.TagName.ToLowerInvariant())
+            public override ComponentModel? Build(IElement element)
+            {
+                var tag = element.TagName.ToLowerInvariant();
+                return TypeByTag.ContainsKey(tag) &&
+                       (tag != "a-mat-autocomplete" ||
+                        element.GetAttribute("[roleType]") != null)
                     ? new RoleComponentModel(element)
                     : base.Build(element);
+            }
         }
 
         public override bool Equals(object? obj)


### PR DESCRIPTION
## BUG-18 — scaffold can't tell role autocompletes from association autocompletes

`RoleComponentModel.Builder` and `AssociationComponentModel.Builder` both match the `a-mat-autocomplete` tag by **tag name only** (`TypeByTag.ContainsKey(tag)`). Role and association autocompletes share that tag and are distinguished only by their attribute — `[roleType]` vs `[associationType]`.

The builder chain is `RoleComponentModel.Builder(AssociationComponentModel.Builder(…))` (Role first, `Scaffold.Command/Program.cs`), so Role claimed **every** autocomplete and its constructor read `[roleType]` — which is null for an association autocomplete → it would `Split('.')` a null / mis-generate, and `AssociationComponentModel.Builder` never ran. (Latent today: a repo grep shows `[associationType]` autocompletes only in the association field component's own template and the base `fields-form`, neither a scaffolded create/edit form — so the base gate is currently green.)

### Fix
Gate the `a-mat-autocomplete` match by attribute (order-independent):
- `RoleComponentModel.Builder.Build` claims `a-mat-autocomplete` only when it has `[roleType]` (other tags unchanged);
- `AssociationComponentModel.Builder.Build` claims it only when it has `[associationType]`.

Also fixes a copy-paste bug folded in here: `AssociationComponentModel.Equals` compared `obj is RoleComponentModel` instead of `is AssociationComponentModel`, so an association model never equalled another (breaking de-dup / Elevate).

### Verification
build(scaffold): the scaffold C# is compiled and executed (page-object generation) by `CiTypescriptE2EAngularBaseTest` and `CiTypescriptWorkspacesE2EAngularAppsIntranetTest`. Existing role-autocomplete output is unchanged (every role autocomplete has `[roleType]`); association autocompletes now route to `AssociationComponentModel` instead of crashing Role. No scaffold unit-test harness exists, so correctness is by inspection of the gating.