### PR TITLE
fix(apps): spread quantity-decrease correction across all issuances [BUG-D2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerShipment.AppsOnDeriveQuantityDecreased` mis-applied a quantity-decrease correction when a shipment
+  item was issued from more than one `ItemIssuance`. While spreading the correction it subtracted the **whole**
+  correction from the running remainder after the first issuance (`itemIssuanceCorrection -= quantity`) rather
+  than the amount just applied (`-= subQuantity`), so the remainder zeroed out, the loop stopped early, and later
+  issuances were left uncorrected (the decrease was under-applied). It now subtracts `subQuantity`.
 - `Quote.Order` (`QuoteExtensions.AppsOrder`) materialised a flat `SalesOrderItem` for **every** quote item,
   including feature sub-items (`QuotedWithFeatures`), instead of nesting them. A feature became a separate priced
   order line (double-counting), and — having no parent `OrderedWithFeature` link — threw a `NullReferenceException`

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/Customershipmenttests.cs
@@ -1352,6 +1352,31 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenShipmentItemWithMultipleIssuances_WhenQuantityDecreased_ThenCorrectionIsSpreadAcrossAllIssuances()
+        {
+            var customerShipment = new CustomerShipmentBuilder(this.Transaction).Build();
+            var shipmentItem = new ShipmentItemBuilder(this.Transaction).WithQuantity(10).Build();
+            customerShipment.AddShipmentItem(shipmentItem);
+
+            // The shipment item's quantity of 10 is issued from two inventory items (6 + 4).
+            new ItemIssuanceBuilder(this.Transaction).WithShipmentItem(shipmentItem).WithQuantity(6).Build();
+            new ItemIssuanceBuilder(this.Transaction).WithShipmentItem(shipmentItem).WithQuantity(4).Build();
+
+            var order = new SalesOrderBuilder(this.Transaction).Build();
+            var orderItem = new SalesOrderItemBuilder(this.Transaction).Build();
+            order.AddSalesOrderItem(orderItem);
+
+            new OrderShipmentBuilder(this.Transaction).WithOrderItem(orderItem).WithShipmentItem(shipmentItem).WithQuantity(10).Build();
+
+            // Decrease the shipped quantity by 7: the correction must be spread across BOTH issuances (6 fully +
+            // 1 from the next), leaving 3 issued. The bug subtracted the whole correction from the running
+            // remainder after the first issuance, stopping early and only applying 6 (leaving 4).
+            customerShipment.AppsOnDeriveQuantityDecreased(shipmentItem, orderItem, 7);
+
+            Assert.Equal(3, shipmentItem.ItemIssuancesWhereShipmentItem.Sum(v => v.Quantity));
+        }
+
+        [Fact]
         public void GivenCustomerShipmentContainingOrderOnHold_WhenTrySetStateToShipped_ThenActionIsNotAllowed()
         {
             var assessable = new VatRegimes(this.Transaction).ZeroRated;

--- a/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Shipment/CustomerShipment.cs
@@ -455,7 +455,7 @@ namespace Allors.Database.Domain
                         if (itemIssuance.Quantity < itemIssuanceCorrection)
                         {
                             subQuantity = itemIssuance.Quantity;
-                            itemIssuanceCorrection -= quantity;
+                            itemIssuanceCorrection -= subQuantity;
                         }
                         else
                         {


### PR DESCRIPTION
## What

`CustomerShipment.AppsOnDeriveQuantityDecreased` (invoked by `OrderShipmentRule` when an `OrderShipment`''s quantity decreases) spreads the decrease across the shipment item''s `ItemIssuance`s. In the `itemIssuance.Quantity < itemIssuanceCorrection` branch it subtracted the **whole** correction (`itemIssuanceCorrection -= quantity`) from the running remainder instead of the amount actually applied to that issuance (`-= subQuantity`).

So when a shipment item was issued from more than one `ItemIssuance`, the remainder zeroed out after the first issuance, the loop `break`ed, and later issuances were never corrected — the quantity decrease was under-applied.

Fix subtracts `subQuantity`.

## Test

New `CustomerShipmentTests.GivenShipmentItemWithMultipleIssuances_WhenQuantityDecreased_ThenCorrectionIsSpreadAcrossAllIssuances`: a shipment item (qty 10) with two `ItemIssuance`s (6 + 4) linked to an order item via an `OrderShipment` (qty 10); `AppsOnDeriveQuantityDecreased(…, 7)` is called directly.

- RED (un-fixed): only the first issuance (6) was corrected, leaving 4 (expected 3).
- GREEN after fix: the correction is spread across both issuances, leaving 3.

## Note

Discovered while re-locating BUG-22 — the worklist flagged `itemIssuanceCorrection -= quantity` as a candidate for #22, but it is a distinct bug in a different method (#22 was the `AppsShip` over-deduction).

[BUG-D2]