### PR TITLE
fix(apps): append shipping address lines in WorkTask CustomerModel [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The Work Task print `CustomerModel` overwrote the **shipping** address the same way as the billing address:
+  each `if (Address2/Address3 present)` block **assigned** `this.ShippingAddress = $"\n{AddressN}"` rather than
+  appending, so `Address1` (and `Address2`) were discarded and a leading newline remained. The two assignments
+  are now `+=`, so the shipping address joins the present lines as `Address1\nAddress2\nAddress3`.
 - The Work Task print `CustomerModel` overwrote the billing address instead of appending it. Each
   `if (Address2/Address3 present)` block **assigned** `this.BillingAddress = $"\n{AddressN}"` rather than
   appending, so `Address1` (and `Address2`) were discarded and a leading newline remained — the printed

--- a/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
@@ -118,6 +118,28 @@ namespace Allors.Database.Domain.Tests.Print
             Assert.Equal("123 Street\nSuite S1\nFloor 3", model.BillingAddress);
         }
 
+        [Fact]
+        public void GivenCustomerWithMultiLineShippingAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined()
+        {
+            var purposes = new ContactMechanismPurposes(this.Transaction);
+
+            var customer = new OrganisationBuilder(this.Transaction).WithName("Customer").Build();
+
+            var usa = new Countries(this.Transaction).Extent().First(c => c.IsoCode.Equals("US"));
+            var michigan = new StateBuilder(this.Transaction).WithName("Michigan").WithCountry(usa).Build();
+            var northville = new CityBuilder(this.Transaction).WithName("Northville").WithState(michigan).Build();
+            var postalCode = new PostalCodeBuilder(this.Transaction).WithCode("48167").Build();
+            var shippingAddress = this.CreatePostalAddress("123 Street", "Suite S1", "Dock D1", northville, postalCode);
+
+            this.CreatePartyContactMechanism(customer, purposes.ShippingAddress, shippingAddress);
+
+            this.Transaction.Derive();
+
+            var model = new CustomerModel(customer);
+
+            Assert.Equal("123 Street\nSuite S1\nDock D1", model.ShippingAddress);
+        }
+
         private Part CreatePart(string id) =>
             new NonUnifiedPartBuilder(this.Transaction)
             .WithProductIdentification(new PartNumberBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Print/Worktask/CustomerModel.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Print/Worktask/CustomerModel.cs
@@ -42,12 +42,12 @@ namespace Allors.Database.Domain.Print.WorkTaskModel
                     this.ShippingAddress = shippingAddress.Address1;
                     if (!string.IsNullOrWhiteSpace(shippingAddress.Address2))
                     {
-                        this.ShippingAddress = $"\n{shippingAddress.Address2}";
+                        this.ShippingAddress += $"\n{shippingAddress.Address2}";
                     }
 
                     if (!string.IsNullOrWhiteSpace(shippingAddress.Address3))
                     {
-                        this.ShippingAddress = $"\n{shippingAddress.Address3}";
+                        this.ShippingAddress += $"\n{shippingAddress.Address3}";
                     }
 
                     this.ShippingCity = shippingAddress.Locality;


### PR DESCRIPTION
## Summary
Sibling of #156 (BUG-09), for the **shipping** address. The Work Task print `CustomerModel` built `ShippingAddress` by **assigning** each present line instead of appending:

```csharp
this.ShippingAddress = shippingAddress.Address1;
if (Address2 present) this.ShippingAddress = $"\n{Address2}";   // overwrites
if (Address3 present) this.ShippingAddress = $"\n{Address3}";   // overwrites
```

So `Address1`/`Address2` were discarded and a leading newline remained — a three-line shipping address printed as only `"\nAddress3"`. The two conditionals now use `+=`, joining the present lines as `Address1\nAddress2\nAddress3`.

## Test
Adds `WorkTaskTests.GivenCustomerWithMultiLineShippingAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined`, reusing the class's existing helpers.

- **RED** on un-fixed code (right reason): `Expected "123 Street\nSuite S1\nDock D1" / Actual "\nDock D1"`.
- **GREEN** after the fix.

Completes the `CustomerModel` address fix (BillingAddress = #156). Remaining print-address siblings: BUG-07 (`IssuerModel`), BUG-18 (`BillToModel`); plus BUG-28 (`TimeEntryModel` time format).