### PR TITLE
fix(apps): gate all received-conditions by the already-billed check in RepeatingPurchaseInvoice [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `RepeatingPurchaseInvoice.Repeat` re-billed already-billed, **partially-received** purchase-order items. The
+  "to bill" guard `!ExistOrderItemBillings && IsReceived || IsPartiallyReceived || (!ExistPart && QuantityReceived == 1)`
+  was mis-parenthesised: since `&&` binds tighter than `||`, the already-billed check only gated the `IsReceived`
+  term, so a partially-received item that was already billed got billed again. The three received-conditions are
+  now wrapped in parentheses so the already-billed guard applies to all of them.
 - `PurchaseOrder.AppsCopy` copied each item's sales terms onto the **source** item instead of the new (copied)
   item: the per-item loop called `purchaseOrderItem.AddSalesTerm(...)` rather than `item.AddSalesTerm(...)`. As a
   result copied purchase orders had no item sales terms and the source items' terms were duplicated. The four

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/RepeatingPurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/RepeatingPurchaseInvoiceTests.cs
@@ -76,5 +76,68 @@ namespace Allors.Database.Domain.Tests
             var errors = this.Derive().Errors.ToList();
             Assert.Contains(errors, e => e.Message.Contains(ErrorMessages.DateDayOfWeek));
         }
+
+        [Fact]
+        public void GivenAlreadyBilledPartiallyReceivedOrderItem_WhenRepeating_ThenItemIsNotRebilled()
+        {
+            var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();
+            new SupplierRelationshipBuilder(this.Transaction).WithSupplier(supplier).WithInternalOrganisation(this.InternalOrganisation).Build();
+
+            var part = new NonUnifiedGoods(this.Transaction).FindBy(this.M.Good.Name, "good1").Part;
+
+            new SupplierOfferingBuilder(this.Transaction)
+                .WithPart(part)
+                .WithSupplier(supplier)
+                .WithFromDate(this.Transaction.Now().AddDays(-1))
+                .WithUnitOfMeasure(new UnitsOfMeasure(this.Transaction).Piece)
+                .WithPrice(5)
+                .WithCurrency(new Currencies(this.Transaction).FindBy(this.M.Currency.IsoCode, "EUR"))
+                .Build();
+
+            var order = new PurchaseOrderBuilder(this.Transaction).WithTakenViaSupplier(supplier).Build();
+
+            var item = new PurchaseOrderItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).PartItem)
+                .WithPart(part)
+                .WithQuantityOrdered(2)
+                .WithAssignedUnitPrice(5)
+                .Build();
+            order.AddPurchaseOrderItem(item);
+            this.Derive();
+
+            order.SetReadyForProcessing();
+            this.Derive();
+
+            order.Send();
+            this.Derive();
+
+            // Partially receive the item (1 of 2 ordered).
+            new ShipmentReceiptBuilder(this.Transaction).WithOrderItem(item).WithQuantityAccepted(1).Build();
+            this.Derive();
+
+            // The item is already billed.
+            var purchaseInvoice = new PurchaseInvoiceBuilder(this.Transaction).Build();
+            var invoiceItem = new PurchaseInvoiceItemBuilder(this.Transaction).Build();
+            purchaseInvoice.AddPurchaseInvoiceItem(invoiceItem);
+            new OrderItemBillingBuilder(this.Transaction).WithOrderItem(item).WithInvoiceItem(invoiceItem).WithQuantity(1).WithAmount(5).Build();
+            this.Derive();
+
+            // Scenario preconditions for RepeatingPurchaseInvoice.Repeat to consider this order/item.
+            Assert.True(order.PurchaseOrderState.IsSent || order.PurchaseOrderState.IsCompleted, $"orderState={order.PurchaseOrderState?.Name}");
+            Assert.True(item.PurchaseOrderItemShipmentState.IsPartiallyReceived, $"itemShipmentState={item.PurchaseOrderItemShipmentState?.Name}");
+
+            var repeatingInvoice = new RepeatingPurchaseInvoiceBuilder(this.Transaction)
+                .WithSupplier(supplier)
+                .WithInternalOrganisation(this.InternalOrganisation)
+                .WithFrequency(new TimeFrequencies(this.Transaction).Month)
+                .Build();
+            this.Derive();
+
+            repeatingInvoice.Repeat();
+            this.Derive();
+
+            // The already-billed item must not be billed a second time.
+            Assert.Single(item.OrderItemBillingsWhereOrderItem);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Invoice/RepeatingPurchaseInvoice.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Invoice/RepeatingPurchaseInvoice.cs
@@ -55,7 +55,7 @@ namespace Allors.Database.Domain
                 foreach (PurchaseOrderItem purchaseOrderItem in purchaseOrder.ValidOrderItems)
                 {
                     if (!purchaseOrderItem.ExistOrderItemBillingsWhereOrderItem &&
-                        purchaseOrderItem.PurchaseOrderItemShipmentState.IsReceived || purchaseOrderItem.PurchaseOrderItemShipmentState.IsPartiallyReceived || !purchaseOrderItem.ExistPart && purchaseOrderItem.QuantityReceived == 1)
+                        (purchaseOrderItem.PurchaseOrderItemShipmentState.IsReceived || purchaseOrderItem.PurchaseOrderItemShipmentState.IsPartiallyReceived || !purchaseOrderItem.ExistPart && purchaseOrderItem.QuantityReceived == 1))
                     {
                         orderItemsToBill.Add(purchaseOrderItem);
                     }


### PR DESCRIPTION
## Summary
`RepeatingPurchaseInvoice.Repeat` re-billed already-billed, **partially-received** purchase-order items. The "to bill" guard was mis-parenthesised:

```csharp
if (!purchaseOrderItem.ExistOrderItemBillingsWhereOrderItem &&
    purchaseOrderItem.PurchaseOrderItemShipmentState.IsReceived
    || purchaseOrderItem.PurchaseOrderItemShipmentState.IsPartiallyReceived
    || !purchaseOrderItem.ExistPart && purchaseOrderItem.QuantityReceived == 1)
```

Since `&&` binds tighter than `||`, this parses as `(!ExistOrderItemBillings && IsReceived) || IsPartiallyReceived || (!ExistPart && QuantityReceived == 1)` — so the already-billed guard only gated the `IsReceived` term. An already-billed item that was partially received still matched `IsPartiallyReceived` and got billed again on the next `Repeat()`.

Fix: wrap the three received-conditions in parentheses so the already-billed guard applies to all of them.

## Test
Adds `RepeatingPurchaseInvoiceTests.GivenAlreadyBilledPartiallyReceivedOrderItem_WhenRepeating_ThenItemIsNotRebilled`: a sent supplier order with a `PartItem` ordered ×2, partially received (`ShipmentReceipt` qty 1 → `IsPartiallyReceived`) and already billed (pre-created `OrderItemBilling`); then `Repeat()`. Asserts the scenario preconditions (order `Sent`, item `PartiallyReceived`) and that the item ends with a single `OrderItemBilling`.

- **RED** on un-fixed code (right reason): `Assert.Single() Failure: The collection contained 2 items` (re-billed).
- **GREEN** after the fix.