### PR TITLE
fix(apps): append billing address lines in WorkTask CustomerModel [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Work Task print `CustomerModel` overwrote the billing address instead of appending it. Each
+  `if (Address2/Address3 present)` block **assigned** `this.BillingAddress = $"\n{AddressN}"` rather than
+  appending, so `Address1` (and `Address2`) were discarded and a leading newline remained — the printed
+  billing address showed only the last present line. The two assignments are now `+=`, so the billing address
+  joins the present lines as `Address1\nAddress2\nAddress3`.
 - The `LegalForms` setup seeded the **FR - SASU** legal form under the `FrSas` id. Because a later
   `merge(...)` for the same id wins, `FrSas` was overwritten (its `Description` became "FR - SASU") and
   `LegalForms.FrSasu` was never created (resolved to `null`). The second `merge(...)` now uses `FrSasuId`,

--- a/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
@@ -96,6 +96,28 @@ namespace Allors.Database.Domain.Tests.Print
             Assert.Single(model.TimeEntriesByBillingRate);
         }
 
+        [Fact]
+        public void GivenCustomerWithMultiLineBillingAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined()
+        {
+            var purposes = new ContactMechanismPurposes(this.Transaction);
+
+            var customer = new OrganisationBuilder(this.Transaction).WithName("Customer").Build();
+
+            var usa = new Countries(this.Transaction).Extent().First(c => c.IsoCode.Equals("US"));
+            var michigan = new StateBuilder(this.Transaction).WithName("Michigan").WithCountry(usa).Build();
+            var northville = new CityBuilder(this.Transaction).WithName("Northville").WithState(michigan).Build();
+            var postalCode = new PostalCodeBuilder(this.Transaction).WithCode("48167").Build();
+            var billingAddress = this.CreatePostalAddress("123 Street", "Suite S1", "Floor 3", northville, postalCode);
+
+            this.CreatePartyContactMechanism(customer, purposes.BillingAddress, billingAddress);
+
+            this.Transaction.Derive();
+
+            var model = new CustomerModel(customer);
+
+            Assert.Equal("123 Street\nSuite S1\nFloor 3", model.BillingAddress);
+        }
+
         private Part CreatePart(string id) =>
             new NonUnifiedPartBuilder(this.Transaction)
             .WithProductIdentification(new PartNumberBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Print/Worktask/CustomerModel.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Print/Worktask/CustomerModel.cs
@@ -19,12 +19,12 @@ namespace Allors.Database.Domain.Print.WorkTaskModel
                     this.BillingAddress = postalBillingAddress.Address1;
                     if (!string.IsNullOrWhiteSpace(postalBillingAddress.Address2))
                     {
-                        this.BillingAddress = $"\n{postalBillingAddress.Address2}";
+                        this.BillingAddress += $"\n{postalBillingAddress.Address2}";
                     }
 
                     if (!string.IsNullOrWhiteSpace(postalBillingAddress.Address3))
                     {
-                        this.BillingAddress = $"\n{postalBillingAddress.Address3}";
+                        this.BillingAddress += $"\n{postalBillingAddress.Address3}";
                     }
 
                     this.BillingCity = postalBillingAddress.Locality;


### PR DESCRIPTION
## Summary
The Work Task print `CustomerModel` built the billing address by **assigning** each present line instead of appending:

```csharp
this.BillingAddress = postalBillingAddress.Address1;
if (Address2 present) this.BillingAddress = $"\n{Address2}";   // overwrites
if (Address3 present) this.BillingAddress = $"\n{Address3}";   // overwrites
```

So when `Address2`/`Address3` were present, `Address1` (and `Address2`) were discarded and a leading newline remained — a three-line billing address printed as only `"\nAddress3"`.

The two conditionals now use `+=`, so the present lines join as `Address1\nAddress2\nAddress3`.

## Test
Adds `WorkTaskTests.GivenCustomerWithMultiLineBillingAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined`, reusing the class's existing `CreatePostalAddress`/`CreatePartyContactMechanism` helpers. (The existing `GivenWorkEffort_…` test builds a multi-line address but never asserted the address strings, so this was uncaught.)

- **RED** on un-fixed code (right reason): `Expected "123 Street\nSuite S1\nFloor 3" / Actual "\nFloor 3"`.
- **GREEN** after the fix.

## Scope
BillingAddress only. The identical `ShippingAddress` block in the same file is a follow-up PR (BUG-08). Sibling print-address bugs: BUG-07 (`IssuerModel`), BUG-18 (`BillToModel`), and BUG-28 (`TimeEntryModel` time format).