### PR TITLE
build(versioning): bump main to 3.2.0-alpha after cutting v3.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.1.0-alpha.{height}",
+  "version": "3.2.0-alpha.{height}",
   "publicReleaseRefs": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+\\.\\d+$"


### PR DESCRIPTION
The `v3.1` maintenance line was cut at `62704290`. This moves `main` to the next dev version `3.2.0-alpha.{height}` so `main` and the stable `v3.1` branch don't both report `3.1.x` (same pattern as when `v3.0` was cut and main went to `3.1.0-alpha`). version.json only.