### PR TITLE
fix(apps): set NextSerialisedItemAvailability on the PurchaseOrderItem return shipment item [BUG-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderItem.Return` (item-level return) built a `PurchaseReturn` `ShipmentItem` for a serialised part
+  without setting `NextSerialisedItemAvailability`, which `ShipmentItemRule` requires for serialised items on a
+  `CustomerShipment`/`PurchaseReturn`. Returning a received serialised order item therefore failed validation
+  (`ShipmentItem.NextSerialisedItemAvailability is required`). The shipment item now sets it to `NotAvailable`,
+  matching the order-level `PurchaseOrder.AppsReturn`.
 - `OrderQuantityBreak` validation required at least one of `FromAmount`/`ThroughAmount`, but checked
   `OrderValue.ThroughAmount` — a different type's roletype — instead of the break's own
   `OrderQuantityBreak.ThroughAmount`. A break with only its own `ThroughAmount` set was therefore wrongly

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderItemTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderItemTests.cs
@@ -1733,6 +1733,35 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenReceivedSerialisedOrderItem_WhenReturning_ThenNoMissingSerialisedItemAvailabilityError()
+        {
+            this.InternalOrganisation.IsAutomaticallyReceived = true;
+            this.Derive();
+
+            var order = this.InternalOrganisation.CreatePurchaseOrderWithBothItems(this.Transaction.Faker());
+            this.Derive();
+
+            order.SetReadyForProcessing();
+            this.Derive();
+
+            order.Send();
+            this.Derive();
+
+            order.QuickReceive();
+            this.Derive();
+
+            var serialisedOrderItem = order.PurchaseOrderItems.First(v => v.ExistSerialisedItem);
+            Assert.True(serialisedOrderItem.PurchaseOrderItemShipmentState.IsReceived, $"shipState={serialisedOrderItem.PurchaseOrderItemShipmentState?.Name}");
+
+            serialisedOrderItem.Return();
+            var errors = this.Derive().Errors.ToList();
+
+            // Returning a serialised item builds a PurchaseReturn ShipmentItem; ShipmentItemRule requires
+            // NextSerialisedItemAvailability on it, so the Return must set it.
+            Assert.DoesNotContain(errors, e => e.Message.Contains("NextSerialisedItemAvailability"));
+        }
+
+        [Fact]
         public void OnChangedOrderShipmentOrderItemDeriveReturnPermission()
         {
             this.InternalOrganisation.IsAutomaticallyReceived = true;

--- a/dotnet/Apps/Database/Domain/Apps/Order/PurchaseOrderItem.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/PurchaseOrderItem.cs
@@ -198,6 +198,7 @@ namespace Allors.Database.Domain
                 var shipmentItem = new ShipmentItemBuilder(this.Strategy.Transaction)
                     .WithPart(this.Part)
                     .WithSerialisedItem(this.SerialisedItem)
+                    .WithNextSerialisedItemAvailability(new SerialisedItemAvailabilities(this.Strategy.Transaction).NotAvailable)
                     .WithQuantity(this.QuantityReceived)
                     .WithContentsDescription($"{this.QuantityReceived} * {this.Part.Name}")
                     .WithReservedFromInventoryItem(inventoryItem)


### PR DESCRIPTION
## Summary
`PurchaseOrderItem.AppsReturn` (item-level return) built a `PurchaseReturn` `ShipmentItem` with `.WithSerialisedItem(...)` but did **not** set `NextSerialisedItemAvailability`. `ShipmentItemRule` requires `NextSerialisedItemAvailability` when a shipment item belongs to a `CustomerShipment`/`PurchaseReturn` and has a `SerialisedItem`, so returning a received **serialised** order item failed derivation with `ShipmentItem.NextSerialisedItemAvailability is required`.

Fix: set `.WithNextSerialisedItemAvailability(new SerialisedItemAvailabilities(...).NotAvailable)`, matching the order-level `PurchaseOrder.AppsReturn` (`PurchaseOrder.cs:367`).

## Test
Adds `GivenReceivedSerialisedOrderItem_WhenReturning_ThenNoMissingSerialisedItemAvailabilityError` (in `PurchaseOrderItemTests.cs`): receives a serialised order item (`CreatePurchaseOrderWithBothItems` → `SetReadyForProcessing` → `Send` → `QuickReceive`), then `Return()` and asserts the availability error is absent.

- **RED** on un-fixed code (right reason): `ShipmentItem.NextSerialisedItemAvailability is required`.
- **GREEN** after the fix.