### PR TITLE
fix(apps): re-derive RequestForQuote SearchString on contact-mechanism rename [BUG-44]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `RequestForQuoteSearchStringRule` had the same wrong reroute as the other request search rules: it watched
+  `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of
+  `RequestsWhereFullfillContactMechanism`, so renaming a request's `FullfillContactMechanism` left its
+  `SearchString` stale. It now reroutes through `RequestsWhereFullfillContactMechanism`.
 - `PurchaseShipmentShipToPartyRule` selected the shipment-number **prefix** used for `SortableShipmentNumber`
   from `CustomerShipmentSequence.IsEnforcedSequence` instead of the purchase shipment's own
   `PurchaseShipmentSequence`. The number itself comes from `NextPurchaseShipmentNumber` (which branches on

--- a/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/RequestTests.cs
@@ -70,6 +70,23 @@ namespace Allors.Database.Domain.Tests
             var number = int.Parse(request.RequestNumber.Split('-').Last()).ToString("000000");
             Assert.Equal(int.Parse(string.Concat(this.Transaction.Now().Date.Year.ToString(), number)), request.SortableRequestNumber);
         }
+
+        [Fact]
+        public void ChangedFullfillContactMechanismDisplayNameDeriveRequestForQuoteSearchString()
+        {
+            var webAddress = new WebAddressBuilder(this.Transaction).WithElectronicAddressString("originaladdress").Build();
+            var request = new RequestForQuoteBuilder(this.Transaction)
+                .WithFullfillContactMechanism(webAddress)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Contains("originaladdress", request.SearchString);
+
+            webAddress.ElectronicAddressString = "changedaddress";
+            this.Transaction.Derive();
+
+            Assert.Contains("changedaddress", request.SearchString);
+        }
     }
 
     public class RequestAnonymousRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForQuoteSearchStringRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/RequestForQuoteSearchStringRule.cs
@@ -30,7 +30,7 @@ namespace Allors.Database.Domain
                 m.Request.RolePattern(v => v.Originator, m.RequestForQuote),
                 m.Party.RolePattern(v => v.DisplayName, v => v.RequestsWhereOriginator, m.RequestForQuote),
                 m.Request.RolePattern(v => v.FullfillContactMechanism, m.RequestForQuote),
-                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.QuotesWhereFullfillContactMechanism, m.RequestForQuote),
+                m.ContactMechanism.RolePattern(v => v.DisplayName, v => v.RequestsWhereFullfillContactMechanism, m.RequestForQuote),
 
                 m.RequestItem.RolePattern(v => v.RequestItemState, v => v.RequestWhereRequestItem.ObjectType, m.RequestForQuote),
                 m.RequestItem.RolePattern(v => v.Description, v => v.RequestWhereRequestItem.ObjectType, m.RequestForQuote),


### PR DESCRIPTION
## What

`RequestForQuoteSearchStringRule` had the same wrong reroute as #188/#189: it watched `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of `RequestsWhereFullfillContactMechanism`. Filtering Quote objects to `RequestForQuote` is always empty, so renaming a request's `FullfillContactMechanism` left its `SearchString` stale.

It now reroutes through `RequestsWhereFullfillContactMechanism`.

This completes the trio #42/#43/#44. The `ProductQuote`/`Proposal`/`StatementOfWork` search rules correctly use the Quote inverse and are unchanged.

## Test

New `RequestTests.ChangedFullfillContactMechanismDisplayNameDeriveRequestForQuoteSearchString` (mirror of #188's test, using `RequestForQuoteBuilder`): renames the `FullfillContactMechanism` and asserts the `SearchString` updates. RED (stale) before, GREEN after.
