### PR TITLE
fix(apps): append bill-to address lines in ProductQuote BillToModel [BUG-18]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- The Product Quote print `BillToModel` overwrote the bill-to address instead of appending it. Each
+  `if (Address2/Address3 present)` block **assigned** `this.Address = $"\n{AddressN}"` rather than appending,
+  so the `FullfillContactMechanism` postal address `Address1` (and `Address2`) were discarded and a leading
+  newline remained. The two assignments are now `+=`, so the address joins the present lines as
+  `Address1\nAddress2\nAddress3`.
 - The Work Task print `TimeEntryModel` formatted `FromTime`/`ThroughTime` with the 12-hour clock pattern
   `"hh:mm:ss"` and no AM/PM designator, so afternoon times collapsed onto the morning (e.g. 13:30 printed as
   "01:30:00"). Both now use the 24-hour pattern `"HH:mm:ss"`.

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -66,6 +66,35 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenBillToWithMultiLinePostalAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined()
+        {
+            var usa = new Countries(this.Transaction).Extent().First(c => c.IsoCode.Equals("US"));
+            var michigan = new StateBuilder(this.Transaction).WithName("Michigan").WithCountry(usa).Build();
+            var northville = new CityBuilder(this.Transaction).WithName("Northville").WithState(michigan).Build();
+            var postalCode = new PostalCodeBuilder(this.Transaction).WithCode("48167").Build();
+            var postalAddress = new PostalAddressBuilder(this.Transaction)
+                .WithAddress1("123 Street")
+                .WithAddress2("Suite S1")
+                .WithAddress3("Floor 3")
+                .WithPostalAddressBoundary(postalCode)
+                .WithPostalAddressBoundary(northville)
+                .WithPostalAddressBoundary(usa)
+                .Build();
+
+            var party = new PersonBuilder(this.Transaction).WithLastName("party").Build();
+            var quote = new ProductQuoteBuilder(this.Transaction)
+                .WithReceiver(party)
+                .WithFullfillContactMechanism(postalAddress)
+                .Build();
+
+            this.Transaction.Derive();
+
+            var model = new BillToModel(quote, new Dictionary<string, byte[]>());
+
+            Assert.Equal("123 Street\nSuite S1\nFloor 3", model.Address);
+        }
+
+        [Fact]
         public void GivenProposal_WhenDeriving_ThenRequiredRelationsMustExist()
         {
             var party = new PersonBuilder(this.Transaction).WithLastName("party").Build();

--- a/dotnet/Apps/Database/Domain/Apps/Print/ProductQuote/BillToModel.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Print/ProductQuote/BillToModel.cs
@@ -20,12 +20,12 @@ namespace Allors.Database.Domain.Print.ProductQuoteModel
                 this.Address = postalAddress.Address1;
                 if (!string.IsNullOrWhiteSpace(postalAddress.Address2))
                 {
-                    this.Address = $"\n{postalAddress.Address2}";
+                    this.Address += $"\n{postalAddress.Address2}";
                 }
 
                 if (!string.IsNullOrWhiteSpace(postalAddress.Address3))
                 {
-                    this.Address = $"\n{postalAddress.Address3}";
+                    this.Address += $"\n{postalAddress.Address3}";
                 }
 
                 this.City = postalAddress.Locality;


### PR DESCRIPTION
## Summary
The Product Quote print `BillToModel` built the bill-to address (from `quote.FullfillContactMechanism` when it is a `PostalAddress`) by **assigning** each present line instead of appending:

```csharp
this.Address = postalAddress.Address1;
if (Address2 present) this.Address = $"\n{Address2}";   // overwrites
if (Address3 present) this.Address = $"\n{Address3}";   // overwrites
```

So `Address1`/`Address2` were discarded and a leading newline remained. The two conditionals now use `+=`, joining the present lines as `Address1\nAddress2\nAddress3`. (The separate `ElectronicAddress` branch is a single correct assignment, unchanged.)

Completes the print-address family with #156/#157/#158.

## Test
Adds `ProductQuoteTests.GivenBillToWithMultiLinePostalAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined`: builds a `ProductQuote` with a 3-line `PostalAddress` as its `FullfillContactMechanism`, then constructs `BillToModel` and asserts the joined address.

- **RED** on un-fixed code (right reason): `Expected "123 Street\nSuite S1\nFloor 3" / Actual "\nFloor 3"`.
- **GREEN** after the fix.