### PR TITLE
fix(apps): guard BasePrice.AppsDelete against null Product/ProductFeature [BUG-19]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `BasePrice.AppsDelete` called `this.Product.RemoveBasePrice(this)` and `this.ProductFeature.RemoveFromBasePrices(this)`
+  without guards, but a base price requires only **one** of `Product`/`ProductFeature` — so deleting a product-only
+  (or feature-only) base price threw a `NullReferenceException`. Each removal is now guarded by
+  `ExistProduct`/`ExistProductFeature`.
 - `PriceComponents` threw a `NullReferenceException` when evaluating a price component that has a `SalesChannel`
   against an order/invoice with **no** `SalesChannel`: `channel.Equals(priceComponent.SalesChannel)` dereferenced
   a null `channel`. It now uses the null-safe `Equals(channel, priceComponent.SalesChannel)`, so a channel-specific

--- a/dotnet/Apps/Database/Domain.Tests/Product/BasePriceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/BasePriceTests.cs
@@ -8,6 +8,7 @@ namespace Allors.Database.Domain.Tests
 {
     using System.Linq;
     using Resources;
+    using TestPopulation;
     using Xunit;
 
     public class BasePriceTests : DomainTest, IClassFixture<Fixture>
@@ -83,6 +84,23 @@ namespace Allors.Database.Domain.Tests
             this.Derive();
 
             Assert.Contains(basePrice, productFeature.BasePrices);
+        }
+
+        [Fact]
+        public void GivenProductBasePriceWithoutProductFeature_WhenDeleting_ThenNoNullReference()
+        {
+            var product = new NonUnifiedGoodBuilder(this.Transaction).WithNonSerialisedDefaults(this.InternalOrganisation).Build();
+            var basePrice = new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProduct(product)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+            this.Derive();
+
+            basePrice.Delete();
+
+            Assert.False(this.Derive().HasErrors);
         }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Product/BasePrice.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Product/BasePrice.cs
@@ -11,9 +11,15 @@ namespace Allors.Database.Domain
 
         public void AppsDelete(DeletableDelete method)
         {
-            this.Product.RemoveBasePrice(this);
+            if (this.ExistProduct)
+            {
+                this.Product.RemoveBasePrice(this);
+            }
 
-            this.ProductFeature.RemoveFromBasePrices(this);
+            if (this.ExistProductFeature)
+            {
+                this.ProductFeature.RemoveFromBasePrices(this);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
A `BasePrice` requires **at least one** of `Product`/`ProductFeature` (per `AppsOnPostDerive`), but `AppsDelete` dereferenced both unconditionally:

```csharp
public void AppsDelete(DeletableDelete method)
{
    this.Product.RemoveBasePrice(this);              // NPE when feature-only
    this.ProductFeature.RemoveFromBasePrices(this);  // NPE when product-only
}
```

So deleting a product-only base price threw a `NullReferenceException` at the `ProductFeature` line (and a feature-only one at the `Product` line). Each removal is now guarded by `ExistProduct`/`ExistProductFeature`.

## Test
Adds `BasePriceTests.GivenProductBasePriceWithoutProductFeature_WhenDeleting_ThenNoNullReference`: builds a valid product-only base price and deletes it (added `using TestPopulation;`).

- **RED** on un-fixed code (right reason): `NullReferenceException` at `BasePrice.AppsDelete:16` during `Delete()`.
- **GREEN** after the fix.