### PR TITLE
fix(apps): inject ILogger into the test TestController [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The Apps test `TestController` (`Database/Server`) no longer throws a `NullReferenceException` inside its own
+  error handler. Its `ILogger<TestController>` property was declared but never injected — the constructor took
+  only `IDatabaseService`, so the property stayed `null` — yet the `catch` blocks of `Init`, `Restart` and
+  `TimeShift` call `this.Logger.LogError(...)`. Any failure therefore NRE'd inside the handler, masking the
+  original exception and turning the intended `400 + message` into a `500`. The logger is now injected through
+  the constructor, mirroring the sibling `TestAuthenticationController`.
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Server/Controllers/Test/TestController.cs
+++ b/dotnet/Apps/Database/Server/Controllers/Test/TestController.cs
@@ -13,11 +13,15 @@ namespace Allors.Database.Server.Controllers
 
     public class TestController : Controller
     {
-        public TestController(IDatabaseService databaseService) => this.DatabaseService = databaseService;
+        public TestController(IDatabaseService databaseService, ILogger<TestController> logger)
+        {
+            this.DatabaseService = databaseService;
+            this.Logger = logger;
+        }
 
         public IDatabaseService DatabaseService { get; set; }
 
-        private ILogger<TestController> Logger { get; set; }
+        private ILogger<TestController> Logger { get; }
 
         [HttpGet]
         [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]


### PR DESCRIPTION
## Problem

`TestController` (`dotnet/Apps/Database/Server/Controllers/Test`) declared an `ILogger<TestController>` property
but its only constructor took `IDatabaseService` alone, so the property was never assigned and stayed `null`.
The `catch` blocks of `Init`, `Restart` and `TimeShift` all call `this.Logger.LogError(...)`, so any failure
threw a `NullReferenceException` **inside** the error handler — masking the original exception and turning the
intended `BadRequest(e.Message)` (400) into a 500.

## Fix

Inject `ILogger<TestController>` through the constructor (mirroring the sibling `TestAuthenticationController`
in the same folder) and make the property get-only. ASP.NET Core's controller activator resolves `ILogger<T>`
from the built-in logging infrastructure, so no extra DI registration is needed. Fixes all three call sites at
once.

## Validation

fix-only — no Apps server xUnit harness exists. `dotnet build dotnet\Apps\Database\Server\Server.csproj`
succeeds with 0 errors. CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-05**.