### PR TITLE
fix(apps): preserve Cancelled/Rejected quote items on Revise/Reopen [BUG-17]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `QuoteExtensions.SetItemState` reset **every** quote item to `Draft` when the quote was `Created`, with no
+  guard — so `Revise()`/`Reopen()` (which return the quote to `Created` and call `SetItemState`) clobbered items
+  that were already `Cancelled` or `Rejected`. The `IsCreated` branch now skips items in those terminal states,
+  matching the `Cancelled`/`Rejected`/`AwaitingApproval` branches.
 - `PurchaseOrderItem.Return` (item-level return) built a `PurchaseReturn` `ShipmentItem` for a serialised part
   without setting `NextSerialisedItemAvailability`, which `ShipmentItemRule` requires for serialised items on a
   `CustomerShipment`/`PurchaseReturn`. Returning a received serialised order item therefore failed validation

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -347,6 +347,31 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenCreatedQuoteWithCancelledItem_WhenSettingItemState_ThenCancelledItemIsNotResetToDraft()
+        {
+            var productQuote = new ProductQuoteBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var quoteItem = new QuoteItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypeBuilder(this.Transaction).Build())
+                .WithAssignedUnitPrice(1)
+                .Build();
+            productQuote.AddQuoteItem(quoteItem);
+            this.Derive();
+
+            quoteItem.Cancel();
+            this.Derive();
+
+            Assert.True(quoteItem.QuoteItemState.IsCancelled);
+            Assert.True(productQuote.QuoteState.IsCreated, $"quoteState={productQuote.QuoteState?.Name}");
+
+            // SetItemState is what Revise()/Reopen() invoke after returning the quote to Created.
+            productQuote.SetItemState();
+
+            Assert.True(quoteItem.QuoteItemState.IsCancelled, $"itemState={quoteItem.QuoteItemState?.Name}");
+        }
+
+        [Fact]
         public void OnChangedProductQuoteStateNotCreatedDeriveSetReadyPermission()
         {
             var productQuote = this.InternalOrganisation.CreateB2BProductQuoteWithSerialisedItem(this.Transaction.Faker());

--- a/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
@@ -432,7 +432,10 @@ namespace Allors.Database.Domain
             {
                 if (@this.QuoteState.IsCreated)
                 {
-                    quoteItem.QuoteItemState = new QuoteItemStates(@this.Strategy.Transaction).Draft;
+                    if (!Equals(quoteItem.QuoteItemState, quoteItemStates.Cancelled) && !Equals(quoteItem.QuoteItemState, quoteItemStates.Rejected))
+                    {
+                        quoteItem.QuoteItemState = new QuoteItemStates(@this.Strategy.Transaction).Draft;
+                    }
                 }
 
                 if (@this.QuoteState.IsCancelled)


### PR DESCRIPTION
## Summary
`QuoteExtensions.SetItemState` set **every** quote item to `Draft` when the quote was `Created`, with no guard:

```csharp
if (@this.QuoteState.IsCreated) { quoteItem.QuoteItemState = …Draft; }   // unconditional
if (@this.QuoteState.IsCancelled) { if (!…Rejected) … Cancelled; }        // guarded
if (@this.QuoteState.IsRejected)  { if (!…Cancelled) … Rejected; }        // guarded
```

`AppsRevise`/`AppsReopen` set `QuoteState = Created` and then call `SetItemState`, so revising or reopening a quote reset items that were already `Cancelled` or `Rejected` back to `Draft`. The `IsCreated` branch now skips items in those terminal states, matching the other branches.

## Test
Adds `GivenCreatedQuoteWithCancelledItem_WhenSettingItemState_ThenCancelledItemIsNotResetToDraft` (in `ProductQuoteTests.cs`): a `Created` quote with a cancelled item, then `SetItemState()` (the call Revise/Reopen make), asserting the item stays `Cancelled`.

- **RED** on un-fixed code (right reason): `itemState=Draft`.
- **GREEN** after the fix.