### PR TITLE
fix(apps): preserve QuotedWithFeature link when copying a quote [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `QuoteExtensions.AppsCopy` dropped the `QuotedWithFeature` parent link when copying a quote. `CopyQuoteItem`
+  recursively copied each item's feature sub-items (`QuotedWithFeatures`) and added them to the copied quote, but
+  never re-linked them to the copied parent item — so a copied feature item became an orphaned standalone quote
+  item. The recursive copy now captures the new feature item and re-links it via `itemCopy.AddQuotedWithFeature(...)`.
 - `QuoteExtensions.SetItemState` reset **every** quote item to `Draft` when the quote was `Created`, with no
   guard — so `Revise()`/`Reopen()` (which return the quote to `Created` and call `SetItemState`) clobbered items
   that were already `Cancelled` or `Rejected`. The `IsCreated` branch now skips items in those terminal states,

--- a/dotnet/Apps/Database/Domain.Tests/Order/QuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/QuoteTests.cs
@@ -419,6 +419,45 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenQuoteItemWithFeature_WhenCopying_ThenFeatureLinkIsPreserved()
+        {
+            var product = new NonUnifiedGoodBuilder(this.Transaction).WithNonSerialisedDefaults(this.InternalOrganisation).Build();
+
+            new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProduct(product)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+
+            var quote = new ProductQuoteBuilder(this.Transaction).WithIssueDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var quoteItem = new QuoteItemBuilder(this.Transaction).WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductItem).WithProduct(product).WithQuantity(1).Build();
+            quote.AddQuoteItem(quoteItem);
+            this.Derive();
+
+            var productFeature = new ColourBuilder(this.Transaction).WithName("a colour").Build();
+            new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProductFeature(productFeature)
+                .WithPrice(0.2M)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+            this.Derive();
+
+            var featureItem = new QuoteItemBuilder(this.Transaction).WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductFeatureItem).WithProductFeature(productFeature).WithQuantity(1).Build();
+            quoteItem.AddQuotedWithFeature(featureItem);
+            this.Derive();
+
+            var copy = quote.AppsCopy(new ProductQuoteCopy(quote));
+            this.Derive();
+
+            // The copied quote must preserve the parent-item -> feature (QuotedWithFeature) link.
+            Assert.Contains(copy.QuoteItems, v => v.ExistQuotedWithFeatures);
+        }
+
+        [Fact]
         public void OnChangedDerivationTriggerTriggeredByPriceComponentFromDateCalculatePrice()
         {
             var product = new NonUnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
@@ -358,7 +358,8 @@ namespace Allors.Database.Domain
 
             foreach (var featureItem in quoteItem.QuotedWithFeatures)
             {
-                CopyQuoteItem(@this, copy, featureItem);
+                var featureItemCopy = CopyQuoteItem(@this, copy, featureItem);
+                itemCopy.AddQuotedWithFeature(featureItemCopy);
             }
 
             foreach (var orderAdjustment in quoteItem.DiscountAdjustments)


### PR DESCRIPTION
## Summary
`QuoteExtensions.AppsCopy` lost the `QuotedWithFeature` bundling link when copying a quote. The top-level loop copies only non-feature items, and `CopyQuoteItem` copies each item's feature sub-items recursively:

```csharp
copy.AddQuoteItem(itemCopy);
foreach (var featureItem in quoteItem.QuotedWithFeatures)
{
    CopyQuoteItem(@this, copy, featureItem);   // adds the feature copy to the quote, but never re-links it
}
```

Each recursive call adds the feature's copy to `copy.QuoteItems` but discards the result and never re-links it to the copied parent via `QuotedWithFeature` — so a copied feature item becomes an **orphaned standalone** quote item. Fix: capture the recursive `CopyQuoteItem` result and `itemCopy.AddQuotedWithFeature(featureItemCopy)`.

## Test
Adds `QuoteTests.GivenQuoteItemWithFeature_WhenCopying_ThenFeatureLinkIsPreserved`: a `ProductQuote` with a `ProductFeatureItem` bundled under a parent item, copied via `AppsCopy(new ProductQuoteCopy(quote))`, asserting a copied item still `ExistQuotedWithFeatures`.

- **RED** on un-fixed code (right reason): `Assert.Contains() Failure: Filter not matched` — both copied items orphaned.
- **GREEN** after the fix.