### PR TITLE
fix(apps): re-derive RequestForInformation SearchString on contact-mechanism rename [BUG-42]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `RequestForInformationSearchStringRule` rerouted its "re-derive when the contact mechanism is renamed" pattern
+  through `QuotesWhereFullfillContactMechanism` (the Quote inverse, copy-pasted from the quote search rules)
+  instead of `RequestsWhereFullfillContactMechanism`. Filtering Quote objects to `RequestForInformation` is always
+  empty, so renaming a request's `FullfillContactMechanism` left its `SearchString` stale. It now reroutes through
+  `RequestsWhereFullfillContactMechanism`.
 - `CustomerShipment.AppsOnDeriveQuantityDecreased` mis-applied a quantity-decrease correction when a shipment
   item was issued from more than one `ItemIssuance`. While spreading the correction it subtracted the **whole**
   correction from the running remainder after the first issuance (`itemIssuanceCorrection -= quantity`) rather

--- a/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
@@ -70,6 +70,23 @@ namespace Allors.Database.Domain.Tests
             var number = int.Parse(request.RequestNumber.Split('-').Last()).ToString("000000");
             Assert.Equal(int.Parse(string.Concat(this.Transaction.Now().Date.Year.ToString(), number)), request.SortableRequestNumber);
         }
+
+        [Fact]
+        public void ChangedFullfillContactMechanismDisplayNameDeriveSearchString()
+        {
+            var webAddress = new WebAddressBuilder(this.Transaction).WithElectronicAddressString("originaladdress").Build();
+            var request = new RequestForInformationBuilder(this.Transaction)
+                .WithFullfillContactMechanism(webAddress)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Contains("originaladdress", request.SearchString);
+
+            webAddress.ElectronicAddressString = "changedaddress";
+            this.Transaction.Derive();
+
+            Assert.Contains("changedaddress", request.SearchString);
+        }
     }
 
     public class RequestAnonymousRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForInformationSearchStringRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForInformationSearchStringRule.cs
@@ -30,7 +30,7 @@ namespace Allors.Database.Domain
                 m.Request.RolePattern(v => v.Originator, m.RequestForInformation),
                 m.Party.RolePattern(v => v.DisplayName, v => v.RequestsWhereOriginator, m.RequestForInformation),
                 m.Request.RolePattern(v => v.FullfillContactMechanism, m.RequestForInformation),
-                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.QuotesWhereFullfillContactMechanism, m.RequestForInformation),
+                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.RequestsWhereFullfillContactMechanism, m.RequestForInformation),
 
                 m.RequestItem.RolePattern(v => v.RequestItemState, v => v.RequestWhereRequestItem.ObjectType, m.RequestForInformation),
                 m.RequestItem.RolePattern(v => v.Description, v => v.RequestWhereRequestItem.ObjectType, m.RequestForInformation),


### PR DESCRIPTION
## What

`RequestForInformationSearchStringRule` rerouted its "re-derive when the contact mechanism is renamed" pattern through `QuotesWhereFullfillContactMechanism` (the Quote inverse, copy-pasted from the quote search rules) instead of `RequestsWhereFullfillContactMechanism`. Filtering Quote objects to `RequestForInformation` is always empty, so renaming a request's `FullfillContactMechanism` left its `SearchString` stale.

It now reroutes through `RequestsWhereFullfillContactMechanism`, matching the single-leg `RequestsWhere…` reroutes already used in the same rule (`RequestsWhereContactPerson`, `RequestsWhereOriginator`). The Quote-family search rules (`ProductQuoteSearchStringRule`, `proposalsearchstringrule`, `statementofWorksearchstringrule`) correctly use the Quote inverse and are unchanged.

## Test

New `RequestTests.ChangedFullfillContactMechanismDisplayNameDeriveSearchString`: builds a `WebAddress` as a `RequestForInformation`'s `FullfillContactMechanism`, derives, edits its `ElectronicAddressString` (→ updates the CM's `DisplayName`), derives again, and asserts the request's `SearchString` reflects the new value. Fails (stale `SearchString`) before the fix; passes after.

First of the identical trio #42/#43/#44 (`RequestForProposal`/`RequestForQuote` get the same one-line swap in their own PRs).
