### PR TITLE
fix(apps): skip zero-billable parts in monthly work-effort billing [BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkTasks.AppsMonthly` (collective/monthly work-effort invoicing) built a `SalesInvoiceItem` for every
+  inventory assignment from `DerivedBillableQuantity` with no guard, so an assignment with a **zero** billable
+  quantity produced an invalid 0-quantity invoice line. It now skips assignments with `DerivedBillableQuantity <= 0`,
+  matching the per-effort `WorkEffort` invoicing and `WorkEffortTotalMaterialRevenueRule`.
 - `WorkEffort` invoicing billed a part that had a **zero** billable quantity. `CreateInvoiceItems` computed the
   invoice quantity as `DerivedBillableQuantity != 0 ? DerivedBillableQuantity : Quantity`, so an inventory
   assignment with `AssignedBillableQuantity = 0` (hence `DerivedBillableQuantity = 0`) fell back to the full

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -768,6 +768,82 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenCollectiveWorkEffortWithZeroBillablePart_WhenMonthlyInvoiced_ThenPartIsNotInvoiced()
+        {
+            var organisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("Customer").Build();
+            new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(customer)
+                .WithContactMechanism(new EmailAddressBuilder(this.Transaction).WithElectronicAddressString("customer@acme.com").Build())
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).BillingAddress)
+                .WithUseAsDefault(true)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction).WithCustomer(customer).WithInternalOrganisation(organisation).Build();
+
+            // Collective (monthly) invoicing for this customer.
+            customer.CollectiveWorkEffortInvoice = true;
+
+            var employee = new PersonBuilder(this.Transaction).WithFirstName("Good").WithLastName("Worker").Build();
+            new EmploymentBuilder(this.Transaction).WithEmployee(employee).WithEmployer(organisation).Build();
+
+            var today = DateTimeFactory.CreateDateTime(this.Transaction.Now());
+            var laterToday = DateTimeFactory.CreateDateTime(today.AddHours(4));
+
+            var part1 = this.CreatePart("P1");
+
+            this.Transaction.Derive();
+
+            new InventoryItemTransactionBuilder(this.Transaction)
+                .WithPart(part1)
+                .WithReason(new InventoryTransactionReasons(this.Transaction).IncomingShipment)
+                .WithQuantity(11)
+                .Build();
+
+            new BasePriceBuilder(this.Transaction)
+                .WithDescription("baseprice part1")
+                .WithPrice(10)
+                .WithProduct(part1)
+                .WithFromDate(today.AddDays(-1))
+                .Build();
+
+            var workOrder = new WorkTaskBuilder(this.Transaction).WithName("Task").WithCustomer(customer).WithTakenBy(organisation).Build();
+
+            this.Transaction.Derive();
+
+            var timeEntryToday = new TimeEntryBuilder(this.Transaction)
+                .WithRateType(new RateTypes(this.Transaction).StandardRate)
+                .WithFromDate(today)
+                .WithThroughDate(laterToday)
+                .WithWorkEffort(workOrder)
+                .WithAssignedBillingRate(12)
+                .Build();
+
+            employee.TimeSheetWhereWorker.AddTimeEntry(timeEntryToday);
+
+            // Part assigned with an explicit 0 billable quantity. It must not be invoiced in the monthly run.
+            new WorkEffortInventoryAssignmentBuilder(this.Transaction)
+                .WithAssignment(workOrder)
+                .WithInventoryItem(part1.InventoryItemsWherePart.FirstOrDefault())
+                .WithQuantity(3)
+                .WithAssignedBillableQuantity(0)
+                .Build();
+
+            this.Transaction.Derive();
+
+            workOrder.Complete();
+            this.Transaction.Derive();
+
+            WorkTasks.AppsMonthly(this.Transaction);
+            this.Derive();
+
+            // The bug built a 0-quantity SalesInvoiceItem for the part (DerivedBillableQuantity == 0) with no skip.
+            // The 0-billable part must not produce a billing; only the time entry is invoiced.
+            Assert.Empty(workOrder.WorkEffortBillingsWhereWorkEffort);
+        }
+
+        [Fact]
         public void GivenWorkEffortWithInvoiceItems_WhenInvoiced_ThenInvoiceItemsAreInvoiced()
         {
             var organisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);

--- a/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkTasks.cs
+++ b/dotnet/Apps/Database/Domain/Apps/WorkEffort/WorkTasks.cs
@@ -93,6 +93,11 @@ namespace Allors.Database.Domain
 
                                 foreach (var inventoryAssignment in workEffort.WorkEffortInventoryAssignmentsWhereAssignment)
                                 {
+                                    if (inventoryAssignment.DerivedBillableQuantity <= 0)
+                                    {
+                                        continue;
+                                    }
+
                                     var part = inventoryAssignment.InventoryItem.Part;
 
                                     var invoiceItem = new SalesInvoiceItemBuilder(transaction)


### PR DESCRIPTION
## What

`WorkTasks.AppsMonthly` (collective/monthly work-effort invoicing) built a `PartItem` `SalesInvoiceItem` for each inventory assignment from `DerivedBillableQuantity` with no guard, so an assignment with `AssignedBillableQuantity = 0` (hence `DerivedBillableQuantity = 0`) produced an invalid 0-quantity invoice line.

Fix skips assignments with `DerivedBillableQuantity <= 0` — the same guard applied to the per-effort `WorkEffort.CreateInvoiceItems` path, and matching `WorkEffortTotalMaterialRevenueRule`.

This is the sibling of the per-effort over-billing fix (the `WorkEffort` invoicing PR); discovered while fixing it.

## Test

New `WorkTaskTests.GivenCollectiveWorkEffortWithZeroBillablePart_WhenMonthlyInvoiced_ThenPartIsNotInvoiced`: a customer with `CollectiveWorkEffortInvoice = true`, a Completed work task with a billable time entry plus a `WorkEffortInventoryAssignment` of `Quantity = 3` and `AssignedBillableQuantity = 0`, then `WorkTasks.AppsMonthly(...)`.

- RED (un-fixed): the 0-billable part still produced a `WorkEffortBilling`.
- GREEN after fix: part skipped, only the time entry billed.

[BUG-D1]