### PR TITLE
fix(apps): skip zero-billable parts in WorkEffort invoicing [BUG-25]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkEffort` invoicing billed a part that had a **zero** billable quantity. `CreateInvoiceItems` computed the
+  invoice quantity as `DerivedBillableQuantity != 0 ? DerivedBillableQuantity : Quantity`, so an inventory
+  assignment with `AssignedBillableQuantity = 0` (hence `DerivedBillableQuantity = 0`) fell back to the full
+  assignment `Quantity` and was invoiced anyway. It now skips assignments with `DerivedBillableQuantity <= 0`
+  and bills `DerivedBillableQuantity` directly, matching `WorkEffortTotalMaterialRevenueRule`.
 - `InternalOrganisation.NextCustomerReturnNumber` decided enforced-vs-fiscal-year numbering from
   `PurchaseShipmentSequence` instead of `CustomerReturnSequence`, so customer-return numbers followed the
   purchase-shipment sequence setting rather than their own (e.g. a fiscal-year customer-return sequence used the

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -692,6 +692,82 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenWorkEffortWithZeroBillablePart_WhenInvoiced_ThenPartIsNotInvoiced()
+        {
+            var organisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("Customer").Build();
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(new EmailAddressBuilder(this.Transaction).WithElectronicAddressString("customer@acme.com").Build())
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).BillingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithCustomer(customer).WithInternalOrganisation(organisation).Build();
+
+            var employee = new PersonBuilder(this.Transaction).WithFirstName("Good").WithLastName("Worker").Build();
+            new EmploymentBuilder(this.Transaction).WithEmployee(employee).WithEmployer(organisation).Build();
+
+            var today = DateTimeFactory.CreateDateTime(this.Transaction.Now());
+            var laterToday = DateTimeFactory.CreateDateTime(today.AddHours(4));
+
+            var part1 = this.CreatePart("P1");
+
+            this.Transaction.Derive();
+
+            new InventoryItemTransactionBuilder(this.Transaction)
+                .WithPart(part1)
+                .WithReason(new InventoryTransactionReasons(this.Transaction).IncomingShipment)
+                .WithQuantity(11)
+                .Build();
+
+            new BasePriceBuilder(this.Transaction)
+                .WithDescription("baseprice part1")
+                .WithPrice(10)
+                .WithProduct(part1)
+                .WithFromDate(today.AddDays(-1))
+                .Build();
+
+            var workOrder = new WorkTaskBuilder(this.Transaction).WithName("Task").WithCustomer(customer).Build();
+
+            this.Transaction.Derive();
+
+            var timeEntryToday = new TimeEntryBuilder(this.Transaction)
+                .WithRateType(new RateTypes(this.Transaction).StandardRate)
+                .WithFromDate(today)
+                .WithThroughDate(laterToday)
+                .WithWorkEffort(workOrder)
+                .WithAssignedBillingRate(12)
+                .Build();
+
+            employee.TimeSheetWhereWorker.AddTimeEntry(timeEntryToday);
+
+            // Part assigned with an explicit 0 billable quantity (e.g. used but not chargeable). It must not be invoiced.
+            new WorkEffortInventoryAssignmentBuilder(this.Transaction)
+                .WithAssignment(workOrder)
+                .WithInventoryItem(part1.InventoryItemsWherePart.FirstOrDefault())
+                .WithQuantity(3)
+                .WithAssignedBillableQuantity(0)
+                .Build();
+
+            this.Transaction.Derive();
+
+            workOrder.Complete();
+            this.Transaction.Derive();
+
+            workOrder.Invoice();
+            this.Transaction.Derive();
+
+            // The bug fell back to the full assignment Quantity (3) when DerivedBillableQuantity was 0, billing the
+            // part anyway. Only the time entry should be invoiced; the 0-billable part must not produce a billing.
+            Assert.Empty(workOrder.WorkEffortBillingsWhereWorkEffort);
+
+            var salesInvoice = customer.SalesInvoicesWhereBillToCustomer.First();
+            Assert.Single(salesInvoice.InvoiceItems);
+        }
+
+        [Fact]
         public void GivenWorkEffortWithInvoiceItems_WhenInvoiced_ThenInvoiceItemsAreInvoiced()
         {
             var organisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);

--- a/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkEffortExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkEffortExtensions.cs
@@ -151,9 +151,14 @@ namespace Allors.Database.Domain
 
             foreach (var workEffortInventoryAssignment in @this.WorkEffortInventoryAssignmentsWhereAssignment)
             {
+                if (workEffortInventoryAssignment.DerivedBillableQuantity <= 0)
+                {
+                    continue;
+                }
+
                 var part = workEffortInventoryAssignment.InventoryItem.Part;
 
-                var quantity = workEffortInventoryAssignment.DerivedBillableQuantity != 0 ? workEffortInventoryAssignment.DerivedBillableQuantity : workEffortInventoryAssignment.Quantity;
+                var quantity = workEffortInventoryAssignment.DerivedBillableQuantity;
 
                 var invoiceItem = new SalesInvoiceItemBuilder(transaction)
                     .WithInvoiceItemType(new InvoiceItemTypes(transaction).PartItem)


### PR DESCRIPTION
## What

`WorkEffort` invoicing (`CreateInvoiceItems`) computed the part invoice quantity as `DerivedBillableQuantity != 0 ? DerivedBillableQuantity : Quantity`. Since `DerivedBillableQuantity = AssignedBillableQuantity ?? Quantity` is already the correct billable quantity, the fallback over-bills the full assignment `Quantity` precisely when `AssignedBillableQuantity` is explicitly 0 — invoicing a part that should not be billed.

Fix skips assignments with `DerivedBillableQuantity <= 0` and bills `DerivedBillableQuantity` directly, matching `WorkEffortTotalMaterialRevenueRule`.

## Test

New `WorkTaskTests.GivenWorkEffortWithZeroBillablePart_WhenInvoiced_ThenPartIsNotInvoiced`: a work task with a billable time entry plus a `WorkEffortInventoryAssignment` of `Quantity = 3` and `AssignedBillableQuantity = 0`, completed and invoiced.

- RED (un-fixed): the 0-billable part still produced a `WorkEffortBilling` (billed the full 3).
- GREEN after fix: part skipped, only the time entry invoiced.

## Note

The `AppsMonthly` collective-billing path (`WorkTasks`) has the same 0-skip omission and is fixed separately (own PR).

[BUG-25]