### PR TITLE
fix(apps): seed PreferNotToSay GenderType under its own id [BUG-20]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The `GenderTypes` setup seeded the **Prefer not to say** gender type under the `Other` id. Because a later
+  `merge(...)` for the same id wins, `Other` was overwritten (its `Name` became "Prefer not to say") and
+  `GenderTypes.PreferNotToSay` was never created (resolved to `null`). The second `merge(...)` now uses
+  `PreferNotToSayId`, so both `Other` and `PreferNotToSay` are seeded correctly.
 - The test-population `SalesInvoiceItemBuilder.WithPartItemDefaults` built a **product** item, not a part item.
   It was a copy of `WithProductItemDefaults` — using the `ProductItem` invoice-item-type and `.WithProduct(...)`
   — despite its name and the `salesInvoiceItem_Part` it populates on the sample sales invoices. It now uses the

--- a/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
@@ -37,5 +37,20 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Empty(diff);
         }
+
+        [Fact]
+        public void GenderTypesAreSeeded()
+        {
+            var transaction = this.Transaction;
+            var database = transaction.Database;
+
+            new Setup(database, new Config()).Apply();
+
+            var genderTypes = new GenderTypes(transaction);
+
+            Assert.Equal("Other", genderTypes.Other.Name);
+            Assert.NotNull(genderTypes.PreferNotToSay);
+            Assert.Equal("Prefer not to say", genderTypes.PreferNotToSay.Name);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Relation/GenderTypes.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Relation/GenderTypes.cs
@@ -54,7 +54,7 @@ namespace Allors.Database.Domain
                 v.IsActive = true;
             });
 
-            merge(OtherId, v =>
+            merge(PreferNotToSayId, v =>
             {
                 v.Name = "Prefer not to say";
                 localisedName.Set(v, dutchLocale, "Zeg liever niet");


### PR DESCRIPTION
## Summary
`GenderTypes.AppsSetup` seeded the **Prefer not to say** gender type under the `Other` id (`merge(OtherId, …)`). Because the last `merge` for a given id wins, this:
- **overwrote `Other`** — its `Name` became `"Prefer not to say"`, and
- **never created `PreferNotToSay`** (`GenderTypes.PreferNotToSay` resolved to `null`).

The fix passes `PreferNotToSayId` to that fourth `merge`, so both `Other` and `PreferNotToSay` are seeded correctly.

## Test
Adds `SetupTests.GenderTypesAreSeeded` (mirrors the existing `Twice()` idiom — applies `Setup`, then queries the seeded cache). It asserts `Other.Name == "Other"`, `PreferNotToSay != null`, and `PreferNotToSay.Name == "Prefer not to say"`.

- **RED** on un-fixed code (right reason): `Expected: "Other" / Actual: "Prefer not to say"`.
- **GREEN** after the fix.

One-line production change in `GenderTypes.cs`; no meta/generated changes.