### PR TITLE
fix(apps): select customer-return number prefix from CustomerReturnSequence [BUG-36]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerReturnExistShipmentNumberRule` selected the shipment-number **prefix** used for
+  `SortableShipmentNumber` from `CustomerShipmentSequence.IsEnforcedSequence` instead of the customer return's
+  own `CustomerReturnSequence`. After the number itself was fixed to follow `CustomerReturnSequence`
+  (`NextCustomerReturnNumber`), the prefix branch could diverge from the number branch: when the two sequences
+  disagreed it picked the wrong prefix, and when the customer-return sequence was enforced while the
+  customer-shipment sequence restarted on fiscal year it dereferenced the (absent) fiscal-year sequence record
+  and threw a `NullReferenceException`. It now branches on `CustomerReturnSequence`.
 - `CustomerShipment.AppsOnDeriveQuantityDecreased` mis-applied a quantity-decrease correction when a shipment
   item was issued from more than one `ItemIssuance`. While spreading the correction it subtracted the **whole**
   correction from the running remainder after the first issuance (`itemIssuanceCorrection -= quantity`) rather

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/CustomerReturnRuleTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/CustomerReturnRuleTests.cs
@@ -36,6 +36,21 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedShipToPartyDeriveSortableShipmentNumberFollowsCustomerReturnSequence()
+        {
+            // The SortableShipmentNumber prefix must be selected by the CustomerReturnSequence, not the CustomerShipmentSequence.
+            this.InternalOrganisation.CustomerReturnSequence = new CustomerReturnSequences(this.Transaction).EnforcedSequence;
+            this.InternalOrganisation.CustomerReturnNumberPrefix = "prefix-";
+            this.InternalOrganisation.CustomerShipmentSequence = new CustomerShipmentSequences(this.Transaction).RestartOnFiscalYear;
+            this.Derive();
+
+            var shipment = new CustomerReturnBuilder(this.Transaction).WithShipToParty(this.InternalOrganisation).Build();
+            this.Derive();
+
+            Assert.Equal(int.Parse(shipment.ShipmentNumber.Split('-')[1]), shipment.SortableShipmentNumber.Value);
+        }
+
+        [Fact]
         public void ChangedShipToPartyDeriveShipToAddress()
         {
             var shipment = new CustomerReturnBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Shipment/CustomerReturnExistShipmentNumberRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Shipment/CustomerReturnExistShipmentNumberRule.cs
@@ -30,7 +30,7 @@ namespace Allors.Database.Domain
                     @this.ShipmentNumber = shipToParty.NextCustomerReturnNumber(year);
 
                     var fiscalYearInternalOrganisationSequenceNumbers = shipToParty.FiscalYearsInternalOrganisationSequenceNumbers.FirstOrDefault(v => v.FiscalYear == year);
-                    var prefix = ((InternalOrganisation)@this.ShipToParty).CustomerShipmentSequence.IsEnforcedSequence ? ((InternalOrganisation)@this.ShipToParty).CustomerReturnNumberPrefix : fiscalYearInternalOrganisationSequenceNumbers.CustomerReturnNumberPrefix;
+                    var prefix = ((InternalOrganisation)@this.ShipToParty).CustomerReturnSequence.IsEnforcedSequence ? ((InternalOrganisation)@this.ShipToParty).CustomerReturnNumberPrefix : fiscalYearInternalOrganisationSequenceNumbers.CustomerReturnNumberPrefix;
                     @this.SortableShipmentNumber = @this.Transaction().GetSingleton().SortableNumber(prefix, @this.ShipmentNumber, year.ToString());
                 }
             }


### PR DESCRIPTION
## What

`CustomerReturnExistShipmentNumberRule` selected the shipment-number **prefix** used to compute `SortableShipmentNumber` from `CustomerShipmentSequence.IsEnforcedSequence` instead of the customer return's own `CustomerReturnSequence`.

After the number itself was fixed to follow `CustomerReturnSequence` (`NextCustomerReturnNumber`, apps-domain #21), the prefix branch could diverge from the branch that actually generated the number:

- when the two sequences disagreed it picked the wrong prefix;
- when `CustomerReturnSequence` was enforced while `CustomerShipmentSequence` restarted on fiscal year, it dereferenced the absent fiscal-year sequence record and threw a `NullReferenceException`.

It now branches on `CustomerReturnSequence`, matching the canonical sibling `PurchaseReturnExistShipmentNumberRule`.

## Test

New `CustomerReturnRuleTests.ChangedShipToPartyDeriveSortableShipmentNumberFollowsCustomerReturnSequence`: diverges the two sequences (`CustomerReturnSequence` enforced with a prefix, `CustomerShipmentSequence` restart-on-fiscal-year) and asserts the sortable number is derived from the correct prefix. Fails with an `NullReferenceException` at `:33` before the fix; passes after.

This is the rule-side half of apps-domain #21 (the domain-side `NextCustomerReturnNumber` fix); triage confirmed it survived the domain change.
