### PR TITLE
fix(apps): copy SalesInvoice item sales terms to the new item, not the source [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoice.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied)
+  item: the per-item loop called `salesInvoiceItem.AddSalesTerm(...)` (the item being iterated) rather than
+  `invoiceItem.AddSalesTerm(...)` (the copy). As a result the copied invoice's items had no sales terms and the
+  source items' terms were duplicated. The four `Inco`/`Invoice`/`Order`/`QuoteTerm` branches now add to
+  `invoiceItem`. (The order-level sales-term loop already correctly targeted the copy.)
 - The repository meta declared `RequestVersion.RequestState` as `[Multiplicity(OneToOne)]`, unlike every other
   version-state relation (e.g. `CustomerShipmentVersion.ShipmentState` is `ManyToOne`). A `OneToOne` state would
   break once a second `RequestVersion` referenced the same `RequestState` singleton; it is now `ManyToOne`. The

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -587,6 +587,51 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenSalesInvoiceItemWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewItemNotSource()
+        {
+            var good = new NonUnifiedGoods(this.Transaction).FindBy(this.M.Good.Name, "good1");
+            var productItem = new InvoiceItemTypes(this.Transaction).ProductItem;
+
+            var customer = new OrganisationBuilder(this.Transaction).WithName("customer").Build();
+            var contactMechanism = new PostalAddressBuilder(this.Transaction)
+                .WithAddress1("Haverwerf 15")
+                .WithLocality("Mechelen")
+                .WithCountry(new Countries(this.Transaction).FindBy(this.M.Country.IsoCode, "BE"))
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer).Build();
+
+            this.Transaction.Derive();
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction)
+                .WithBillToCustomer(customer)
+                .WithAssignedBillToContactMechanism(contactMechanism)
+                .Build();
+
+            var item = new SalesInvoiceItemBuilder(this.Transaction)
+                .WithInvoiceItemType(productItem)
+                .WithProduct(good)
+                .WithQuantity(1)
+                .WithAssignedUnitPrice(8)
+                .Build();
+
+            item.AddSalesTerm(new InvoiceTermBuilder(this.Transaction)
+                .WithTermType(new InvoiceTermTypes(this.Transaction).PaymentNetDays)
+                .WithTermValue("30")
+                .Build());
+
+            invoice.AddSalesInvoiceItem(item);
+
+            this.Transaction.Derive();
+
+            var copy = invoice.AppsCopy(new SalesInvoiceCopy(invoice));
+
+            // The item-level sales term must be copied onto the new item, not added to the source item.
+            Assert.Single(copy.SalesInvoiceItems.First().SalesTerms);
+            Assert.Single(item.SalesTerms);
+        }
+
+        [Fact]
         public void GivenSalesInvoice_WhenDeriving_ThenTotalAmountMustBeDerived()
         {
             var euro = new Currencies(this.Transaction).FindBy(this.M.Currency.IsoCode, "EUR");

--- a/dotnet/Apps/Database/Domain/Apps/Invoice/SalesInvoice.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Invoice/SalesInvoice.cs
@@ -227,7 +227,7 @@ namespace Allors.Database.Domain
                 {
                     if (salesTerm.GetType().Name == nameof(IncoTerm))
                     {
-                        salesInvoiceItem.AddSalesTerm(new IncoTermBuilder(this.Strategy.Transaction)
+                        invoiceItem.AddSalesTerm(new IncoTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -236,7 +236,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(InvoiceTerm))
                     {
-                        salesInvoiceItem.AddSalesTerm(new InvoiceTermBuilder(this.Strategy.Transaction)
+                        invoiceItem.AddSalesTerm(new InvoiceTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -245,7 +245,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(OrderTerm))
                     {
-                        salesInvoiceItem.AddSalesTerm(new OrderTermBuilder(this.Strategy.Transaction)
+                        invoiceItem.AddSalesTerm(new OrderTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -254,7 +254,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(QuoteTerm))
                     {
-                        salesInvoiceItem.AddSalesTerm(new QuoteTermBuilder(this.Strategy.Transaction)
+                        invoiceItem.AddSalesTerm(new QuoteTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)


### PR DESCRIPTION
## Summary
`SalesInvoice.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied) item. In the per-item loop, the four term branches called `salesInvoiceItem.AddSalesTerm(...)` (the item being iterated) rather than `invoiceItem.AddSalesTerm(...)` (the copy):

```csharp
foreach (var salesTerm in salesInvoiceItem.SalesTerms)
{
    if (salesTerm.GetType().Name == nameof(IncoTerm))
        salesInvoiceItem.AddSalesTerm(new IncoTermBuilder(...) ...);   // source, should be invoiceItem
    // InvoiceTerm / OrderTerm / QuoteTerm — same
}
```

Effect: copied invoices' items had **no** sales terms, and each source item's terms were **duplicated**. The four branches now add to `invoiceItem`. (The order-level sales-term loop already correctly targeted the copy.)

First of the CP "AddSalesTerm to source" trio (siblings: BUG-05 `QuoteExtensions`, BUG-15 `PurchaseOrder`).

## Test
Adds `SalesInvoiceTests.GivenSalesInvoiceItemWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewItemNotSource`: builds an invoice item with an `InvoiceTerm`, copies via `invoice.AppsCopy(new SalesInvoiceCopy(invoice))` (mirroring `RepeatingSalesInvoice`), and asserts the copy's item has the term and the source isn't duplicated.

- **RED** on un-fixed code (right reason): `Assert.Single() Failure: The collection was empty` (copy's item had no terms).
- **GREEN** after the fix.