### PR TITLE
fix(apps): deduct issued quantity per reserved item on ship [BUG-22]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerShipment` shipping over-deducted inventory when a shipment item was issued from more than one
+  inventory item. `AppsShip` iterates the item's `ReservedFromInventoryItems` and, for non-serialised parts,
+  created an `OutgoingShipment` transaction of the **whole** `shipmentItem.Quantity` for *each* reserved item —
+  so a quantity issued as a split (e.g. 6 + 4 across two facilities) deducted the full quantity twice. It now
+  deducts each reserved item's actually-issued quantity (summed from `ItemIssuancesWhereShipmentItem`), matching
+  the per-item granularity of the serialised branch.
 - `CustomerShipment.CreatePickList` decided whether a shipment item was serialised from `unifiedGood` only
   (`unifiedGood?.InventoryItemKind`). For a serialised `NonUnifiedGood`/`NonUnifiedPart`, `unifiedGood` is null,
   so `serialized` was false and the non-serialised branch cast the part's `SerialisedInventoryItem` to

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
@@ -1261,6 +1261,97 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenCustomerShipmentSplitAcrossTwoInventoryItems_WhenShipped_ThenInventoryIsDeductedOncePerIssuedQuantity()
+        {
+            var good = new UnifiedGoodBuilder(this.Transaction).WithNonSerialisedDefaults(this.InternalOrganisation).Build();
+            this.Transaction.Derive();
+
+            var facility1 = good.DefaultFacility;
+            var facility2 = new FacilityBuilder(this.Transaction)
+                .WithFacilityType(new FacilityTypes(this.Transaction).Warehouse)
+                .WithName("facility2")
+                .WithOwner(this.InternalOrganisation)
+                .Build();
+            this.Transaction.Derive();
+
+            // Stock the part across two owned facilities (6 + 5). Neither alone covers a shipment of 10, so the
+            // orderless pick must split the issuance across both inventory items (two ReservedFromInventoryItems).
+            new InventoryItemTransactionBuilder(this.Transaction)
+                .WithQuantity(6)
+                .WithReason(new InventoryTransactionReasons(this.Transaction).PhysicalCount)
+                .WithPart(good)
+                .WithFacility(facility1)
+                .Build();
+
+            new InventoryItemTransactionBuilder(this.Transaction)
+                .WithQuantity(5)
+                .WithReason(new InventoryTransactionReasons(this.Transaction).PhysicalCount)
+                .WithPart(good)
+                .WithFacility(facility2)
+                .Build();
+
+            var mechelen = new CityBuilder(this.Transaction).WithName("Mechelen").Build();
+            var mechelenAddress = new PostalAddressBuilder(this.Transaction).WithPostalAddressBoundary(mechelen).WithAddress1("Haverwerf 15").Build();
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("customer").Build();
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(mechelenAddress)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).ShippingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer).Build();
+
+            this.Transaction.Derive();
+
+            var shipment = new CustomerShipmentBuilder(this.Transaction)
+                .WithShipToParty(customer)
+                .WithShipToAddress(mechelenAddress)
+                .WithShipmentMethod(new ShipmentMethods(this.Transaction).Ground)
+                .Build();
+
+            var shipmentItem = new ShipmentItemBuilder(this.Transaction).WithGood(good).WithQuantity(10).Build();
+            shipment.AddShipmentItem(shipmentItem);
+
+            this.Transaction.Derive();
+
+            shipment.Pick();
+            this.Transaction.Derive();
+
+            // Precondition: the pick really did split across both inventory items.
+            Assert.Equal(2, shipmentItem.ReservedFromInventoryItems.Count());
+
+            var pickList = shipmentItem.ItemIssuancesWhereShipmentItem.ElementAt(0).PickListItem.PickListWherePickListItem;
+            pickList.Picker = this.OrderProcessor;
+            pickList.SetPicked();
+            this.Transaction.Derive();
+
+            var package = new ShipmentPackageBuilder(this.Transaction).Build();
+            package.AddPackagingContent(new PackagingContentBuilder(this.Transaction).WithShipmentItem(shipmentItem).WithQuantity(shipmentItem.Quantity).Build());
+            shipment.AddShipmentPackage(package);
+
+            this.Transaction.Derive();
+
+            shipment.Ship();
+
+            // The bug over-deducts and drives the split inventory items negative, so derive non-throwing here
+            // and assert no errors below (rather than letting the throwing derive mask the quantity assertion).
+            var derivation = this.Derive();
+
+            // Shipping must deduct exactly the shipped quantity (10), spread over the reserved items as actually
+            // issued. The bug deducted the full shipment quantity (10) once per reserved item => 20.
+            var outgoing = new InventoryTransactionReasons(this.Transaction).OutgoingShipment;
+            var totalDeducted = good.InventoryItemsWherePart
+                .SelectMany(v => v.InventoryItemTransactionsWhereInventoryItem)
+                .Where(v => Equals(v.Reason, outgoing))
+                .Sum(v => v.Quantity);
+
+            Assert.Equal(10, totalDeducted);
+            Assert.False(derivation.HasErrors);
+        }
+
+        [Fact]
         public void GivenCustomerShipmentContainingOrderOnHold_WhenTrySetStateToShipped_ThenActionIsNotAllowed()
         {
             var assessable = new VatRegimes(this.Transaction).ZeroRated;

--- a/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
@@ -238,12 +238,16 @@ namespace Allors.Database.Domain
                         }
                         else
                         {
+                            var issuedQuantity = shipmentItem.ItemIssuancesWhereShipmentItem
+                                .Where(v => Equals(v.InventoryItem, inventoryItem))
+                                .Sum(v => v.Quantity);
+
                             new InventoryItemTransactionBuilder(this.Transaction())
                                 .WithPart(inventoryItem.Part)
                                 .WithUnitOfMeasure(inventoryItem.Part.UnitOfMeasure)
                                 .WithFacility(inventoryItem.Facility)
                                 .WithReason(new InventoryTransactionReasons(this.Strategy.Transaction).OutgoingShipment)
-                                .WithQuantity(shipmentItem.Quantity)
+                                .WithQuantity(issuedQuantity)
                                 .WithCostInApplicationCurrency(inventoryItem.Part.PartWeightedAverage.AverageCostInApplicationCurrency)
                                 .Build();
                         }


### PR DESCRIPTION
## What

`CustomerShipment.AppsShip` iterates a shipment item''s `ReservedFromInventoryItems` and, for non-serialised parts, created an `OutgoingShipment` inventory transaction of the **whole** `shipmentItem.Quantity` for *each* reserved item. When a quantity is issued as a split across multiple inventory items (the orderless pick path splits across facilities and adds each to `ReservedFromInventoryItems`), shipping deducted the full quantity once per reserved item — e.g. qty 10 issued 6 + 4 across two facilities deducted 20.

Fix sums each reserved item''s actually-issued quantity from `ItemIssuancesWhereShipmentItem` and deducts that, matching the per-item granularity of the serialised branch. The common single-reservation case is unchanged.

## Test

New `CustomerShipmentTests.GivenCustomerShipmentSplitAcrossTwoInventoryItems_WhenShipped_ThenInventoryIsDeductedOncePerIssuedQuantity`: a non-serialised good stocked 6 + 5 across two owned facilities (forcing the pick to split), an orderless shipment of 10, then pick/setpicked/package/ship.

- RED (un-fixed): total `OutgoingShipment` deduction = 20 (expected 10); the over-deduction also drives the split items negative.
- GREEN after fix.

## Note

The worklist''s alternative candidate `itemIssuanceCorrection -= quantity` (`AppsOnDeriveQuantityDecreased`) is a **separate** bug, logged for its own PR — not addressed here.

[BUG-22]