### PR TITLE
fix(ci): stop Nerdbank.GitVersioning from corrupting GITHUB_ENV under parallel builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- CI no longer fails intermittently with `Unable to process file command 'env' successfully. Invalid
+  format '<version>'`. Under GitHub Actions, Nerdbank.GitVersioning's `SetCloudBuildVersionVars` MSBuild
+  target appended its (unused) `Git*` version variables to the shared `$GITHUB_ENV` on every project
+  build; because the Nuke build compiles projects in parallel, the concurrent appends interleaved and
+  corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
+  `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
+  is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
 - `CustomerShipment` billing computed how much was left to invoice from the **optional** `AssignedUnitPrice`
   (`QuantityOrdered * AssignedUnitPrice - amountAlreadyInvoiced`). For a catalog-priced order line (no assigned
   price), `AssignedUnitPrice` is null, so the result was null, `leftToInvoice > 0` was false, and the line was

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -1,0 +1,26 @@
+<Project>
+  <!--
+    Neutralize Nerdbank.GitVersioning's GitHub Actions $GITHUB_ENV writes.
+
+    On every project build under GitHub Actions, NB.GV's `SetCloudBuildVersionVars` target appends
+    its Git* version variables (GitBuildVersion, GitBuildVersionSimple, GitAssemblyInformationalVersion)
+    to the shared $GITHUB_ENV file. Nothing in this repo consumes those variables, and when the Nuke
+    build compiles many projects in parallel their appends interleave and corrupt the file, so a
+    random matrix job intermittently fails with:
+
+        ##[error]Unable to process file command 'env' successfully.
+        ##[error]Invalid format '<version fragment>'
+
+    (`version.json` `cloudBuild.setVersionVariables: false` does NOT gate this MSBuild-side write.)
+
+    Clearing the item before the target runs makes its `@(CloudBuildVersionVars) != ''` condition
+    false, so the target is skipped. Assembly version stamping is unaffected — it does not depend on
+    these cloud variables. The dedicated `dotnet nbgv cloud` workflow step remains the single, correct
+    place those variables are set if ever needed.
+  -->
+  <Target Name="_DisableNbgvCloudBuildVersionVars" BeforeTargets="SetCloudBuildVersionVars">
+    <ItemGroup>
+      <CloudBuildVersionVars Remove="@(CloudBuildVersionVars)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
## Problem

CI fails intermittently — a random matrix job dies *after* a green build/tests with:

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '<version>'    # e.g. '3.2.0' on main, '.1.3' on v3.1
```

## Root cause

Every dotnet project references the **Nerdbank.GitVersioning** MSBuild package. Under GitHub Actions
its `SetCloudBuildVersionVars` target appends `Git*` version variables (`GitBuildVersion`,
`GitBuildVersionSimple`, `GitAssemblyInformationalVersion`) to the **shared `$GITHUB_ENV`** file on
every project build. The Nuke build compiles projects in parallel, so the concurrent appends
**interleave and corrupt** the file, orphaning a version fragment onto its own line — which the
runner rejects. Whichever job's runner reads the corrupted file fails; the rest stay green (hence the
randomness, and why some runs pass entirely).

The variables are **unused** anywhere in the repo, and `cloudBuild.setVersionVariables: false` does
**not** gate this MSBuild-side write (verified empirically).

## Fix

A new `dotnet/Directory.Build.targets` clears the `CloudBuildVersionVars` item just before the target
runs, so its `@(CloudBuildVersionVars) != ''` condition is false and the emission is skipped.

- Verified locally: with the fix, a build under `GITHUB_ACTIONS=true` writes **0** lines to
  `$GITHUB_ENV` (was 3 per build, doubled without caching), in both NB.GV cache modes.
- Assembly version stamping is **unaffected** (still `3.x.y.z` / `3.x.y+sha`).
- The dedicated `dotnet nbgv cloud` workflow step (the correct, single writer) is untouched.

Same fix is being applied to `v3.1` and `v3.0`, which carry the identical setup.
