### PR TITLE
fix(apps): number customer returns by CustomerReturnSequence [BUG-21]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `InternalOrganisation.NextCustomerReturnNumber` decided enforced-vs-fiscal-year numbering from
+  `PurchaseShipmentSequence` instead of `CustomerReturnSequence`, so customer-return numbers followed the
+  purchase-shipment sequence setting rather than their own (e.g. a fiscal-year customer-return sequence used the
+  global enforced counter when purchase shipments were enforced). It now branches on `CustomerReturnSequence`.
 - `PurchaseShipment.AppsReceive` dereferenced `shipmentItem.Part.InventoryItemKind` for every shipment item with
   no `ExistPart` guard, so receiving a shipment that contained a part-less item (e.g. a manually added
   non-inventory line) threw a `NullReferenceException`. A part-less item has no inventory to receive, so it is now

--- a/dotnet/Apps/Database/Domain.Tests/Relation/InternalOrganisationTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Relation/InternalOrganisationTests.cs
@@ -312,6 +312,21 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenInternalOrganisationWithFiscalYearCustomerReturns_WhenNextCustomerReturnNumber_ThenCustomerReturnSequenceGovernsNumbering()
+        {
+            // CustomerReturn numbering must follow CustomerReturnSequence, independently of PurchaseShipmentSequence.
+            this.InternalOrganisation.PurchaseShipmentSequence = new PurchaseShipmentSequences(this.Transaction).EnforcedSequence;
+            this.InternalOrganisation.CustomerReturnSequence = new CustomerReturnSequences(this.Transaction).RestartOnFiscalYear;
+            this.Derive();
+
+            this.InternalOrganisation.NextCustomerReturnNumber(2099);
+
+            // RestartOnFiscalYear must create a per-fiscal-year sequence for the year. The bug branched on
+            // PurchaseShipmentSequence (Enforced), took the global-counter path, and created no fiscal-year sequence.
+            Assert.Contains(this.InternalOrganisation.FiscalYearsInternalOrganisationSequenceNumbers, v => v.FiscalYear == 2099);
+        }
+
+        [Fact]
         public void ChangedInvoiceSequenceDerivePurchaseOrderNumberCounter()
         {
             var internalOrganisation = new OrganisationBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Relation/InternalOrganisationExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Relation/InternalOrganisationExtensions.cs
@@ -269,7 +269,7 @@ namespace Allors.Database.Domain
 
         public static string NextCustomerReturnNumber(this InternalOrganisation @this, int year)
         {
-            if (@this.PurchaseShipmentSequence.Equals(new PurchaseShipmentSequences(@this.Transaction()).EnforcedSequence))
+            if (@this.CustomerReturnSequence.Equals(new CustomerReturnSequences(@this.Transaction()).EnforcedSequence))
             {
                 return string.Concat(@this.CustomerReturnNumberPrefix, @this.CustomerReturnNumberCounter?.NextValue()).Replace("{year}", year.ToString());
             }


### PR DESCRIPTION
## What

`InternalOrganisation.NextCustomerReturnNumber` decided enforced-vs-fiscal-year numbering from `PurchaseShipmentSequence` (a copy/paste from the adjacent `NextPurchaseShipmentNumber`), while its body correctly uses the `CustomerReturn*` prefix/counter and per-year sequence. So customer-return numbering followed the purchase-shipment sequence setting instead of its own `CustomerReturnSequence`.

Fix branches on `CustomerReturnSequence`.

## Test

New `InternalOrganisationTests.GivenInternalOrganisationWithFiscalYearCustomerReturns_WhenNextCustomerReturnNumber_ThenCustomerReturnSequenceGovernsNumbering`: sets `PurchaseShipmentSequence = EnforcedSequence` and `CustomerReturnSequence = RestartOnFiscalYear` (so they differ), calls `NextCustomerReturnNumber(2099)`, and asserts a per-fiscal-year sequence entry for 2099 was created (which only the `CustomerReturnSequence`-driven fiscal-year branch does).

- RED (un-fixed): no fiscal-year sequence created (enforced branch taken) — empty collection.
- GREEN after fix.

## Note

The rule-side sibling `CustomerReturnExistShipmentNumberRule` (which invokes this method) is tracked for the `apps-rules` area, not addressed here.

[BUG-21]