### PR TITLE
fix(apps): bill catalog-priced lines on customer shipment (use UnitPrice) [BUG-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerShipment` billing computed how much was left to invoice from the **optional** `AssignedUnitPrice`
+  (`QuantityOrdered * AssignedUnitPrice - amountAlreadyInvoiced`). For a catalog-priced order line (no assigned
+  price), `AssignedUnitPrice` is null, so the result was null, `leftToInvoice > 0` was false, and the line was
+  never invoiced on shipment. It now uses the derived `UnitPrice` (which the created invoice item already uses),
+  so catalog-priced lines are billed.
 - `BasePrice.AppsDelete` called `this.Product.RemoveBasePrice(this)` and `this.ProductFeature.RemoveFromBasePrices(this)`
   without guards, but a base price requires only **one** of `Product`/`ProductFeature` — so deleting a product-only
   (or feature-only) base price threw a `NullReferenceException`. Each removal is now guarded by

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
@@ -1035,6 +1035,91 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenCatalogPricedOrderItem_WhenCustomerShipmentShipped_ThenItemIsInvoiced()
+        {
+            var assessable = new VatRegimes(this.Transaction).ZeroRated;
+
+            var good1 = new NonUnifiedGoods(this.Transaction).FindBy(this.M.Good.Name, "good1");
+
+            // Catalog price for good1; the order item below has no AssignedUnitPrice, so UnitPrice derives from this.
+            new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProduct(good1)
+                .WithPrice(15)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+
+            new InventoryItemTransactionBuilder(this.Transaction).WithQuantity(100).WithReason(new InventoryTransactionReasons(this.Transaction).PhysicalCount).WithPart(good1.Part).Build();
+
+            var mechelen = new CityBuilder(this.Transaction).WithName("Mechelen").Build();
+            var mechelenAddress = new PostalAddressBuilder(this.Transaction).WithPostalAddressBoundary(mechelen).WithAddress1("Haverwerf 15").Build();
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("customer").Build();
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(mechelenAddress)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).ShippingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(mechelenAddress)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).BillingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer).Build();
+
+            this.Transaction.Derive();
+
+            var order = new SalesOrderBuilder(this.Transaction)
+                .WithBillToCustomer(customer)
+                .WithShipToCustomer(customer)
+                .WithAssignedVatRegime(assessable)
+                .Build();
+
+            var item1 = new SalesOrderItemBuilder(this.Transaction).WithProduct(good1).WithQuantityOrdered(1).Build();
+            order.AddSalesOrderItem(item1);
+
+            this.Transaction.Derive();
+
+            order.SetReadyForPosting();
+            this.Transaction.Derive();
+
+            order.Post();
+            this.Transaction.Derive();
+
+            order.Accept();
+            this.Transaction.Derive();
+
+            var shipment = (CustomerShipment)item1.OrderShipmentsWhereOrderItem.ElementAt(0).ShipmentItem.ShipmentWhereShipmentItem;
+
+            shipment.Pick();
+            this.Transaction.Derive();
+
+            var pickList = shipment.ShipmentItems.ElementAt(0).ItemIssuancesWhereShipmentItem.ElementAt(0).PickListItem.PickListWherePickListItem;
+            pickList.Picker = this.OrderProcessor;
+            pickList.SetPicked();
+
+            var package = new ShipmentPackageBuilder(this.Transaction).Build();
+            shipment.AddShipmentPackage(package);
+
+            foreach (ShipmentItem shipmentItem in shipment.ShipmentItems)
+            {
+                package.AddPackagingContent(new PackagingContentBuilder(this.Transaction).WithShipmentItem(shipmentItem).WithQuantity(shipmentItem.Quantity).Build());
+            }
+
+            this.Transaction.Derive();
+
+            shipment.Ship();
+            this.Transaction.Derive();
+
+            // The catalog-priced shipment item must be billed/invoiced, not dropped.
+            Assert.NotEmpty(shipment.ShipmentItems.ElementAt(0).ShipmentItemBillingsWhereShipmentItem);
+        }
+
+        [Fact]
         public void GivenCustomerShipmentWithoutOrder_WhenStateIsSetToShipped_ThenInventoryIsUpdated()
         {
             var good = new UnifiedGoodBuilder(this.Transaction).WithNonSerialisedDefaults(this.InternalOrganisation).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
@@ -382,7 +382,7 @@ namespace Allors.Database.Domain
                         }
 
                         var amountAlreadyInvoiced = shipmentItem.ShipmentItemBillingsWhereShipmentItem.Sum(v => v.Amount);
-                        var leftToInvoice = orderShipment.OrderItem.QuantityOrdered * orderShipment.OrderItem.AssignedUnitPrice - amountAlreadyInvoiced;
+                        var leftToInvoice = orderShipment.OrderItem.QuantityOrdered * orderShipment.OrderItem.UnitPrice - amountAlreadyInvoiced;
 
                         if (leftToInvoice > 0)
                         {


### PR DESCRIPTION
## Summary
When a customer shipment ships, each item is billed using:

```csharp
var leftToInvoice = orderShipment.OrderItem.QuantityOrdered * orderShipment.OrderItem.AssignedUnitPrice - amountAlreadyInvoiced;
if (leftToInvoice > 0) { /* create SalesInvoiceItem + ShipmentItemBilling */ }
```

`AssignedUnitPrice` is the **optional** assigned price. For a **catalog-priced** line (priced via `BasePrice`/`PriceComponent`, no assigned price) it is null, so `leftToInvoice` is null, `leftToInvoice > 0` is false, and the line is **never invoiced** on shipment. Fix: compute from the derived `UnitPrice` (which the created invoice item already uses at the next line).

## Test
Adds `CustomerShipmentTests.GivenCatalogPricedOrderItem_WhenCustomerShipmentShipped_ThenItemIsInvoiced`: a catalog-priced order item (a `BasePrice` for the good, no `AssignedUnitPrice`) taken through post/accept/pick/ship, asserting the shipped item has a `ShipmentItemBilling`.

- **RED** on un-fixed code (right reason): `Assert.NotEmpty() Failure: Collection was empty` (the line was dropped).
- **GREEN** after the fix.

Note: `CustomerShipment` billing is shadowed by an Aviation `StopPropagation` override; the base fix is still correct/wanted upstream.