### PR TITLE
fix(apps): deny SetReadyForProcessing on item-less Proposals [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- `Proposal` quotes could be set ready for processing even with no valid quote items. The `Proposals` security
+  config set `DeniedPermissions` on the **`ProductQuote`** `SetReadyForProcessing` revocation (a copy-paste from
+  `ProductQuotes`) instead of the `Proposal` one, so the `ProposalSetReadyForProcessingRevocation` that
+  `ProposalDeniedPermissionRule` attaches to a created, item-less proposal denied nothing — a no-op gate. It now
+  populates `ProposalSetReadyForProcessingRevocation.DeniedPermissions`, making the gate effective (and no longer
+  clobbering the ProductQuote revocation's permissions).
 - `TimeFrequency.GetConvertToFactor` dereferenced `FirstOrDefault(...).ConversionFactor`: when the frequency had
   no conversion to the requested target, `FirstOrDefault` returned null and the `.ConversionFactor` access threw a
   `NullReferenceException` instead of returning null. It now uses `?.ConversionFactor`, honouring the method's

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProposalTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProposalTests.cs
@@ -78,6 +78,31 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void OnChangedProposalValidQuoteItemsDeriveSetReadyForProcessingDeniedPermission()
+        {
+            var quote = new ProposalBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var quoteItem = new QuoteItemBuilder(this.Transaction)
+                    .WithInvoiceItemType(new InvoiceItemTypeBuilder(this.Transaction).Build())
+                    .WithAssignedUnitPrice(1)
+                    .Build();
+            quote.AddQuoteItem(quoteItem);
+            this.Derive();
+
+            quoteItem.Cancel();
+            this.Derive();
+
+            // The revocation is attached (Created, no valid items), but the gate is only effective if the
+            // revocation actually denies the SetReadyForProcessing permission. The bug populated the ProductQuote
+            // revocation instead, leaving the Proposal revocation's DeniedPermissions empty (a no-op gate).
+            Assert.Contains(this.setReadyForProcessingRevocation, quote.Revocations);
+
+            var setReadyForProcessingPermission = new Permissions(this.Transaction).Get(this.M.Proposal, this.M.Proposal.SetReadyForProcessing);
+            Assert.Contains(setReadyForProcessingPermission, quote.Revocations.SelectMany(v => v.DeniedPermissions));
+        }
+
+        [Fact]
         public void OnChangedProductQuoteStateNotCreatedDeriveSetReadyPermission()
         {
             var quote = this.InternalOrganisation.CreateB2BProductQuoteWithSerialisedItem(this.Transaction.Faker());

--- a/dotnet/Apps/Database/Domain/Apps/Order/Proposals.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/Proposals.cs
@@ -65,7 +65,7 @@ namespace Allors.Database.Domain
                 permissions.Get(this.Meta, this.Meta.Delete),
             };
 
-            revocations.ProductQuoteSetReadyForProcessingRevocation.DeniedPermissions = new[]
+            revocations.ProposalSetReadyForProcessingRevocation.DeniedPermissions = new[]
             {
                 permissions.Get(this.Meta, this.Meta.SetReadyForProcessing),
             };


### PR DESCRIPTION
## What

`Proposals.AppsSecure` configures revocations for the `Proposal` type. At `:68` it set `DeniedPermissions` on the **`ProductQuoteSetReadyForProcessingRevocation`** (a copy-paste from `ProductQuotes.cs`, which already sets it) instead of the dedicated `ProposalSetReadyForProcessingRevocation`.

`ProposalDeniedPermissionRule` attaches `ProposalSetReadyForProcessingRevocation` to a `Created` proposal with no valid quote items — but since its `DeniedPermissions` was never populated, the attached revocation denied nothing, so `SetReadyForProcessing` was never actually revoked (a no-op gate). `Proposal` and `ProductQuote` are sibling concrete `Quote` types, so they do not share the revocation.

Fix populates `ProposalSetReadyForProcessingRevocation.DeniedPermissions` (and stops clobbering the ProductQuote revocation). The attaching rule is already correct; no rule change.

## Test

New `ProposalDeniedPermissionRuleTests.OnChangedProposalValidQuoteItemsDeriveSetReadyForProcessingDeniedPermission` (`SetupSecurity = true`): a `Proposal` whose only quote item is cancelled (Created, no valid items → revocation attached), asserting the attached revocation actually carries the `SetReadyForProcessing` permission in its `DeniedPermissions`. (Existing tests only assert attachment, which passes even with the bug.)

- RED (un-fixed): attached, but `SetReadyForProcessing` not in `DeniedPermissions`.
- GREEN after fix.

[BUG-03]