### PR TITLE
test(apps): build the named object in the ProductFeature required-relations tests [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- The `ProductFeatureTests` "required relations" tests now build the named object before asserting it derives
+  without errors. `GivenModel`, `GivenServiceFeature`, `GivenSizeConstant`, `GivenSoftwareFeature` and
+  `GivenProductQualityConstant` set `builder.WithName("Mt")` but never called `builder.Build()` afterwards
+  (unlike the correct `GivenDimension`), so after the `Rollback()` there was no object to derive and the
+  positive assertion `Assert.False(this.Derive().HasErrors)` passed vacuously. Each now calls `builder.Build()`
+  after `WithName`, so the assertion actually exercises a named object's derivation. (The review flagged
+  `GivenModel` and `GivenServiceFeature`; the identical omission was present in three sibling tests.)
 - The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
   Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
   breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were

--- a/dotnet/Apps/Database/Domain.Tests/Product/ProductFeatureTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/ProductFeatureTests.cs
@@ -39,6 +39,7 @@ namespace Allors.Database.Domain.Tests
             this.Transaction.Rollback();
 
             builder.WithName("Mt");
+            builder.Build();
 
             Assert.False(this.Derive().HasErrors);
         }
@@ -54,6 +55,7 @@ namespace Allors.Database.Domain.Tests
             this.Transaction.Rollback();
 
             builder.WithName("Mt");
+            builder.Build();
 
             Assert.False(this.Derive().HasErrors);
         }
@@ -69,6 +71,7 @@ namespace Allors.Database.Domain.Tests
             this.Transaction.Rollback();
 
             builder.WithName("Mt");
+            builder.Build();
 
             Assert.False(this.Derive().HasErrors);
         }
@@ -84,6 +87,7 @@ namespace Allors.Database.Domain.Tests
             this.Transaction.Rollback();
 
             builder.WithName("Mt");
+            builder.Build();
 
             Assert.False(this.Derive().HasErrors);
         }
@@ -99,6 +103,7 @@ namespace Allors.Database.Domain.Tests
             this.Transaction.Rollback();
 
             builder.WithName("Mt");
+            builder.Build();
 
             Assert.False(this.Derive().HasErrors);
         }


### PR DESCRIPTION
## Problem

In `ProductFeatureTests`, the "required relations must exist" tests follow this pattern: build an empty object →
assert `HasErrors` (a required relation is missing) → `Rollback()` → set `WithName(...)` → assert `!HasErrors`.
The correct template `GivenDimension` calls `builder.Build()` after `WithName`. Five siblings **do not**:

`GivenModel`, `GivenServiceFeature`, `GivenSizeConstant`, `GivenSoftwareFeature`, `GivenProductQualityConstant`
set `builder.WithName("Mt")` but never call `builder.Build()`, so after the rollback **no object is built** and
`Assert.False(this.Derive().HasErrors)` passes **vacuously** — it would pass even if the name-required rule were
broken.

> The code-review backlog flagged `GivenModel` and `GivenServiceFeature`; the identical omission is present in
> three more sibling tests, all fixed here.

## Fix

Add `builder.Build();` after `builder.WithName("Mt");` in all five tests, so the positive assertion exercises a
named object's derivation. (`GivenDimension` already does this and is untouched.)

## Validation

Domain.Tests (TV carve-out). Ran via `--filter "FullyQualifiedName~ProductFeatureTests"`:
- all fixed tests → **pass**;
- teeth check on `GivenModel` (build the second object **without** the name → unnamed Model) → **fails**,
  confirming the positive assertion now genuinely exercises the built object rather than passing vacuously.

CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-01**.