### PR TITLE
fix(apps): copy PurchaseOrder item sales terms to the new item, not the source [BUG-15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrder.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied)
+  item: the per-item loop called `purchaseOrderItem.AddSalesTerm(...)` rather than `item.AddSalesTerm(...)`. As a
+  result copied purchase orders had no item sales terms and the source items' terms were duplicated. The four
+  `Inco`/`Invoice`/`Order`/`QuoteTerm` branches now add to `item`. (The discount- and surcharge-adjustment loops
+  already correctly targeted the copy.)
 - `QuoteExtensions.AppsCopy` (ProductQuote / Proposal / StatementOfWork) copied the quote's order-level sales
   terms onto the **source** quote instead of the new `copy`: the loop called `@this.AddSalesTerm(...)` rather
   than `copy.AddSalesTerm(...)`. As a result copied quotes had no order-level sales terms and the source quote's

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -37,6 +37,39 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenPurchaseOrderItemWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewItemNotSource()
+        {
+            var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();
+            new SupplierRelationshipBuilder(this.Transaction).WithSupplier(supplier).Build();
+
+            var order = new PurchaseOrderBuilder(this.Transaction).WithTakenViaSupplier(supplier).Build();
+
+            var part = new NonUnifiedGoods(this.Transaction).FindBy(this.M.Good.Name, "good1").Part;
+
+            var item = new PurchaseOrderItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).PartItem)
+                .WithPart(part)
+                .WithQuantityOrdered(1)
+                .WithAssignedUnitPrice(1)
+                .Build();
+
+            order.AddPurchaseOrderItem(item);
+
+            item.AddSalesTerm(new InvoiceTermBuilder(this.Transaction)
+                .WithTermType(new InvoiceTermTypes(this.Transaction).PaymentNetDays)
+                .WithTermValue("30")
+                .Build());
+
+            this.Transaction.Derive();
+
+            var copy = order.AppsCopy(new PurchaseOrderCopy(order));
+
+            // The item-level sales term must be copied onto the new item, not added to the source item.
+            Assert.Single(copy.PurchaseOrderItems.First().SalesTerms);
+            Assert.Single(item.SalesTerms);
+        }
+
+        [Fact]
         public void GivenOrder_WhenDeriving_ThenRequiredRelationsMustExist()
         {
             var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier2").Build();

--- a/dotnet/Apps/Database/Domain/Apps/Order/PurchaseOrder.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/PurchaseOrder.cs
@@ -581,7 +581,7 @@ namespace Allors.Database.Domain
                 {
                     if (salesTerm.GetType().Name == nameof(IncoTerm))
                     {
-                        purchaseOrderItem.AddSalesTerm(new IncoTermBuilder(this.Strategy.Transaction)
+                        item.AddSalesTerm(new IncoTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -590,7 +590,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(InvoiceTerm))
                     {
-                        purchaseOrderItem.AddSalesTerm(new InvoiceTermBuilder(this.Strategy.Transaction)
+                        item.AddSalesTerm(new InvoiceTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -599,7 +599,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(OrderTerm))
                     {
-                        purchaseOrderItem.AddSalesTerm(new OrderTermBuilder(this.Strategy.Transaction)
+                        item.AddSalesTerm(new OrderTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)
@@ -608,7 +608,7 @@ namespace Allors.Database.Domain
 
                     if (salesTerm.GetType().Name == nameof(QuoteTerm))
                     {
-                        purchaseOrderItem.AddSalesTerm(new QuoteTermBuilder(this.Strategy.Transaction)
+                        item.AddSalesTerm(new QuoteTermBuilder(this.Strategy.Transaction)
                             .WithTermType(salesTerm.TermType)
                             .WithTermValue(salesTerm.TermValue)
                             .WithDescription(salesTerm.Description)


### PR DESCRIPTION
## Summary
`PurchaseOrder.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied) item. In the per-item loop, the four term branches called `purchaseOrderItem.AddSalesTerm(...)` (the item being iterated) rather than `item.AddSalesTerm(...)` (the copy):

```csharp
foreach (var salesTerm in purchaseOrderItem.SalesTerms)
{
    if (salesTerm.GetType().Name == nameof(IncoTerm))
        purchaseOrderItem.AddSalesTerm(new IncoTermBuilder(...) ...);   // source, should be item
    // InvoiceTerm / OrderTerm / QuoteTerm — same
}
```

Effect: copied purchase orders' items had **no** sales terms, and each source item's terms were **duplicated**. The four branches now add to `item`. (The discount- and surcharge-adjustment loops already correctly targeted the copy.)

Last of the CP "AddSalesTerm to source" trio (with #163 BUG-02, #164 BUG-05).

## Test
Adds `PurchaseOrderTests.GivenPurchaseOrderItemWithSalesTerm_WhenCopying_ThenSalesTermIsCopiedToNewItemNotSource`: builds a `PartItem` purchase-order item with an `InvoiceTerm`, copies via `order.AppsCopy(new PurchaseOrderCopy(order))`, and asserts the copy's item has the term and the source isn't duplicated.

- **RED** on un-fixed code (right reason): `Assert.Single() Failure: The collection was empty` (copy's item had no terms).
- **GREEN** after the fix.