### PR TITLE
fix(apps): return null from TimeFrequency.GetConvertToFactor when no conversion [BUG-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `TimeFrequency.GetConvertToFactor` dereferenced `FirstOrDefault(...).ConversionFactor`: when the frequency had
+  no conversion to the requested target, `FirstOrDefault` returned null and the `.ConversionFactor` access threw a
+  `NullReferenceException` instead of returning null. It now uses `?.ConversionFactor`, honouring the method's
+  `decimal?` contract (and `ConvertToFrequency`, which already null-checks the result).
 - `WorkTasks.AppsMonthly` (collective/monthly work-effort invoicing) built a `SalesInvoiceItem` for every
   inventory assignment from `DerivedBillableQuantity` with no guard, so an assignment with a **zero** billable
   quantity produced an invalid 0-quantity invoice line. It now skips assignments with `DerivedBillableQuantity <= 0`,

--- a/dotnet/Apps/Database/Domain.Tests/Accounting/TimeFrequencyTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Accounting/TimeFrequencyTests.cs
@@ -1,0 +1,24 @@
+// <copyright file="TimeFrequencyTests.cs" company="Allors bv">
+// Copyright (c) Allors bv. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Allors.Database.Domain.Tests
+{
+    using Xunit;
+
+    public class TimeFrequencyTests : DomainTest, IClassFixture<Fixture>
+    {
+        public TimeFrequencyTests(Fixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void GivenTimeFrequencyWithoutConversionToTarget_WhenGetConvertToFactor_ThenReturnsNull()
+        {
+            var frequencies = new TimeFrequencies(this.Transaction);
+
+            // Hour has conversions to Millisecond..Week but none to Year, so GetConvertToFactor must return null
+            // rather than dereferencing the null FirstOrDefault result.
+            Assert.Null(frequencies.Hour.GetConvertToFactor(frequencies.Year));
+        }
+    }
+}

--- a/dotnet/Apps/Database/Domain/Apps/Accounting/TimeFrequency.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Accounting/TimeFrequency.cs
@@ -10,7 +10,7 @@ namespace Allors.Database.Domain
     public partial class TimeFrequency
     {
         public decimal? GetConvertToFactor(TimeFrequency timeFrquency)
-            => this.UnitOfMeasureConversions?.FirstOrDefault(c => c.ToUnitOfMeasure.Equals(timeFrquency)).ConversionFactor;
+            => this.UnitOfMeasureConversions?.FirstOrDefault(c => c.ToUnitOfMeasure.Equals(timeFrquency))?.ConversionFactor;
 
         public decimal? ConvertToFrequency(decimal value, TimeFrequency timeFrequency)
         {


### PR DESCRIPTION
## What

`TimeFrequency.GetConvertToFactor` dereferenced `FirstOrDefault(...).ConversionFactor`. The `?.` only guards the (never-null) `UnitOfMeasureConversions` collection; `FirstOrDefault(...)` returns null whenever the frequency has no conversion to the requested target, and `.ConversionFactor` on that null threw a `NullReferenceException` instead of returning null as the `decimal?` signature implies.

Fix uses `?.ConversionFactor`.

## Test

New `Accounting/TimeFrequencyTests.cs` → `GivenTimeFrequencyWithoutConversionToTarget_WhenGetConvertToFactor_ThenReturnsNull`: `Hour.GetConvertToFactor(Year)` (the seeded frequencies only convert within Millisecond..Week).

- RED (un-fixed): `NullReferenceException` at `GetConvertToFactor` line 13.
- GREEN after fix: returns null.

[BUG-13]