### PR TITLE
fix(apps): seed Reviewed EmploymentApplicationStatus under its own id [BUG-27]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The `EmploymentApplicationStatuses` setup seeded the **Reviewed** status under the `Received` id. Because a
+  later `merge(...)` for the same id wins, `Received` was overwritten (its `Name` became "Reviewed") and
+  `EmploymentApplicationStatuses.Reviewed` was never created (resolved to `null`). The second `merge(...)` now
+  uses `ReviewedId`, so both `Received` and `Reviewed` are seeded correctly.
 - The `GenderTypes` setup seeded the **Prefer not to say** gender type under the `Other` id. Because a later
   `merge(...)` for the same id wins, `Other` was overwritten (its `Name` became "Prefer not to say") and
   `GenderTypes.PreferNotToSay` was never created (resolved to `null`). The second `merge(...)` now uses

--- a/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
@@ -52,5 +52,20 @@ namespace Allors.Database.Domain.Tests
             Assert.NotNull(genderTypes.PreferNotToSay);
             Assert.Equal("Prefer not to say", genderTypes.PreferNotToSay.Name);
         }
+
+        [Fact]
+        public void EmploymentApplicationStatusesAreSeeded()
+        {
+            var transaction = this.Transaction;
+            var database = transaction.Database;
+
+            new Setup(database, new Config()).Apply();
+
+            var statuses = new EmploymentApplicationStatuses(transaction);
+
+            Assert.Equal("Received", statuses.Received.Name);
+            Assert.NotNull(statuses.Reviewed);
+            Assert.Equal("Reviewed", statuses.Reviewed.Name);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/HumanResource/EmploymentApplicationStatuses.cs
+++ b/dotnet/Apps/Database/Domain/Apps/HumanResource/EmploymentApplicationStatuses.cs
@@ -46,7 +46,7 @@ namespace Allors.Database.Domain
                 v.IsActive = true;
             });
 
-            merge(ReceivedId, v =>
+            merge(ReviewedId, v =>
             {
                 v.Name = "Reviewed";
                 localisedName.Set(v, dutchLocale, "Gereviewed");


### PR DESCRIPTION
## Summary
`EmploymentApplicationStatuses.AppsSetup` seeded the **Reviewed** status under the `Received` id (`merge(ReceivedId, …)` while setting `Name = "Reviewed"`). Because the last `merge` for a given id wins, this:
- **overwrote `Received`** — its `Name` became `"Reviewed"`, and
- **never created `Reviewed`** (`EmploymentApplicationStatuses.Reviewed` resolved to `null`).

The fix passes `ReviewedId` to that second `merge`, so both `Received` and `Reviewed` are seeded correctly.

## Test
Adds `SetupTests.EmploymentApplicationStatusesAreSeeded` (same pattern as the `GenderTypesAreSeeded` seed test). It asserts `Received.Name == "Received"`, `Reviewed != null`, and `Reviewed.Name == "Reviewed"`.

- **RED** on un-fixed code (right reason): `Expected: "Received" / Actual: "Reviewed"`.
- **GREEN** after the fix.

One-line production change; no meta/generated changes. Sibling of #153 (BUG-20).