### PR TITLE
fix(apps): append issuer address lines in ProductQuote IssuerModel [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Product Quote print `IssuerModel` overwrote the issuer's address instead of appending it. Each
+  `if (Address2/Address3 present)` block **assigned** `this.Address = $"\n{AddressN}"` rather than appending,
+  so the issuer's `GeneralCorrespondence` `Address1` (and `Address2`) were discarded and a leading newline
+  remained. The two assignments are now `+=`, so the address joins the present lines as
+  `Address1\nAddress2\nAddress3`.
 - The Work Task print `CustomerModel` overwrote the **shipping** address the same way as the billing address:
   each `if (Address2/Address3 present)` block **assigned** `this.ShippingAddress = $"\n{AddressN}"` rather than
   appending, so `Address1` (and `Address2`) were discarded and a leading newline remained. The two assignments

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -6,7 +6,9 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System.Collections.Generic;
     using System.Linq;
+    using Domain.Print.ProductQuoteModel;
     using Resources;
     using TestPopulation;
     using Xunit;
@@ -40,6 +42,27 @@ namespace Allors.Database.Domain.Tests
             builder.Build();
 
             Assert.False(this.Derive().HasErrors);
+        }
+
+        [Fact]
+        public void GivenIssuerWithMultiLineGeneralCorrespondence_WhenCreatingModel_ThenAllAddressLinesAreJoined()
+        {
+            var generalAddress = (PostalAddress)this.InternalOrganisation.GeneralCorrespondence;
+            generalAddress.Address1 = "123 Street";
+            generalAddress.Address2 = "Suite S1";
+            generalAddress.Address3 = "Floor 3";
+
+            var party = new PersonBuilder(this.Transaction).WithLastName("party").Build();
+            var quote = new ProductQuoteBuilder(this.Transaction)
+                .WithReceiver(party)
+                .WithFullfillContactMechanism(new WebAddressBuilder(this.Transaction).WithElectronicAddressString("test").Build())
+                .Build();
+
+            this.Transaction.Derive();
+
+            var model = new IssuerModel(quote, new Dictionary<string, byte[]>());
+
+            Assert.Equal("123 Street\nSuite S1\nFloor 3", model.Address);
         }
 
         [Fact]

--- a/dotnet/Apps/Database/Domain/Apps/Print/ProductQuote/IssuerModel.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Print/ProductQuote/IssuerModel.cs
@@ -37,12 +37,12 @@ namespace Allors.Database.Domain.Print.ProductQuoteModel
                     this.Address = generalAddress.Address1;
                     if (!string.IsNullOrWhiteSpace(generalAddress.Address2))
                     {
-                        this.Address = $"\n{generalAddress.Address2}";
+                        this.Address += $"\n{generalAddress.Address2}";
                     }
 
                     if (!string.IsNullOrWhiteSpace(generalAddress.Address3))
                     {
-                        this.Address = $"\n{generalAddress.Address3}";
+                        this.Address += $"\n{generalAddress.Address3}";
                     }
 
                     this.City = generalAddress.Locality;


### PR DESCRIPTION
## Summary
The Product Quote print `IssuerModel` built the issuer's address by **assigning** each present line instead of appending:

```csharp
this.Address = generalAddress.Address1;
if (Address2 present) this.Address = $"\n{Address2}";   // overwrites
if (Address3 present) this.Address = $"\n{Address3}";   // overwrites
```

So `Address1`/`Address2` of the issuer's `GeneralCorrespondence` were discarded and a leading newline remained. The two conditionals now use `+=`, joining the present lines as `Address1\nAddress2\nAddress3`.

Same family as #156 (BUG-09) / #157 (BUG-08), for the ProductQuote issuer model.

## Test
Adds `ProductQuoteTests.GivenIssuerWithMultiLineGeneralCorrespondence_WhenCreatingModel_ThenAllAddressLinesAreJoined`: gives the issuer (internal organisation) a 3-line `GeneralCorrespondence` `PostalAddress`, builds a `ProductQuote`, then constructs `IssuerModel` and asserts the joined address.

- **RED** on un-fixed code (right reason): `Expected "123 Street\nSuite S1\nFloor 3" / Actual "\nFloor 3"`.
- **GREEN** after the fix.

Remaining print-address siblings: BUG-18 (`BillToModel`, same ProductQuoteTests home), BUG-28 (`TimeEntryModel` time format).