### PR TITLE
fix(apps): type CapitalBudget version relations as CapitalBudgetVersion [BUG-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The repository meta typed `CapitalBudget.CurrentVersion`/`AllVersions` as `SalesOrderVersion` /
+  `SalesOrderVersion[]` (a copy-paste error), even though `CapitalBudget : Budget, Versioned` versions into
+  `CapitalBudgetVersion`. Both relations are now typed `CapitalBudgetVersion`, so CapitalBudget version history
+  is correctly typed. The relation ids are unchanged.
 - The Product Quote print `BillToModel` overwrote the bill-to address instead of appending it. Each
   `if (Address2/Address3 present)` block **assigned** `this.Address = $"\n{AddressN}"` rather than appending,
   so the `FullfillContactMechanism` postal address `Address1` (and `Address2`) were discarded and a leading

--- a/dotnet/Apps/Repository/Domain/Apps/CapitalBudget.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/CapitalBudget.cs
@@ -69,7 +69,7 @@ namespace Allors.Repository
         #endregion
         [Multiplicity(Multiplicity.OneToOne)]
         [Workspace(Default)]
-        public SalesOrderVersion CurrentVersion { get; set; }
+        public CapitalBudgetVersion CurrentVersion { get; set; }
 
         #region Allors
         [Id("31B6B215-5115-4B2C-A5A9-11031A38D533")]
@@ -77,7 +77,7 @@ namespace Allors.Repository
         #endregion
         [Multiplicity(Multiplicity.OneToMany)]
         [Workspace(Default)]
-        public SalesOrderVersion[] AllVersions { get; set; }
+        public CapitalBudgetVersion[] AllVersions { get; set; }
         #endregion
 
         #region inherited methods


### PR DESCRIPTION
## Summary
`CapitalBudget : Budget, Versioned` declared its versioning relations with the **wrong target type** — a copy-paste from the SalesOrder meta:

```csharp
[Multiplicity(OneToOne)]  … public SalesOrderVersion   CurrentVersion { get; set; }
[Multiplicity(OneToMany)] … public SalesOrderVersion[] AllVersions    { get; set; }
```

`CapitalBudgetVersion` is the correct version type for `CapitalBudget` (and already exists). Both relations are now typed `CapitalBudgetVersion`. The relation `Id`s (`7DDE0157-…`, `31B6B215-…`) are **unchanged** — this is a target-type correction only.

## Validation (fix-only: regen + build)
This is a repository-meta change. No behavior test: a test asserting `CapitalBudgetVersion` cannot compile against the un-fixed generated code (which types it `SalesOrderVersion`). Validated by:

- `.\build.ps1 DotnetAppsGenerate` → **Succeeded**
- `dotnet build …/Domain.Tests` → **0 errors** (Domain + Meta + generated + tests compile with the corrected type)

The generated tree is gitignored, so the diff is the repository meta `.cs` only.

Model change approved before implementation. Sibling meta fix: BUG-26 (`RequestVersion.RequestState` OneToOne → ManyToOne).