### PR TITLE
fix(apps): log the validation detail in the test server's model-state handler [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- The Apps test server's invalid-model-state logger silently dropped the validation detail. `Startup`'s
+  `InvalidModelStateResponseFactory` called `logger.LogError(problemDetails.Title, message)`, but `LogError`'s
+  first argument is the message *template* and `ValidationProblemDetails.Title` is the constant
+  `"One or more validation errors occurred."` with no `{}` placeholders — so `message` (the joined field
+  errors) had nowhere to bind and was discarded, logging only the generic title. It now calls
+  `LogError("{Title}: {Errors}", problemDetails.Title, message)`, so the actual validation errors are logged
+  and both values become structured properties.
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Server/Startup.cs
+++ b/dotnet/Apps/Database/Server/Startup.cs
@@ -95,7 +95,7 @@ namespace Allors.Database.Server.Controllers
 
                     var problemDetails = new ValidationProblemDetails(context.ModelState);
                     var message = string.Join("; ", problemDetails.Errors.Select(v => $"{string.Join(",", v.Value)}"));
-                    logger.LogError(problemDetails.Title, message);
+                    logger.LogError("{Title}: {Errors}", problemDetails.Title, message);
 
                     return builtInFactory(context);
                 };


### PR DESCRIPTION
## Problem

In `Startup.ConfigureServices`, the `InvalidModelStateResponseFactory` (set via
`PostConfigure<ApiBehaviorOptions>`) logged model-validation failures with:

```csharp
logger.LogError(problemDetails.Title, message);
```

`LogError`'s first argument is the message **template**, and `ValidationProblemDetails.Title` is the framework
constant `"One or more validation errors occurred."` — it has no `{}` placeholders. So `message` (the joined
per-field validation errors) had no hole to bind to and was **silently dropped**; every validation failure
logged only the generic title, never the useful detail.

## Fix

```csharp
logger.LogError("{Title}: {Errors}", problemDetails.Title, message);
```

Two structured-logging placeholders, so the title **and** the actual field errors are rendered and captured as
structured properties.

## Validation

fix-only — no Apps server xUnit harness exists. `dotnet build dotnet\Apps\Database\Server\Server.csproj`
succeeds with 0 errors. CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-09**.