### PR TITLE
test(apps): re-derive and assert DisplayName in the AutomatedAgent name test [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `AutomatedAgentTest.ChangedNameDerivePartyName` was vacuous: it set `automatedAgent.Name = "name"`, never
+  re-derived, and asserted the raw `Name` it had just set — and the `PartyName` role it was named for does not
+  exist (the role derived from `Name` is `DisplayName`, via `AutomatedAgentRule`). It now re-derives after the
+  change and asserts the derived `DisplayName`, and is renamed `ChangedNameDeriveDisplayName` to match what it
+  verifies.
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Domain.Tests/Relation/AutomatedAgentTest.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Relation/AutomatedAgentTest.cs
@@ -13,14 +13,15 @@ namespace Allors.Database.Domain.Tests
         public AutomatedAgentTest(Fixture fixture) : base(fixture) { }
 
         [Fact]
-        public void ChangedNameDerivePartyName()
+        public void ChangedNameDeriveDisplayName()
         {
             var automatedAgent = new AutomatedAgentBuilder(this.Transaction).Build();
             this.Transaction.Derive();
 
             automatedAgent.Name = "name";
+            this.Transaction.Derive();
 
-            Assert.Equal("name", automatedAgent.Name);
+            Assert.Equal("name", automatedAgent.DisplayName);
         }
     }
 }


### PR DESCRIPTION
## Problem

`AutomatedAgentTest.ChangedNameDerivePartyName` was vacuous:

```csharp
automatedAgent.Name = "name";
Assert.Equal("name", automatedAgent.Name);
```

It set `Name`, **never re-derived**, and asserted the raw `Name` it had just set — so it could never fail and
exercised no derivation. The `PartyName` role in its name **does not exist** on `AutomatedAgent`/`Party`
anywhere in the domain; the role derived from `Name` is `DisplayName` (`AutomatedAgentRule` derives
`DisplayName = Name`).

## Fix

Re-derive after the change and assert the **derived** `DisplayName`, and rename the test to
`ChangedNameDeriveDisplayName` to match what it actually verifies:

```csharp
automatedAgent.Name = "name";
this.Transaction.Derive();
Assert.Equal("name", automatedAgent.DisplayName);
```

## Validation

Domain.Tests (TV carve-out). Ran the single test via `--filter`:
- with the assertion on `DisplayName` but **before** adding the re-derive → **fails** (DisplayName stale),
  confirming both the missing-`Derive()` bug and that the assertion has teeth;
- after adding `this.Transaction.Derive()` → **passes**.

CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

> Noted for the **apps-rules** area (out of scope here): `AutomatedAgentRule` (`DisplayName = Name`, on `Name`)
> and `AutomatedAgentDisplayNameRule` (`DisplayName = UserName ?? "N/A"`, on `UserName`) both write
> `DisplayName` from different patterns — a last-writer-wins overlap.

Code-review backlog: **BUG-02**.