### PR TITLE
build(versioning): pin v3.1 maintenance line to 3.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.1.0-alpha.{height}",
+  "version": "3.1",
   "publicReleaseRefs": [
-    "^refs/heads/main$",
     "^refs/heads/v\\d+\\.\\d+$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
Pins the `v3.1` maintenance branch's `version.json` to stable `3.1` (mirroring the `v3.0` line) so nbgv stamps `3.1.x` on `v3.1` instead of `3.1.0-alpha`. No code change — `v3.1` was cut at `62704290`. Companion to the `main` -> `3.2.0-alpha` bump.