### PR TITLE
feat(apps-worktask): add WorkEffortPurpose to WorkRequirement (backport of #122 to v3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ under a dated version heading.
 
 ### Added
 
+- `WorkRequirement.WorkEffortPurpose` (enumeration Refurbishment / Maintenance / Repair): defaults to
+  **Repair** on init, is copied onto the `WorkTask` created by `CreateWorkTask`, and is mirrored into
+  `WorkRequirementVersion` for version history.
 - Configuration is now delivered from outside the source tree via the **required** `ALLORS_CONFIG_ROOT`
   environment variable. Each server, command-line tool and integration test loads
   `$ALLORS_CONFIG_ROOT/<domain>/appsettings.json` (domain = `core`/`base`/`apps`) through the new

--- a/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
@@ -6,7 +6,9 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System.Linq;
     using Xunit;
+    using TestPopulation;
 
     public class WorkRequirementTests : DomainTest, IClassFixture<Fixture>
     {
@@ -47,6 +49,40 @@ namespace Allors.Database.Domain.Tests
             builder.Build();
 
             Assert.False(this.Derive().HasErrors);
+        }
+
+        [Fact]
+        public void GivenWorkRequirement_WhenBuild_ThenWorkEffortPurposeDefaultsToRepair()
+        {
+            var requirement = new WorkRequirementBuilder(this.Transaction).WithDescription("WorkRequirement").Build();
+
+            this.Transaction.Derive();
+
+            Assert.Equal(new WorkEffortPurposes(this.Transaction).Repair, requirement.WorkEffortPurpose);
+        }
+
+        [Fact]
+        public void GivenWorkRequirementWithPurpose_WhenCreateWorkTask_ThenWorkEffortPurposeIsCopied()
+        {
+            var internalOrganisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
+            var maintenance = new WorkEffortPurposes(this.Transaction).Maintenance; // non-default, proves copy
+
+            var requirement = new WorkRequirementBuilder(this.Transaction)
+                .WithDescription("desc")
+                .WithFixedAsset(serialisedItem)
+                .WithWorkEffortPurpose(maintenance)
+                .Build();
+
+            this.Transaction.Derive();
+
+            requirement.CreateWorkTask();
+
+            this.Transaction.Derive(false);
+
+            var workTask = (WorkTask)requirement.WorkRequirementFulfillmentWhereFullfilledBy.FullfillmentOf;
+
+            Assert.Equal(maintenance, workTask.WorkEffortPurpose);
         }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkRequirement.cs
+++ b/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkRequirement.cs
@@ -29,6 +29,11 @@ namespace Allors.Database.Domain
             {
                 this.ServicedBy = internalOrganisations[0];
             }
+
+            if (!this.ExistWorkEffortPurpose)
+            {
+                this.WorkEffortPurpose = new WorkEffortPurposes(this.Strategy.Transaction).Repair;
+            }
         }
 
         public void AppsDelete(DeletableDelete method)
@@ -73,6 +78,7 @@ namespace Allors.Database.Domain
                 .WithDescription(this.Reason)
                 .WithTakenBy(this.ServicedBy)
                 .WithCustomer(this.Originator)
+                .WithWorkEffortPurpose(this.WorkEffortPurpose)
                 .Build();
 
             new WorkEffortFixedAssetAssignmentBuilder(transaction).WithAssignment(workTask).WithFixedAsset(this.FixedAsset).Build();

--- a/dotnet/Apps/Repository/Domain/Apps/WorkRequirement.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/WorkRequirement.cs
@@ -149,6 +149,14 @@ namespace Allors.Repository
         [Workspace(Default)]
         public bool UnServiceable{ get; set; }
 
+        #region Allors
+        [Id("9f8049e4-1bc6-4ef8-bb9f-de1ee4c17362")]
+        #endregion
+        [Multiplicity(Multiplicity.ManyToOne)]
+        [Indexed]
+        [Workspace(Default)]
+        public WorkEffortPurpose WorkEffortPurpose { get; set; }
+
         #region inherited methods
 
         public void OnBuild() { }

--- a/dotnet/Apps/Repository/Domain/Apps/WorkRequirementVersion.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/WorkRequirementVersion.cs
@@ -63,6 +63,13 @@ namespace Allors.Repository
         [Workspace(Default)]
         public bool UnServiceable { get; set; }
 
+        #region Allors
+        [Id("c7f2a934-8b15-4d62-a0e7-3f9b6d1c8e54")]
+        #endregion
+        [Multiplicity(Multiplicity.ManyToOne)]
+        [Workspace(Default)]
+        public WorkEffortPurpose WorkEffortPurpose { get; set; }
+
         #region inherited methods
 
         public void OnBuild() { }


### PR DESCRIPTION
Backport of #122 to the `v3.1` maintenance line (cherry-picked from `c357edf1a`).

`WorkRequirement` now carries a `WorkEffortPurpose` (Refurbishment / Maintenance / Repair): it defaults to **Repair** in `OnInit`, is copied onto the `WorkTask` created by `CreateWorkTask`, and is mirrored onto `WorkRequirementVersion` for version history. Includes the two domain tests from #122 (default-to-Repair and copy-on-CreateWorkTask).

`v3.1` was branched from `main` before #122 merged, so this carries the change onto the release line. The cherry-pick was clean except for `CHANGELOG.md`; resolved to add **only** the `WorkRequirement.WorkEffortPurpose` entry (the unrelated Identity / Workspace-signals entries that surround it on `main` are not on v3.1 and were not part of #122).

No generated files committed — `./build.sh Generate` runs in CI.

**Files (+60 / −0):**
- `CHANGELOG.md`
- `dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs`
- `dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkRequirement.cs`
- `dotnet/Apps/Repository/Domain/Apps/WorkRequirement.cs`
- `dotnet/Apps/Repository/Domain/Apps/WorkRequirementVersion.cs`
