### PR TITLE
fix(apps): nest quote feature items under their order item on Order [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ under a dated version heading.
 
 ### Fixed
 
+- `Quote.Order` (`QuoteExtensions.AppsOrder`) materialised a flat `SalesOrderItem` for **every** quote item,
+  including feature sub-items (`QuotedWithFeatures`), instead of nesting them. A feature became a separate priced
+  order line (double-counting), and — having no parent `OrderedWithFeature` link — threw a `NullReferenceException`
+  during order-item pricing (`SalesOrderItemPriceRule`). Ordering a quote now creates order items only for
+  top-level quote items and nests their ordered feature sub-items under the parent via `OrderedWithFeature`,
+  mirroring the quote's `QuotedWithFeature` structure and the quote-copy logic.
 - `Proposal` quotes could be set ready for processing even with no valid quote items. The `Proposals` security
   config set `DeniedPermissions` on the **`ProductQuote`** `SetReadyForProcessing` revocation (a copy-paste from
   `ProductQuotes`) instead of the `Proposal` one, so the `ProposalSetReadyForProcessingRevocation` that

--- a/dotnet/Apps/Database/Domain.Tests/Order/QuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/QuoteTests.cs
@@ -661,6 +661,59 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenQuoteWithProductFeature_WhenOrdered_ThenFeatureIsNestedUnderItsOrderItem()
+        {
+            var product = new NonUnifiedGoodBuilder(this.Transaction).Build();
+
+            new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProduct(product)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+
+            var customer = this.InternalOrganisation.ActiveCustomers.FirstOrDefault();
+            var quote = new ProductQuoteBuilder(this.Transaction).WithReceiver(customer).WithIssueDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var quoteItem = new QuoteItemBuilder(this.Transaction).WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductItem).WithProduct(product).WithQuantity(1).Build();
+            quote.AddQuoteItem(quoteItem);
+            this.Derive();
+
+            var productFeature = new ColourBuilder(this.Transaction).WithName("a colour").Build();
+            new BasePriceBuilder(this.Transaction)
+                .WithPricedBy(this.InternalOrganisation)
+                .WithProduct(product)
+                .WithProductFeature(productFeature)
+                .WithPrice(0.1M)
+                .WithFromDate(this.Transaction.Now().AddMinutes(-1))
+                .Build();
+            this.Derive();
+
+            var featureItem = new QuoteItemBuilder(this.Transaction).WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductFeatureItem).WithProductFeature(productFeature).WithQuantity(1).Build();
+            quoteItem.AddQuotedWithFeature(featureItem);
+            quote.AddQuoteItem(featureItem);
+            this.Derive();
+
+            // Accept both items (the state quote items are in when an accepted quote is ordered), then order.
+            var accepted = new QuoteItemStates(this.Transaction).Accepted;
+            quoteItem.QuoteItemState = accepted;
+            featureItem.QuoteItemState = accepted;
+            this.Derive();
+
+            quote.Order();
+            this.Derive();
+
+            var salesOrder = quote.SalesOrderWhereQuote;
+            Assert.NotNull(salesOrder);
+
+            // The feature must be nested under its product order item (OrderedWithFeature), mirroring the quote's
+            // QuotedWithFeature, not materialised as a separate flat order line.
+            var productOrderItem = salesOrder.SalesOrderItems.First(v => v.ExistProduct);
+            Assert.Contains(productOrderItem.OrderedWithFeatures, v => v is SalesOrderItem soi && Equals(soi.ProductFeature, productFeature));
+        }
+
+        [Fact]
         public void OnChangedReceiverCalculatePrice()
         {
             var theGood = new CustomOrganisationClassificationBuilder(this.Transaction).WithName("good customer").Build();

--- a/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Order/QuoteExtensions.cs
@@ -152,29 +152,42 @@ namespace Allors.Database.Domain
                 .WithLocale(@this.DerivedLocale)
                 .Build();
 
+            var orderedState = new QuoteItemStates(@this.Strategy.Transaction).Ordered;
+
             var quoteItems = @this.ValidQuoteItems
-                .Where(i => i.QuoteItemState.Equals(new QuoteItemStates(@this.Strategy.Transaction).Ordered))
+                .Where(i => i.QuoteItemState.Equals(orderedState))
                 .ToArray();
 
-            foreach (var quoteItem in quoteItems)
-            {
-                quoteItem.QuoteItemState = new QuoteItemStates(@this.Strategy.Transaction).Ordered;
+            SalesOrderItem CreateSalesOrderItem(QuoteItem quoteItem) =>
+                new SalesOrderItemBuilder(@this.Strategy.Transaction)
+                    .WithInvoiceItemType(quoteItem.InvoiceItemType)
+                    .WithAssignedDeliveryDate(quoteItem.EstimatedDeliveryDate)
+                    .WithAssignedUnitPrice(quoteItem.UnitPrice)
+                    .WithAssignedVatRegime(quoteItem.AssignedVatRegime)
+                    .WithAssignedIrpfRegime(quoteItem.AssignedIrpfRegime)
+                    .WithProduct(quoteItem.Product)
+                    .WithSerialisedItem(quoteItem.SerialisedItem)
+                    .WithNextSerialisedItemAvailability(new SerialisedItemAvailabilities(@this.Transaction()).Sold)
+                    .WithProductFeature(quoteItem.ProductFeature)
+                    .WithQuantityOrdered(quoteItem.Quantity)
+                    .WithDescription(quoteItem.Details)
+                    .WithInternalComment(quoteItem.InternalComment)
+                    .Build();
 
-                salesOrder.AddSalesOrderItem(
-                    new SalesOrderItemBuilder(@this.Strategy.Transaction)
-                        .WithInvoiceItemType(quoteItem.InvoiceItemType)
-                        .WithAssignedDeliveryDate(quoteItem.EstimatedDeliveryDate)
-                        .WithAssignedUnitPrice(quoteItem.UnitPrice)
-                        .WithAssignedVatRegime(quoteItem.AssignedVatRegime)
-                        .WithAssignedIrpfRegime(quoteItem.AssignedIrpfRegime)
-                        .WithProduct(quoteItem.Product)
-                        .WithSerialisedItem(quoteItem.SerialisedItem)
-                        .WithNextSerialisedItemAvailability(new SerialisedItemAvailabilities(@this.Transaction()).Sold)
-                        .WithProductFeature(quoteItem.ProductFeature)
-                        .WithQuantityOrdered(quoteItem.Quantity)
-                        .WithDescription(quoteItem.Details)
-                        .WithInternalComment(quoteItem.InternalComment)
-                        .Build());
+            // Top-level quote items become order lines; their ordered feature sub-items are nested under the
+            // created order item via OrderedWithFeature (mirroring the quote's QuotedWithFeature), not materialised
+            // as separate flat order lines (which double-counts and, with no parent, cannot be priced).
+            foreach (var quoteItem in quoteItems.Where(i => !i.ExistQuoteItemWhereQuotedWithFeature))
+            {
+                var orderItem = CreateSalesOrderItem(quoteItem);
+                salesOrder.AddSalesOrderItem(orderItem);
+
+                foreach (var featureItem in quoteItem.QuotedWithFeatures.Where(f => f.QuoteItemState.Equals(orderedState)))
+                {
+                    var featureOrderItem = CreateSalesOrderItem(featureItem);
+                    salesOrder.AddSalesOrderItem(featureOrderItem);
+                    orderItem.AddOrderedWithFeature(featureOrderItem);
+                }
             }
 
             foreach (var salesTerm in @this.SalesTerms)


### PR DESCRIPTION
## What

`QuoteExtensions.AppsOrder` (Quote → SalesOrder) materialised a flat `SalesOrderItem` for **every** quote item, including feature sub-items (`QuotedWithFeatures`), instead of nesting them. Consequences:

- A feature sub-item became a separate, independently-priced order line — double-counting.
- A flat feature order item has no `SalesOrderItemWhereOrderedWithFeature`, so `SalesOrderItemPriceRule` dereferenced a null parent and threw a `NullReferenceException` while pricing the order.

The intended model is nested: `SalesOrderItem.OrderedWithFeatures` mirrors `QuoteItem.QuotedWithFeatures`, `SalesOrderItemPriceRule` folds nested features into the parent''s price, and the quote-copy logic nests features.

Fix: `Order()` now creates order items only for top-level quote items and nests each ordered feature sub-item under its parent via `OrderedWithFeature` (a local `CreateSalesOrderItem` builds both). Mirrors `CopyQuoteItem`.

## Test

New `QuoteTests.GivenQuoteWithProductFeature_WhenOrdered_ThenFeatureIsNestedUnderItsOrderItem`: a product quote with a product item + a nested `QuotedWithFeature` colour feature (both priced), accepted then ordered.

- RED (un-fixed): `NullReferenceException` in `SalesOrderItemPriceRule` (flat feature, no parent).
- GREEN after fix: the product order item carries the feature as a nested `OrderedWithFeature`.

[BUG-06]