### PR TITLE
fix(apps): copy Quote order-level sales terms to the new quote, not the source [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `QuoteExtensions.AppsCopy` (ProductQuote / Proposal / StatementOfWork) copied the quote's order-level sales
+  terms onto the **source** quote instead of the new `copy`: the loop called `@this.AddSalesTerm(...)` rather
+  than `copy.AddSalesTerm(...)`. As a result copied quotes had no order-level sales terms and the source quote's
+  terms were duplicated. The four `Inco`/`Invoice`/`Order`/`QuoteTerm` branches now add to `copy`. (The
+  item-level loop already correctly targeted the item copy.)
 - `SalesInvoice.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied)
   item: the per-item loop called `salesInvoiceItem.AddSalesTerm(...)` (the item being iterated) rather than
   `invoiceItem.AddSalesTerm(...)` (the copy). As a result the copied invoice's items had no sales terms and the

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -66,6 +66,29 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenQuoteWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewQuoteNotSource()
+        {
+            var party = new PersonBuilder(this.Transaction).WithLastName("party").Build();
+            var quote = new ProductQuoteBuilder(this.Transaction)
+                .WithReceiver(party)
+                .WithFullfillContactMechanism(new WebAddressBuilder(this.Transaction).WithElectronicAddressString("test").Build())
+                .Build();
+
+            quote.AddSalesTerm(new OrderTermBuilder(this.Transaction)
+                .WithTermType(new InvoiceTermTypes(this.Transaction).PaymentNetDays)
+                .WithTermValue("30")
+                .Build());
+
+            this.Transaction.Derive();
+
+            var copy = quote.AppsCopy(new ProductQuoteCopy(quote));
+
+            // Order-level sales terms must be copied onto the new quote, not added to the source.
+            Assert.Single(copy.SalesTerms);
+            Assert.Single(quote.SalesTerms);
+        }
+
+        [Fact]
         public void GivenBillToWithMultiLinePostalAddress_WhenCreatingModel_ThenAllAddressLinesAreJoined()
         {
             var usa = new Countries(this.Transaction).Extent().First(c => c.IsoCode.Equals("US"));

--- a/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
@@ -259,7 +259,7 @@ namespace Allors.Database.Domain
             {
                 if (salesTerm.GetType().Name == nameof(IncoTerm))
                 {
-                    @this.AddSalesTerm(new IncoTermBuilder(@this.Transaction())
+                    copy.AddSalesTerm(new IncoTermBuilder(@this.Transaction())
                         .WithTermType(salesTerm.TermType)
                         .WithTermValue(salesTerm.TermValue)
                         .WithDescription(salesTerm.Description)
@@ -268,7 +268,7 @@ namespace Allors.Database.Domain
 
                 if (salesTerm.GetType().Name == nameof(InvoiceTerm))
                 {
-                    @this.AddSalesTerm(new InvoiceTermBuilder(@this.Transaction())
+                    copy.AddSalesTerm(new InvoiceTermBuilder(@this.Transaction())
                         .WithTermType(salesTerm.TermType)
                         .WithTermValue(salesTerm.TermValue)
                         .WithDescription(salesTerm.Description)
@@ -277,7 +277,7 @@ namespace Allors.Database.Domain
 
                 if (salesTerm.GetType().Name == nameof(OrderTerm))
                 {
-                    @this.AddSalesTerm(new OrderTermBuilder(@this.Transaction())
+                    copy.AddSalesTerm(new OrderTermBuilder(@this.Transaction())
                         .WithTermType(salesTerm.TermType)
                         .WithTermValue(salesTerm.TermValue)
                         .WithDescription(salesTerm.Description)
@@ -286,7 +286,7 @@ namespace Allors.Database.Domain
 
                 if (salesTerm.GetType().Name == nameof(QuoteTerm))
                 {
-                    @this.AddSalesTerm(new QuoteTermBuilder(@this.Transaction())
+                    copy.AddSalesTerm(new QuoteTermBuilder(@this.Transaction())
                         .WithTermType(salesTerm.TermType)
                         .WithTermValue(salesTerm.TermValue)
                         .WithDescription(salesTerm.Description)


### PR DESCRIPTION
## Summary
`QuoteExtensions.AppsCopy` (ProductQuote / Proposal / StatementOfWork) copied the quote's order-level sales terms onto the **source** quote instead of the new `copy`. The four term branches called `@this.AddSalesTerm(...)` rather than `copy.AddSalesTerm(...)`:

```csharp
foreach (var salesTerm in @this.SalesTerms)
{
    if (salesTerm.GetType().Name == nameof(IncoTerm))
        @this.AddSalesTerm(new IncoTermBuilder(...) ...);   // source, should be copy
    // InvoiceTerm / OrderTerm / QuoteTerm — same
}
```

Effect: copied quotes had **no** order-level sales terms, and the source quote's terms were **duplicated**. The four branches now add to `copy`. (The QuoteItem copy loop already correctly targeted `itemCopy`.)

Second of the CP "AddSalesTerm to source" trio (with #163 BUG-02; BUG-15 `PurchaseOrder` next).

## Test
Adds `ProductQuoteTests.GivenQuoteWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewQuoteNotSource`: builds a quote with an order-level `OrderTerm`, copies via `quote.AppsCopy(new ProductQuoteCopy(quote))`, and asserts the copy has the term and the source isn't duplicated.

- **RED** on un-fixed code (right reason): `Assert.Single() Failure: The collection was empty` (copy had no order-level terms).
- **GREEN** after the fix.