### PR TITLE
fix(apps): re-derive RequestForProposal SearchString on contact-mechanism rename [BUG-43]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `RequestForProposalSearchStringRule` had the same wrong reroute as `RequestForInformationSearchStringRule`: it
+  watched `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of
+  `RequestsWhereFullfillContactMechanism`, so renaming a request's `FullfillContactMechanism` left its
+  `SearchString` stale. It now reroutes through `RequestsWhereFullfillContactMechanism`.
 - `PurchaseShipmentShipToPartyRule` selected the shipment-number **prefix** used for `SortableShipmentNumber`
   from `CustomerShipmentSequence.IsEnforcedSequence` instead of the purchase shipment's own
   `PurchaseShipmentSequence`. The number itself comes from `NextPurchaseShipmentNumber` (which branches on

--- a/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
@@ -70,6 +70,23 @@ namespace Allors.Database.Domain.Tests
             var number = int.Parse(request.RequestNumber.Split('-').Last()).ToString("000000");
             Assert.Equal(int.Parse(string.Concat(this.Transaction.Now().Date.Year.ToString(), number)), request.SortableRequestNumber);
         }
+
+        [Fact]
+        public void ChangedFullfillContactMechanismDisplayNameDeriveRequestForProposalSearchString()
+        {
+            var webAddress = new WebAddressBuilder(this.Transaction).WithElectronicAddressString("originaladdress").Build();
+            var request = new RequestForProposalBuilder(this.Transaction)
+                .WithFullfillContactMechanism(webAddress)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Contains("originaladdress", request.SearchString);
+
+            webAddress.ElectronicAddressString = "changedaddress";
+            this.Transaction.Derive();
+
+            Assert.Contains("changedaddress", request.SearchString);
+        }
     }
 
     public class RequestAnonymousRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForProposalSearchStringRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForProposalSearchStringRule.cs
@@ -30,7 +30,7 @@ namespace Allors.Database.Domain
                 m.Request.RolePattern(v => v.Originator, m.RequestForProposal),
                 m.Party.RolePattern(v => v.DisplayName, v => v.RequestsWhereOriginator, m.RequestForProposal),
                 m.Request.RolePattern(v => v.FullfillContactMechanism, m.RequestForProposal),
-                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.QuotesWhereFullfillContactMechanism, m.RequestForProposal),
+                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.RequestsWhereFullfillContactMechanism, m.RequestForProposal),
 
                 m.RequestItem.RolePattern(v => v.RequestItemState, v => v.RequestWhereRequestItem.ObjectType, m.RequestForProposal),
                 m.RequestItem.RolePattern(v => v.Description, v => v.RequestWhereRequestItem.ObjectType, m.RequestForProposal),


### PR DESCRIPTION
## What

`RequestForProposalSearchStringRule` had the same wrong reroute as #188 (`RequestForInformationSearchStringRule`): it watched `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of `RequestsWhereFullfillContactMechanism`. Filtering Quote objects to `RequestForProposal` is always empty, so renaming a request's `FullfillContactMechanism` left its `SearchString` stale.

It now reroutes through `RequestsWhereFullfillContactMechanism`.

## Test

New `RequestTests.ChangedFullfillContactMechanismDisplayNameDeriveRequestForProposalSearchString` (mirror of #188's test, using `RequestForProposalBuilder`): renames the `FullfillContactMechanism` and asserts the `SearchString` updates. RED (stale) before, GREEN after.

Middle of the identical trio #42/#43/#44.
