### PR TITLE
fix(apps): make RequestVersion.RequestState ManyToOne [BUG-26]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- The repository meta declared `RequestVersion.RequestState` as `[Multiplicity(OneToOne)]`, unlike every other
+  version-state relation (e.g. `CustomerShipmentVersion.ShipmentState` is `ManyToOne`). A `OneToOne` state would
+  break once a second `RequestVersion` referenced the same `RequestState` singleton; it is now `ManyToOne`. The
+  relation id is unchanged.
 - The repository meta typed `CapitalBudget.CurrentVersion`/`AllVersions` as `SalesOrderVersion` /
   `SalesOrderVersion[]` (a copy-paste error), even though `CapitalBudget : Budget, Versioned` versions into
   `CapitalBudgetVersion`. Both relations are now typed `CapitalBudgetVersion`, so CapitalBudget version history

--- a/dotnet/Apps/Repository/Domain/Apps/RequestVersion.cs
+++ b/dotnet/Apps/Repository/Domain/Apps/RequestVersion.cs
@@ -27,7 +27,7 @@ namespace Allors.Repository
         [Id("649F4856-6B08-4AC1-B4CB-87A1CCAFAAF8")]
 
         #endregion
-        [Multiplicity(Multiplicity.OneToOne)]
+        [Multiplicity(Multiplicity.ManyToOne)]
         [Workspace(Default)]
         RequestState RequestState { get; set; }
 


### PR DESCRIPTION
## Summary
`RequestVersion.RequestState` was declared `[Multiplicity(OneToOne)]`, unlike every other version-state relation (confirmed: `CustomerShipmentVersion.ShipmentState` is `ManyToOne`).

`RequestState` is a shared singleton object state, so a version's reference to it must be **`ManyToOne`** — many `RequestVersion`s share the same state singleton. `OneToOne` is the bug: it would break as soon as a second `RequestVersion` referenced an already-used `RequestState`. Now `ManyToOne`; the relation `Id` (`649F4856-…`) is unchanged.

## Validation (fix-only: regen + build)
Repository-meta multiplicity change; no behavior test.

- `.\build.ps1 DotnetAppsGenerate` → **Succeeded**
- `dotnet build …/Domain.Tests` → **0 errors**

Generated tree is gitignored, so the diff is the repository meta `.cs` only. Model change approved before implementation. Sibling: BUG-12 (`CapitalBudget` version type, PR #161).