### PR TITLE
fix(apps): select purchase-shipment number prefix from PurchaseShipmentSequence [BUG-37]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseShipmentShipToPartyRule` selected the shipment-number **prefix** used for `SortableShipmentNumber`
+  from `CustomerShipmentSequence.IsEnforcedSequence` instead of the purchase shipment's own
+  `PurchaseShipmentSequence`. The number itself comes from `NextPurchaseShipmentNumber` (which branches on
+  `PurchaseShipmentSequence`), so when the two sequences disagreed the prefix branch diverged from the number
+  branch — picking the wrong prefix, or (when the purchase-shipment sequence was enforced while the
+  customer-shipment sequence restarted on fiscal year) dereferencing the absent fiscal-year sequence record and
+  throwing a `NullReferenceException`. It now branches on `PurchaseShipmentSequence`.
 - `CustomerShipment.AppsOnDeriveQuantityDecreased` mis-applied a quantity-decrease correction when a shipment
   item was issued from more than one `ItemIssuance`. While spreading the correction it subtracted the **whole**
   correction from the running remainder after the first issuance (`itemIssuanceCorrection -= quantity`) rather

--- a/dotnet/Apps/Database/Domain.Tests/Shipment/PurchaseShipmentTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Shipment/PurchaseShipmentTests.cs
@@ -155,6 +155,28 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenShipToWithShipmentNumberPrefix_WhenDeriving_ThenSortableShipmentNumberFollowsPurchaseShipmentSequence()
+        {
+            // The SortableShipmentNumber prefix must be selected by the PurchaseShipmentSequence, not the CustomerShipmentSequence.
+            this.InternalOrganisation.PurchaseShipmentSequence = new PurchaseShipmentSequences(this.Transaction).EnforcedSequence;
+            this.InternalOrganisation.PurchaseShipmentNumberPrefix = "prefix-";
+            this.InternalOrganisation.CustomerShipmentSequence = new CustomerShipmentSequences(this.Transaction).RestartOnFiscalYear;
+            var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();
+            new SupplierRelationshipBuilder(this.Transaction).WithSupplier(supplier).Build();
+
+            this.Transaction.Derive();
+
+            var shipment = new PurchaseShipmentBuilder(this.Transaction)
+                .WithShipmentMethod(new ShipmentMethods(this.Transaction).Ground)
+                .WithShipFromParty(supplier)
+                .Build();
+
+            this.Transaction.Derive();
+
+            Assert.Equal(int.Parse(shipment.ShipmentNumber.Split('-')[1]), shipment.SortableShipmentNumber);
+        }
+
+        [Fact]
         public void GivenPurchaseShipmentWithShipToCustomerWithshippingAddress_WhenDeriving_ThenDerivedShipToCustomerAndDerivedShipToAddressMustExist()
         {
             var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Shipment/PurchaseShipmentShipToPartyRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Shipment/PurchaseShipmentShipToPartyRule.cs
@@ -31,7 +31,7 @@ namespace Allors.Database.Domain
                     @this.ShipmentNumber = shipToParty.NextPurchaseShipmentNumber(year);
 
                     var fiscalYearInternalOrganisationSequenceNumbers = shipToParty.FiscalYearsInternalOrganisationSequenceNumbers.FirstOrDefault(v => v.FiscalYear == year);
-                    var prefix = ((InternalOrganisation)@this.ShipToParty).CustomerShipmentSequence.IsEnforcedSequence ? ((InternalOrganisation)@this.ShipToParty).PurchaseShipmentNumberPrefix : fiscalYearInternalOrganisationSequenceNumbers.PurchaseShipmentNumberPrefix;
+                    var prefix = ((InternalOrganisation)@this.ShipToParty).PurchaseShipmentSequence.IsEnforcedSequence ? ((InternalOrganisation)@this.ShipToParty).PurchaseShipmentNumberPrefix : fiscalYearInternalOrganisationSequenceNumbers.PurchaseShipmentNumberPrefix;
                     @this.SortableShipmentNumber = @this.Transaction().GetSingleton().SortableNumber(prefix, @this.ShipmentNumber, year.ToString());
                 }
 


### PR DESCRIPTION
## What

`PurchaseShipmentShipToPartyRule` selected the shipment-number **prefix** used to compute `SortableShipmentNumber` from `CustomerShipmentSequence.IsEnforcedSequence` instead of the purchase shipment's own `PurchaseShipmentSequence`.

The number itself comes from `NextPurchaseShipmentNumber`, which branches enforced-vs-fiscal-year on `PurchaseShipmentSequence`. So when the two sequences disagree, the prefix branch diverges from the branch that actually generated the number:

- when the two sequences disagreed it picked the wrong prefix;
- when `PurchaseShipmentSequence` was enforced while `CustomerShipmentSequence` restarted on fiscal year, it dereferenced the absent fiscal-year sequence record and threw a `NullReferenceException`.

It now branches on `PurchaseShipmentSequence`. The sibling `CustomerShipmentExistShipmentNumberRule` legitimately uses `CustomerShipmentSequence` and is left unchanged.

## Test

New `PurchaseShipmentTests.GivenShipToWithShipmentNumberPrefix_WhenDeriving_ThenSortableShipmentNumberFollowsPurchaseShipmentSequence`: diverges the two sequences (`PurchaseShipmentSequence` enforced with a prefix, `CustomerShipmentSequence` restart-on-fiscal-year) and asserts the sortable number is derived from the correct prefix. Fails with a `NullReferenceException` at `:34` before the fix; passes after.

Twin of #186 (`CustomerReturnExistShipmentNumberRule`) — same wrong-sequence shape, in a different shipment rule.
