### PR TITLE
fix(apps): pick serialised non-unified goods in CustomerShipment [BUG-23]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerShipment.CreatePickList` decided whether a shipment item was serialised from `unifiedGood` only
+  (`unifiedGood?.InventoryItemKind`). For a serialised `NonUnifiedGood`/`NonUnifiedPart`, `unifiedGood` is null,
+  so `serialized` was false and the non-serialised branch cast the part's `SerialisedInventoryItem` to
+  `NonSerialisedInventoryItem`, throwing an `InvalidCastException` when picking. It now derives `serialized` from
+  the resolved `part` (which covers all three good types), so picking a serialised non-unified good works.
 - CI no longer fails intermittently with `Unable to process file command 'env' successfully. Invalid
   format '<version>'`. Under GitHub Actions, Nerdbank.GitVersioning's `SetCloudBuildVersionVars` MSBuild
   target appended its (unused) `Git*` version variables to the shared `$GITHUB_ENV` on every project

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
@@ -1205,6 +1205,62 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenCustomerShipmentForSerialisedNonUnifiedGood_WhenPicked_ThenSerialisedInventoryIsHandled()
+        {
+            var good = new NonUnifiedGoodBuilder(this.Transaction).WithSerialisedDefaults(this.InternalOrganisation).Build();
+            this.Transaction.Derive();
+
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithSerialNumber("sn-bug23").Build();
+            good.Part.AddSerialisedItem(serialisedItem);
+            this.Transaction.Derive();
+
+            new InventoryItemTransactionBuilder(this.Transaction)
+                .WithQuantity(1)
+                .WithReason(new InventoryTransactionReasons(this.Transaction).PhysicalCount)
+                .WithPart(good.Part)
+                .WithSerialisedItem(serialisedItem)
+                .Build();
+            this.Transaction.Derive();
+
+            var mechelen = new CityBuilder(this.Transaction).WithName("Mechelen").Build();
+            var mechelenAddress = new PostalAddressBuilder(this.Transaction).WithPostalAddressBoundary(mechelen).WithAddress1("Haverwerf 15").Build();
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("customer").Build();
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(mechelenAddress)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).ShippingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer).Build();
+
+            this.Transaction.Derive();
+
+            var shipment = new CustomerShipmentBuilder(this.Transaction)
+                .WithShipToParty(customer)
+                .WithShipToAddress(mechelenAddress)
+                .WithShipmentMethod(new ShipmentMethods(this.Transaction).Ground)
+                .Build();
+
+            var shipmentItem = new ShipmentItemBuilder(this.Transaction)
+                .WithGood(good)
+                .WithSerialisedItem(serialisedItem)
+                .WithNextSerialisedItemAvailability(new SerialisedItemAvailabilities(this.Transaction).Sold)
+                .WithQuantity(1)
+                .Build();
+            shipment.AddShipmentItem(shipmentItem);
+
+            this.Transaction.Derive();
+
+            // Picking creates the pick list; a serialised NonUnifiedGood must be detected as serialised
+            // (otherwise the SerialisedInventoryItem is cast to NonSerialisedInventoryItem -> InvalidCastException).
+            shipment.Pick();
+
+            Assert.False(this.Derive().HasErrors);
+        }
+
+        [Fact]
         public void GivenCustomerShipmentContainingOrderOnHold_WhenTrySetStateToShipped_ThenActionIsNotAllowed()
         {
             var assessable = new VatRegimes(this.Transaction).ZeroRated;

--- a/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
@@ -523,8 +523,8 @@ namespace Allors.Database.Domain
                     var unifiedGood = shipmentItem.Good as UnifiedGood;
                     var nonUnifiedGood = shipmentItem.Good as NonUnifiedGood;
                     var nonUnifiedPart = shipmentItem.Good as NonUnifiedPart;
-                    var serialized = unifiedGood?.InventoryItemKind.Equals(new InventoryItemKinds(this.Transaction()).Serialised);
                     var part = unifiedGood ?? nonUnifiedGood?.Part ?? nonUnifiedPart;
+                    var serialized = part?.InventoryItemKind.Equals(new InventoryItemKinds(this.Transaction()).Serialised);
 
                     var facilities = ((InternalOrganisation)this.ShipFromParty).FacilitiesWhereOwner;
                     var inventoryItems = part.InventoryItemsWherePart.Where(v => facilities.Contains(v.Facility));


### PR DESCRIPTION
## What

`CustomerShipment.CreatePickList` decided whether a shipment item was serialised from `unifiedGood` only (`unifiedGood?.InventoryItemKind`), but resolves `part` (whose inventory it iterates) from `UnifiedGood`/`NonUnifiedGood`/`NonUnifiedPart`. For a serialised `NonUnifiedGood`/`NonUnifiedPart`, `unifiedGood` is null, so `serialized` was false and the non-serialised branch cast the part's `SerialisedInventoryItem` to `NonSerialisedInventoryItem`, throwing `InvalidCastException` on `Pick()`.

Fix derives `serialized` from the resolved `part`, which covers all three good shapes.

## Test

New `CustomerShipmentTests.GivenCustomerShipmentForSerialisedNonUnifiedGood_WhenPicked_ThenSerialisedInventoryIsHandled`: a serialised `NonUnifiedGood` stocked via an `InventoryItemTransaction`, a customer shipment with a serialised item, then `Pick()`.

- RED (un-fixed): `InvalidCastException: SerialisedInventoryItem -> NonSerialisedInventoryItem` at `CreatePickList()`.
- GREEN after fix.

[BUG-23]