### PR TITLE
test(apps): exercise the named UseWoCo/ExcludeWoCo scenario in the RgsFilter test [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- `RgsFilterRuleTests.RgsFilterUseWoCoTrueAndUseExcludeWoCoFalseShouldNotGiveError` now exercises the scenario in
+  its name. Its body set `UseWoCo = false; ExcludeWoCo = true` — the opposite of the name, and byte-identical to
+  the preceding `…UseWoCoFalseAndUseExcludeWoCoTrue…` test — so the "UseWoCo true / ExcludeWoCo false"
+  combination was never actually tested and the case merely duplicated its sibling. It now sets
+  `UseWoCo = true; ExcludeWoCo = false`, asserting that the single-flag combination derives without the
+  "cannot both be true" error.
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Domain.Tests/Accounting/RgsFilterTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Accounting/RgsFilterTests.cs
@@ -225,8 +225,8 @@ namespace Allors.Database.Domain.Tests
             var errors = this.Derive().Errors.ToList();
             Assert.Empty(errors);
 
-            rgsFilter.UseWoCo = false;
-            rgsFilter.ExcludeWoCo = true;
+            rgsFilter.UseWoCo = true;
+            rgsFilter.ExcludeWoCo = false;
 
             errors = this.Derive().Errors.ToList();
             Assert.Empty(errors);


### PR DESCRIPTION
## Problem

`RgsFilterRuleTests.RgsFilterUseWoCoTrueAndUseExcludeWoCoFalseShouldNotGiveError` set the **opposite** flags of
its name:

```csharp
rgsFilter.UseWoCo = false;
rgsFilter.ExcludeWoCo = true;
```

That body is byte-identical to the preceding `RgsFilterUseWoCoFalseAndUseExcludeWoCoTrueShouldNotGiveError`
test, so the "UseWoCo true / ExcludeWoCo false" combination the name promises was **never actually exercised** —
the case only duplicated its sibling.

## Fix

```csharp
rgsFilter.UseWoCo = true;
rgsFilter.ExcludeWoCo = false;
```

The RgsFilter rule errors only when **both** flags are true (see
`RgsFilterUseWoCoAndUseExcludeWoCoCanNotBeBothTrue`), so the single-flag combination derives without the "cannot
both be true" error, matching the test's `Assert.Empty(errors)`.

## Validation

Domain.Tests (TV carve-out). Ran the single test via `--filter`:
- corrected body → **passes**;
- a teeth check setting `ExcludeWoCo = true` too (both true — the actual violation) → **fails**, confirming the
  assertion genuinely reacts to the derivation rather than being trivially green.

CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-07**.