### PR TITLE
fix(apps): build a part item in SalesInvoiceItem WithPartItemDefaults [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,9 @@ under a dated version heading.
   — despite its name and the `salesInvoiceItem_Part` it populates on the sample sales invoices. It now uses the
   `PartItem` invoice-item-type (`InvoiceItemTypes.PartItemId`) and `.WithPart(...)`, matching the correct
   `PurchaseInvoiceItemBuilder.WithPartItemDefaults`. (`UnifiedGood` is both a `Good` and a `Part`, so the
-  existing serialised-good source remains valid for the part role.)
+  existing serialised-good source remains valid for the part role.) The part item sets only `Part` — not
+  `SerialisedItem`/availability — because a `SalesInvoiceItem` permits at most one of
+  `SerialisedItem` / `ProductFeatures` / `Part`.
 - `CustomerShipmentTests.GivenCustomerShipmentBuilder_WhenBuild_ThenPostBuildRelationsMustExist` now asserts the
   derived `ShipFromParty` against the expected internal organisation instead of comparing the value to itself.
   The assertion read `Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty)` — a tautology that passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- The test-population `SalesInvoiceItemBuilder.WithPartItemDefaults` built a **product** item, not a part item.
+  It was a copy of `WithProductItemDefaults` — using the `ProductItem` invoice-item-type and `.WithProduct(...)`
+  — despite its name and the `salesInvoiceItem_Part` it populates on the sample sales invoices. It now uses the
+  `PartItem` invoice-item-type (`InvoiceItemTypes.PartItemId`) and `.WithPart(...)`, matching the correct
+  `PurchaseInvoiceItemBuilder.WithPartItemDefaults`. (`UnifiedGood` is both a `Good` and a `Part`, so the
+  existing serialised-good source remains valid for the part role.)
 - `CustomerShipmentTests.GivenCustomerShipmentBuilder_WhenBuild_ThenPostBuildRelationsMustExist` now asserts the
   derived `ShipFromParty` against the expected internal organisation instead of comparing the value to itself.
   The assertion read `Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty)` — a tautology that passed

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Allors.Database.Domain.TestPopulation
         {
             var m = @this.Transaction.Database.Services.Get<MetaPopulation>();
             var faker = @this.Transaction.Faker();
-            var invoiceItemType = @this.Transaction.Extent<InvoiceItemType>().FirstOrDefault(v => v.UniqueId.Equals(InvoiceItemTypes.ProductItemId));
+            var invoiceItemType = @this.Transaction.Extent<InvoiceItemType>().FirstOrDefault(v => v.UniqueId.Equals(InvoiceItemTypes.PartItemId));
 
             var unifiedGoodExtent = @this.Transaction.Extent<UnifiedGood>();
             unifiedGoodExtent.Filter.AddEquals(m.UnifiedGood.InventoryItemKind, new InventoryItemKinds(@this.Transaction).Serialised);
@@ -96,7 +96,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithComment(faker.Lorem.Sentence())
                 .WithInternalComment(faker.Lorem.Sentence())
                 .WithInvoiceItemType(invoiceItemType)
-                .WithProduct(serializedPart)
+                .WithPart(serializedPart)
                 .WithSerialisedItem(serializedPart.SerialisedItems.FirstOrDefault())
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
@@ -97,8 +97,6 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithInternalComment(faker.Lorem.Sentence())
                 .WithInvoiceItemType(invoiceItemType)
                 .WithPart(serializedPart)
-                .WithSerialisedItem(serializedPart.SerialisedItems.FirstOrDefault())
-                .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
                 .WithAssignedUnitPrice(faker.Random.UInt(2, 100));


### PR DESCRIPTION
## Problem

`SalesInvoiceItemBuilder.WithPartItemDefaults` (test population) was a near-copy of `WithProductItemDefaults`:

```csharp
var invoiceItemType = ...FirstOrDefault(v => v.UniqueId.Equals(InvoiceItemTypes.ProductItemId));
...
.WithInvoiceItemType(invoiceItemType)
.WithProduct(serializedPart)
```

So despite its name — and the `salesInvoiceItem_Part` it populates on the sample sales invoices
(`SalesInvoiceBuilderExtensions`) — it built a **product** item: `ProductItem` invoice-item-type and the
`Product` role.

## Fix

Use the part invoice-item-type and the part role:

```csharp
var invoiceItemType = ...FirstOrDefault(v => v.UniqueId.Equals(InvoiceItemTypes.PartItemId));
...
.WithPart(serializedPart)
```

- `InvoiceItemTypes.PartItemId` already exists (used elsewhere in the same file).
- `SalesInvoiceItem.Part` is a `Part` role, so `WithPart` is the generated builder method.
- `UnifiedGood : Good, Part`, so the existing serialised-`UnifiedGood` source is a valid `Part` — the object
  source is unchanged.
- This matches the already-correct `PurchaseInvoiceItemBuilder.WithPartItemDefaults`.

## Validation

fix-only (population builder; exercised by `Commands Populate` / sample-population paths, not the Domain.Tests
unit fixtures). `dotnet build dotnet\Apps\Database\TestPopulation\TestPopulation.csproj` succeeds with 0 errors.
CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

> Discovered (separate PR): `SalesOrderItemBuilder.WithPartItemDefaults` has the same `.WithProduct` →
> `.WithPart` defect (its invoice-item-type is already correct).

Code-review backlog: **BUG-06**.