### PR TITLE
test(apps): assert CustomerShipment ShipFromParty against the internal organisation [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerShipmentTests.GivenCustomerShipmentBuilder_WhenBuild_ThenPostBuildRelationsMustExist` now asserts the
+  derived `ShipFromParty` against the expected internal organisation instead of comparing the value to itself.
+  The assertion read `Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty)` — a tautology that passed
+  even if the `ShipFromParty` derivation were wrong (or null). It now asserts
+  `Assert.Equal(this.InternalOrganisation, shipment.ShipFromParty)`, matching the sibling `ShipFromAddress`
+  assertion and the derivation (the single internal organisation becomes the ship-from party).
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
@@ -69,7 +69,7 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(new ShipmentStates(this.Transaction).Created, shipment.ShipmentState);
             Assert.Equal(this.InternalOrganisation.ShippingAddress, shipment.ShipFromAddress);
-            Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty);
+            Assert.Equal(this.InternalOrganisation, shipment.ShipFromParty);
             Assert.Equal(new Stores(this.Transaction).FindBy(this.M.Store.Name, "store"), shipment.Store);
         }
 


### PR DESCRIPTION
## Problem

`CustomerShipmentTests.GivenCustomerShipmentBuilder_WhenBuild_ThenPostBuildRelationsMustExist` asserted:

```csharp
Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty);
```

The value was compared to **itself** — a tautology that passed regardless of what `ShipFromParty` derived to
(even `null`), so it gave no coverage of the ship-from-party derivation.

## Fix

```csharp
Assert.Equal(this.InternalOrganisation, shipment.ShipFromParty);
```

`CustomerShipment` (`CustomerShipment.cs:89-94`) assigns the single internal organisation as `ShipFromParty`
when none is set, and the sibling assertion at `:71` already checks
`this.InternalOrganisation.ShippingAddress == shipment.ShipFromAddress` (and `ShipFromAddress` derives from
`ShipFromParty.ShippingAddress`). So the expected `ShipFromParty` is `this.InternalOrganisation`.

## Validation

Domain.Tests (TV carve-out — correcting the vacuous assertion is the fix). Ran the single test via `--filter`:
- corrected assertion → **passes**;
- a deliberately-wrong expected value → **fails** at line 72, confirming the assertion now has teeth.

CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-03**.