### PR TITLE
fix(apps): guard PurchaseShipment receive against part-less items [BUG-24]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseShipment.AppsReceive` dereferenced `shipmentItem.Part.InventoryItemKind` for every shipment item with
+  no `ExistPart` guard, so receiving a shipment that contained a part-less item (e.g. a manually added
+  non-inventory line) threw a `NullReferenceException`. A part-less item has no inventory to receive, so it is now
+  marked received but skips the inventory receipt and inventory transaction (purchase order items without a part
+  are non-receivable, so order-linked receipts are unaffected).
 - `CustomerShipment` shipping over-deducted inventory when a shipment item was issued from more than one
   inventory item. `AppsShip` iterates the item's `ReservedFromInventoryItems` and, for non-serialised parts,
   created an `OutgoingShipment` transaction of the **whole** `shipmentItem.Quantity` for *each* reserved item —

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/PurchaseShipmentTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/PurchaseShipmentTests.cs
@@ -312,5 +312,29 @@ namespace Allors.Database.Domain.Tests
 
             Assert.True(shipment.ShipmentState.IsReceived);
         }
+
+        [Fact]
+        public void GivenPurchaseShipmentWithPartlessItem_WhenReceived_ThenReceiveDoesNotThrow()
+        {
+            var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();
+            new SupplierRelationshipBuilder(this.Transaction).WithSupplier(supplier).Build();
+            this.Transaction.Derive();
+
+            var shipment = new PurchaseShipmentBuilder(this.Transaction)
+                .WithShipmentMethod(new ShipmentMethods(this.Transaction).Ground)
+                .WithShipFromParty(supplier)
+                .Build();
+
+            // A shipment item without a Part (e.g. a non-inventory line). Receive must not dereference Part.
+            var shipmentItem = new ShipmentItemBuilder(this.Transaction).WithQuantity(1).Build();
+            shipment.AddShipmentItem(shipmentItem);
+            this.Transaction.Derive();
+
+            // Without the ExistPart guard, AppsReceive dereferences shipmentItem.Part.InventoryItemKind => NRE.
+            shipment.Receive();
+
+            Assert.False(this.Derive().HasErrors);
+            Assert.True(shipment.ShipmentState.IsReceived);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Shipment/PurchaseShipment.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Shipment/PurchaseShipment.cs
@@ -62,6 +62,13 @@ namespace Allors.Database.Domain
             {
                 shipmentItem.ShipmentItemState = new ShipmentItemStates(this.Transaction()).Received;
 
+                if (!shipmentItem.ExistPart)
+                {
+                    // A part-less shipment item (e.g. a non-inventory line) has no inventory to receive, so there
+                    // is no inventory receipt or inventory transaction to record for it.
+                    continue;
+                }
+
                 if (!shipmentItem.ExistShipmentReceiptWhereShipmentItem)
                 {
                     if (!shipmentItem.ExistOrderShipmentsWhereShipmentItem)


### PR DESCRIPTION
## What

`PurchaseShipment.AppsReceive` dereferenced `shipmentItem.Part.InventoryItemKind` for every shipment item with no `ExistPart` guard, so receiving a shipment that contained a part-less item (a manually added non-inventory line) threw a `NullReferenceException`.

A part-less line has no inventory to receive, so it is now marked received but skips both the inventory receipt and the inventory transaction. Purchase order items without a part are non-receivable (`PurchaseOrderItemIsReceivableRule`), so no order-linked receipt tracking is affected.

## Test

New `GivenPurchaseShipmentWithPartlessItem_WhenReceived_ThenReceiveDoesNotThrow`: a `PurchaseShipment` from a supplier with a part-less `ShipmentItem`, then `Receive()`.

- RED (un-fixed): `NullReferenceException` at `AppsReceive` line 89.
- GREEN after fix: no errors, shipment `IsReceived`.

## Note

The rule-side sibling `PurchaseShipmentShipToPartyRule` is tracked for the `apps-rules` area, not addressed here.

[BUG-24]