### PR TITLE
fix(apps): use 24-hour clock for WorkTask TimeEntryModel times [BUG-28]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- The Work Task print `TimeEntryModel` formatted `FromTime`/`ThroughTime` with the 12-hour clock pattern
+  `"hh:mm:ss"` and no AM/PM designator, so afternoon times collapsed onto the morning (e.g. 13:30 printed as
+  "01:30:00"). Both now use the 24-hour pattern `"HH:mm:ss"`.
 - The Product Quote print `IssuerModel` overwrote the issuer's address instead of appending it. Each
   `if (Address2/Address3 present)` block **assigned** `this.Address = $"\n{AddressN}"` rather than appending,
   so the issuer's `GeneralCorrespondence` `Address1` (and `Address2`) were discarded and a leading newline

--- a/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Print/WorkTaskTests.cs
@@ -140,6 +140,20 @@ namespace Allors.Database.Domain.Tests.Print
             Assert.Equal("123 Street\nSuite S1\nDock D1", model.ShippingAddress);
         }
 
+        [Fact]
+        public void GivenAfternoonTimeEntry_WhenCreatingModel_ThenTimesUse24HourClock()
+        {
+            var timeEntry = new TimeEntryBuilder(this.Transaction)
+                .WithFromDate(new DateTime(2024, 1, 2, 13, 30, 0, DateTimeKind.Utc))
+                .WithThroughDate(new DateTime(2024, 1, 2, 14, 45, 0, DateTimeKind.Utc))
+                .Build();
+
+            var model = new TimeEntryModel(timeEntry);
+
+            Assert.Equal("13:30:00", model.FromTime);
+            Assert.Equal("14:45:00", model.ThroughTime);
+        }
+
         private Part CreatePart(string id) =>
             new NonUnifiedPartBuilder(this.Transaction)
             .WithProductIdentification(new PartNumberBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Print/Worktask/TimeEntryModel.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Print/Worktask/TimeEntryModel.cs
@@ -23,9 +23,9 @@ namespace Allors.Database.Domain.Print.WorkTaskModel
             this.Description = timeEntry.Description;
             this.IsBillable = timeEntry.IsBillable == true;
             this.FromDate = timeEntry.FromDate.ToString("yyyy-MM-dd");
-            this.FromTime = timeEntry.FromDate.ToString("hh:mm:ss");
+            this.FromTime = timeEntry.FromDate.ToString("HH:mm:ss");
             this.ThroughDate = timeEntry.ThroughDate?.ToString("yyyy-MM-dd");
-            this.ThroughTime = timeEntry.ThroughDate?.ToString("hh:mm:ss");
+            this.ThroughTime = timeEntry.ThroughDate?.ToString("HH:mm:ss");
         }
 
         public decimal AmountOfTime { get; }


### PR DESCRIPTION
## Summary
The Work Task print `TimeEntryModel` formatted `FromTime`/`ThroughTime` with the **12-hour** pattern `"hh:mm:ss"` and no AM/PM (`tt`) designator:

```csharp
this.FromTime = timeEntry.FromDate.ToString("hh:mm:ss");
this.ThroughTime = timeEntry.ThroughDate?.ToString("hh:mm:ss");
```

So afternoon times collapsed onto the morning — 13:30 printed as `"01:30:00"`. Both now use the **24-hour** pattern `"HH:mm:ss"`. (The date parts already used `"yyyy-MM-dd"` and are unchanged.)

## Test
Adds `WorkTaskTests.GivenAfternoonTimeEntry_WhenCreatingModel_ThenTimesUse24HourClock`: a minimal `TimeEntry` with afternoon `FromDate`/`ThroughDate`, then constructs `TimeEntryModel` and asserts the rendered times.

- **RED** on un-fixed code (right reason): `Expected "13:30:00" / Actual "01:30:00"`.
- **GREEN** after the fix.

Last of the WorkTask/ProductQuote print-model cluster (with #156/#157/#158).