### PR TITLE
test(apps): remove the misplaced duplicate NonUnifiedPart part-required test [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- Removed a misplaced, vacuous duplicate test from the NonUnifiedPart suite. `NonUnifiedPartTests` contained a
+  single `OnPostDeriveAssertExistPart` that was a byte-identical copy of the test in `NonUnifiedGoodTests`: it
+  built a `NonUnifiedGood` and asserted `"NonUnifiedGood.Part is required"`, so it exercised `NonUnifiedGood`,
+  not `NonUnifiedPart` (which has no required-part rule — an empty `NonUnifiedPart` derives clean), and merely
+  duplicated coverage already in `NonUnifiedGoodTests`. The now-empty `NonUnifiedPartTests` class was removed;
+  the genuine `NonUnifiedPartRuleTests` / `NonUnifiedPartDeniedPermissionRuleTests` in the same file are
+  unchanged.
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Domain.Tests/Product/NonUnifiedPartTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/NonUnifiedPartTests.cs
@@ -10,22 +10,6 @@ namespace Allors.Database.Domain.Tests
     using System.Linq;
     using Xunit;
 
-    public class NonUnifiedPartTests : DomainTest, IClassFixture<Fixture>
-    {
-        public NonUnifiedPartTests(Fixture fixture) : base(fixture) { }
-
-        [Fact]
-        public void OnPostDeriveAssertExistPart()
-        {
-            this.Transaction.GetSingleton().Settings.UseProductNumberCounter = true;
-
-            var nonUnifiedGood = new NonUnifiedGoodBuilder(this.Transaction).Build();
-
-            var errors = this.Derive().Errors.ToList();
-            Assert.Contains(errors, e => e.Message.Equals("NonUnifiedGood.Part is required"));
-        }
-    }
-
     public class NonUnifiedPartRuleTests : DomainTest, IClassFixture<Fixture>
     {
         public NonUnifiedPartRuleTests(Fixture fixture) : base(fixture) { }


### PR DESCRIPTION
## Problem

`NonUnifiedPartTests` (in `Domain.Tests/Product/NonUnifiedPartTests.cs`) contained a single test,
`OnPostDeriveAssertExistPart`, that was a **byte-identical copy** of the test in `NonUnifiedGoodTests`:

```csharp
var nonUnifiedGood = new NonUnifiedGoodBuilder(this.Transaction).Build();
var errors = this.Derive().Errors.ToList();
Assert.Contains(errors, e => e.Message.Equals("NonUnifiedGood.Part is required"));
```

It built a **NonUnifiedGood** and asserted the **NonUnifiedGood** part requirement, so despite living in the
NonUnifiedPart suite it gave zero NonUnifiedPart coverage. The asserted requirement comes from
`NonUnifiedGood.cs:32` (`AssertExists(this, M.NonUnifiedGood.Part)`) and is already covered by the identical
`NonUnifiedGoodTests.OnPostDeriveAssertExistPart`.

`NonUnifiedPart` itself has **no** required-part rule — `NonUnifiedPartRule` performs no `AssertExists`, and an
empty `NonUnifiedPart` derives clean (the sibling `NonUnifiedPartRuleTests` build empty parts and derive without
error). So there is no equivalent assertion to retarget the test to.

## Fix

Remove the now-redundant `NonUnifiedPartTests` class (its only method was the duplicate). The genuine
`NonUnifiedPartRuleTests` and `NonUnifiedPartDeniedPermissionRuleTests` in the same file are unchanged, and the
NonUnifiedGood requirement remains covered in `NonUnifiedGoodTests`.

## Validation

`dotnet build dotnet\Apps\Database\Domain.Tests\Domain.Tests.csproj` succeeds with 0 errors (remaining classes
compile; no dangling references). CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-08**.