### PR TITLE
fix(apps): validate OrderQuantityBreak.ThroughAmount, not OrderValue.ThroughAmount [BUG-14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `OrderQuantityBreak` validation required at least one of `FromAmount`/`ThroughAmount`, but checked
+  `OrderValue.ThroughAmount` — a different type's roletype — instead of the break's own
+  `OrderQuantityBreak.ThroughAmount`. A break with only its own `ThroughAmount` set was therefore wrongly
+  rejected with the "at least one" error. `AppsOnPostDerive` now asserts on `OrderQuantityBreak.ThroughAmount`.
 - `RepeatingPurchaseInvoice.Repeat` re-billed already-billed, **partially-received** purchase-order items. The
   "to bill" guard `!ExistOrderItemBillings && IsReceived || IsPartiallyReceived || (!ExistPart && QuantityReceived == 1)`
   was mis-parenthesised: since `&&` binds tighter than `||`, the already-billed check only gated the `IsReceived`

--- a/dotnet/Apps/Database/Domain.Tests/Order/OrderQuantityBreakTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/OrderQuantityBreakTests.cs
@@ -23,5 +23,14 @@ namespace Allors.Database.Domain.Tests
             var errors = this.Derive().Errors.ToList();
             Assert.Single(errors, e => e.Message == "OrderQuantityBreak.FromAmount, OrderQuantityBreak.ThroughAmount at least one");
         }
+
+        [Fact]
+        public void GivenOrderQuantityBreakWithOnlyThroughAmount_WhenDeriving_ThenNoAtLeastOneError()
+        {
+            new OrderQuantityBreakBuilder(this.Transaction).WithThroughAmount(100M).Build();
+
+            var errors = this.Derive().Errors.ToList();
+            Assert.DoesNotContain(errors, e => e.Message == "OrderQuantityBreak.FromAmount, OrderQuantityBreak.ThroughAmount at least one");
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Order/OrderQuantityBreak.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/OrderQuantityBreak.cs
@@ -7,6 +7,6 @@ namespace Allors.Database.Domain
 {
     public partial class OrderQuantityBreak
     {
-        public void AppsOnPostDerive(ObjectOnPostDerive method) => method.Derivation.Validation.AssertAtLeastOne(this, this.M.OrderQuantityBreak.FromAmount, this.M.OrderValue.ThroughAmount);
+        public void AppsOnPostDerive(ObjectOnPostDerive method) => method.Derivation.Validation.AssertAtLeastOne(this, this.M.OrderQuantityBreak.FromAmount, this.M.OrderQuantityBreak.ThroughAmount);
     }
 }


### PR DESCRIPTION
## Summary
`OrderQuantityBreak.AppsOnPostDerive` asserted that at least one of `FromAmount`/`ThroughAmount` is set, but passed `this.M.OrderValue.ThroughAmount` as the second roletype:

```csharp
… AssertAtLeastOne(this, this.M.OrderQuantityBreak.FromAmount, this.M.OrderValue.ThroughAmount);
```

`OrderQuantityBreak : Object` does **not** extend `OrderValue` and declares its own `ThroughAmount`. The foreign `OrderValue.ThroughAmount` roletype reads as absent on an `OrderQuantityBreak`, so a break with only its own `ThroughAmount` set was wrongly rejected with the "at least one" error. Now asserts on `this.M.OrderQuantityBreak.ThroughAmount`.

## Test
Adds `OrderQuantityBreakTests.GivenOrderQuantityBreakWithOnlyThroughAmount_WhenDeriving_ThenNoAtLeastOneError`: builds a break with only `ThroughAmount` and asserts the "at least one" error is **absent**.

- **RED** on un-fixed code (right reason): `Assert.DoesNotContain() Failure: Filter matched` — the error was present despite `ThroughAmount` being set.
- **GREEN** after the fix. The existing `OnBuildThrowValidationError` (empty break) still passes — its message renders against the concrete type and is unaffected.