### PR TITLE
fix(apps): seed FrSasu LegalForm under its own id [BUG-29]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The `LegalForms` setup seeded the **FR - SASU** legal form under the `FrSas` id. Because a later
+  `merge(...)` for the same id wins, `FrSas` was overwritten (its `Description` became "FR - SASU") and
+  `LegalForms.FrSasu` was never created (resolved to `null`). The second `merge(...)` now uses `FrSasuId`,
+  so both `FrSas` and `FrSasu` are seeded correctly.
 - The `EmploymentApplicationStatuses` setup seeded the **Reviewed** status under the `Received` id. Because a
   later `merge(...)` for the same id wins, `Received` was overwritten (its `Name` became "Reviewed") and
   `EmploymentApplicationStatuses.Reviewed` was never created (resolved to `null`). The second `merge(...)` now

--- a/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Population/SetupTests.cs
@@ -67,5 +67,20 @@ namespace Allors.Database.Domain.Tests
             Assert.NotNull(statuses.Reviewed);
             Assert.Equal("Reviewed", statuses.Reviewed.Name);
         }
+
+        [Fact]
+        public void LegalFormsAreSeeded()
+        {
+            var transaction = this.Transaction;
+            var database = transaction.Database;
+
+            new Setup(database, new Config()).Apply();
+
+            var legalForms = new LegalForms(transaction);
+
+            Assert.Equal("FR - SAS", legalForms.FrSas.Description);
+            Assert.NotNull(legalForms.FrSasu);
+            Assert.Equal("FR - SASU", legalForms.FrSasu.Description);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Relation/LegalForms.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Relation/LegalForms.cs
@@ -112,7 +112,7 @@ namespace Allors.Database.Domain
 
             merge(FrSaId, v => v.Description = "FR - SA");
             merge(FrSasId, v => v.Description = "FR - SAS");
-            merge(FrSasId, v => v.Description = "FR - SASU");
+            merge(FrSasuId, v => v.Description = "FR - SASU");
             merge(FrSarlId, v => v.Description = "FR - SARL");
             merge(FrSncId, v => v.Description = "FR - SNC");
             merge(FrScsId, v => v.Description = "FR - SCS");


### PR DESCRIPTION
## Summary
`LegalForms.AppsSetup` seeded the **FR - SASU** legal form under the `FrSas` id (`merge(FrSasId, …)` while setting `Description = "FR - SASU"`). Because the last `merge` for a given id wins, this:
- **overwrote `FrSas`** — its `Description` became `"FR - SASU"`, and
- **never created `FrSasu`** (`LegalForms.FrSasu` resolved to `null`).

The fix passes `FrSasuId` to that `merge`, so both `FrSas` and `FrSasu` are seeded correctly.

## Test
Adds `SetupTests.LegalFormsAreSeeded` (same pattern as the `GenderTypesAreSeeded`/`EmploymentApplicationStatusesAreSeeded` seed tests). It asserts `FrSas.Description == "FR - SAS"`, `FrSasu != null`, and `FrSasu.Description == "FR - SASU"`.

- **RED** on un-fixed code (right reason): `Expected: "FR - SAS" / Actual: "FR - SASU"`.
- **GREEN** after the fix.

One-line production change; no meta/generated changes. Completes the seed-id trio (#153 BUG-20, #154 BUG-27, this BUG-29).