### PR TITLE
fix(apps): generate the apps-extranet workspace libs against the Extranet workspace [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- The Apps meta/workspace generator built the **apps-extranet** TypeScript workspace libraries against the
+  **Default** workspace instead of **Extranet**. `Generate/Program.cs` applied a single `workspaceName = "Default"`
+  to every workspace output, including the three `libs/apps-extranet/workspace/**` outputs, so the extranet
+  meta / meta-json / domain were generated with the full Default workspace rather than the restricted Extranet
+  one. Each output now carries its own workspace name and the apps-extranet outputs use `"Extranet"`. (The
+  generated files are gitignored, so only the generator changes; regenerating drops the extranet domain from
+  ~580 to ~18 classes, matching the Extranet workspace.)
 - `CustomerShipmentTests.GivenCustomerShipmentBuilder_WhenBuild_ThenPostBuildRelationsMustExist` now asserts the
   derived `ShipFromParty` against the expected internal organisation instead of comparing the value to itself.
   The assertion read `Assert.Equal(shipment.ShipFromParty, shipment.ShipFromParty)` — a tautology that passed

--- a/dotnet/Apps/Database/Generate/Program.cs
+++ b/dotnet/Apps/Database/Generate/Program.cs
@@ -24,18 +24,18 @@ namespace Allors.Meta.Generation.Storage
 
             string[,] workspace =
             {
-                { "../Core/Workspace/Templates/meta.cs.stg", "Workspace/Meta/Generated" },
-                { "../Core/Workspace/Templates/meta.lazy.cs.stg", "Workspace/Meta.Lazy/Generated" },
-                { "../Core/Workspace/Templates/domain.cs.stg", "Workspace/Domain/Generated" },
-                { "../Core/Workspace/Templates/uml.cs.stg", "Workspace/Diagrams/Generated" },
+                { "../Core/Workspace/Templates/meta.cs.stg", "Workspace/Meta/Generated", "Default" },
+                { "../Core/Workspace/Templates/meta.lazy.cs.stg", "Workspace/Meta.Lazy/Generated", "Default" },
+                { "../Core/Workspace/Templates/domain.cs.stg", "Workspace/Domain/Generated", "Default" },
+                { "../Core/Workspace/Templates/uml.cs.stg", "Workspace/Diagrams/Generated", "Default" },
 
-                { "../../typescript/modules/templates/workspace.meta.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/meta/src/lib/generated" },
-                { "../../typescript/modules/templates/workspace.meta.json.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/meta-json/src/lib/generated" },
-                { "../../typescript/modules/templates/workspace.domain.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/domain/src/lib/generated" },
+                { "../../typescript/modules/templates/workspace.meta.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/meta/src/lib/generated", "Default" },
+                { "../../typescript/modules/templates/workspace.meta.json.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/meta-json/src/lib/generated", "Default" },
+                { "../../typescript/modules/templates/workspace.domain.ts.stg", "../../typescript/modules/libs/apps-intranet/workspace/domain/src/lib/generated", "Default" },
 
-                { "../../typescript/modules/templates/workspace.meta.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/meta/src/lib/generated" },
-                { "../../typescript/modules/templates/workspace.meta.json.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/meta-json/src/lib/generated" },
-                { "../../typescript/modules/templates/workspace.domain.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/domain/src/lib/generated" },
+                { "../../typescript/modules/templates/workspace.meta.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/meta/src/lib/generated", "Extranet" },
+                { "../../typescript/modules/templates/workspace.meta.json.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/meta-json/src/lib/generated", "Extranet" },
+                { "../../typescript/modules/templates/workspace.domain.ts.stg", "../../typescript/modules/libs/apps-extranet/workspace/domain/src/lib/generated", "Extranet" },
             };
 
             var metaPopulation = MetaBuilder.Build();
@@ -57,12 +57,11 @@ namespace Allors.Meta.Generation.Storage
                 }
             }
 
-            var workspaceName = "Default";
-
             for (var i = 0; i < workspace.GetLength(0); i++)
             {
                 var template = workspace[i, 0];
                 var output = workspace[i, 1];
+                var workspaceName = workspace[i, 2];
 
                 Console.WriteLine("-> " + output);
 


### PR DESCRIPTION
## Problem

`Generate/Program.cs` builds the workspace outputs — the dotnet C# workspace, the three `apps-intranet`
TypeScript libs, and the three `apps-extranet` TypeScript libs — in one loop that applied a single
`var workspaceName = "Default"` to **all** of them. So the `libs/apps-extranet/workspace/{meta,meta-json,domain}`
libraries were generated against the full **Default** workspace instead of the restricted **Extranet** workspace
(`Meta/Custom/MetaBuilder.cs` `ExtranetWorkspace`). The commented-out block at the bottom of `Main` shows the
original intent to generate for both `"Default"` and `"Extranet"`.

## Fix

Give each output row its own workspace name (a third column in the `workspace` table) and read it in the loop:
`"Default"` for the dotnet + apps-intranet outputs (unchanged), `"Extranet"` for the three apps-extranet outputs.

## Validation

fix-only — no harness for the generator, and the generated trees
(`typescript/modules/libs/apps-*/workspace/**/generated/**`) are **gitignored/untracked**, so the only tracked
change is `Program.cs` (no committed regeneration).

- `./build.ps1 DotnetAppsGenerate` runs successfully.
- After regenerating, the apps-**extranet** domain has **18** generated files (meta 6,183 lines) vs
  apps-**intranet** **580** files (meta 115,417 lines) — the extranet libs are now the restricted Extranet
  workspace (before the fix they matched intranet, both Default).

CI (`CiDotnetAppsDatabaseTest`) is the regression gate.

Code-review backlog: **BUG-04**.