### PR TITLE
fix(apps): null-safe SalesChannel comparison in PriceComponents [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PriceComponents` threw a `NullReferenceException` when evaluating a price component that has a `SalesChannel`
+  against an order/invoice with **no** `SalesChannel`: `channel.Equals(priceComponent.SalesChannel)` dereferenced
+  a null `channel`. It now uses the null-safe `Equals(channel, priceComponent.SalesChannel)`, so a channel-specific
+  price component simply does not apply to a channel-less order.
 - `QuoteExtensions.AppsCopy` dropped the `QuotedWithFeature` parent link when copying a quote. `CopyQuoteItem`
   recursively copied each item's feature sub-items (`QuotedWithFeatures`) and added them to the copied quote, but
   never re-linked them to the copied parent item — so a copied feature item became an orphaned standalone quote

--- a/dotnet/Apps/Database/Domain.Tests/Order/SalesOrderItemPricingTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/SalesOrderItemPricingTests.cs
@@ -1795,6 +1795,33 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenSalesChannelDiscountComponent_WhenOrderHasNoSalesChannel_ThenDerivesWithoutNullReference()
+        {
+            const decimal quantityOrdered = 3;
+
+            var email = new SalesChannels(this.Transaction).EmailChannel;
+            new DiscountComponentBuilder(this.Transaction)
+                .WithDescription("discount with sales channel")
+                .WithSalesChannel(email)
+                .WithProduct(this.good)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .WithThroughDate(this.Transaction.Now().AddYears(1).AddDays(-1))
+                .Build();
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
+            this.InstantiateObjects(this.Transaction);
+
+            // The order has no SalesChannel, while the discount component is channel-specific.
+            var item1 = new SalesOrderItemBuilder(this.Transaction).WithProduct(this.good).WithQuantityOrdered(quantityOrdered).Build();
+            this.order.AddSalesOrderItem(item1);
+
+            Assert.False(this.Derive().HasErrors);
+        }
+
+        [Fact]
         public void GivenOrderItemWithDiscountPercentageAndItemDiscountPercentage_WhenDeriving_ThenExtraDiscountIsCalculated()
         {
             const decimal quantityOrdered = 3;

--- a/dotnet/Apps/Database/Domain/Apps/Product/PriceComponents.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Product/PriceComponents.cs
@@ -138,7 +138,7 @@ namespace Allors.Database.Domain
                     channel = salesInvoice.SalesChannel;
                 }
 
-                if (channel.Equals(priceComponent.SalesChannel))
+                if (Equals(channel, priceComponent.SalesChannel))
                 {
                     salesChannelValid = true;
                 }


### PR DESCRIPTION
## Summary
`PriceComponents.AppsIsApplicable` threw a `NullReferenceException` when a price component declares a `SalesChannel` and the order/invoice has **none**:

```csharp
SalesChannel channel = null;
if (salesOrder != null)   { channel = salesOrder.SalesChannel; }      // may be null
if (salesInvoice != null) { channel = salesInvoice.SalesChannel; }    // may be null
if (channel.Equals(priceComponent.SalesChannel)) { … }                // NPE when channel is null
```

Now uses the null-safe `Equals(channel, priceComponent.SalesChannel)`, so a channel-specific price component simply doesn't match a channel-less order.

## Test
Adds `SalesOrderItemPricingTests.GivenSalesChannelDiscountComponent_WhenOrderHasNoSalesChannel_ThenDerivesWithoutNullReference` (mirrors the existing channel-discount test but leaves `this.order.SalesChannel` unset).

- **RED** on un-fixed code (right reason): `NullReferenceException` at `PriceComponents.cs:141` during `SalesOrderItemPriceRule` derivation.
- **GREEN** after the fix.