### PR TITLE
fix(apps): skip non-TimeEntry service entries in WorkEffort labour cost [BUG-14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkEffortTotalCostRule` computed `TotalLabourCost` by hard-casting **every** `ServiceEntriesWhereWorkEffort`
+  entry to `TimeEntry` (`((TimeEntry)v).Cost`). As soon as a non-`TimeEntry` service entry (e.g. a `MaterialsUsage`
+  or `ExpenseEntry`) was attached to the work effort, the cast threw an `InvalidCastException` and the entire cost
+  derivation failed. It now filters with `OfType<TimeEntry>()` before summing `Cost`.
 - `RequestForQuoteSearchStringRule` had the same wrong reroute as the other request search rules: it watched
   `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of
   `RequestsWhereFullfillContactMechanism`, so renaming a request's `FullfillContactMechanism` left its

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -136,6 +136,46 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void GivenWorkEffortWithNonTimeEntryServiceEntry_WhenDeriving_ThenTotalLabourCostExcludesIt()
+        {
+            // Arrange
+            var customer = new OrganisationBuilder(this.Transaction).WithName("Org1").Build();
+            var internalOrganisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+            new CustomerRelationshipBuilder(this.Transaction).WithCustomer(customer).WithInternalOrganisation(internalOrganisation).Build();
+
+            var workOrder = new WorkTaskBuilder(this.Transaction).WithName("Task").WithCustomer(customer).WithTakenBy(internalOrganisation).Build();
+
+            var employee = new PersonBuilder(this.Transaction).WithFirstName("Good").WithLastName("Worker").Build();
+            new EmploymentBuilder(this.Transaction).WithEmployee(employee).WithEmployer(internalOrganisation).Build();
+
+            this.Transaction.Derive();
+
+            var today = DateTimeFactory.CreateDateTime(this.Transaction.Now());
+            var laterToday = DateTimeFactory.CreateDateTime(today.AddHours(4));
+
+            var timeEntry = new TimeEntryBuilder(this.Transaction)
+                .WithRateType(new RateTypes(this.Transaction).StandardRate)
+                .WithFromDate(today)
+                .WithThroughDate(laterToday)
+                .WithWorkEffort(workOrder)
+                .Build();
+            employee.TimeSheetWhereWorker.AddTimeEntry(timeEntry);
+
+            // A non-TimeEntry ServiceEntry on the same WorkEffort must not break the labour-cost derivation.
+            new MaterialsUsageBuilder(this.Transaction)
+                .WithWorkEffort(workOrder)
+                .WithIsBillable(false)
+                .WithAmount(50M)
+                .Build();
+
+            // Act
+            this.Transaction.Derive();
+
+            // Assert
+            Assert.Equal(Math.Round(timeEntry.Cost, 2), workOrder.TotalLabourCost);
+        }
+
+        [Fact]
         public void GivenWorkEffortAndTimeEntries_WhenDeriving_ThenActualStartAndCompletionDerived()
         {
             // Arrange

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalCostRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalCostRule.cs
@@ -42,7 +42,7 @@ namespace Allors.Database.Domain
     {
         public static void DeriveWorkEffortTotalCost(this WorkEffort @this, IValidation validation)
         {
-            @this.TotalLabourCost = Math.Round(@this.ServiceEntriesWhereWorkEffort.Sum(v => ((TimeEntry)v).Cost), 2);
+            @this.TotalLabourCost = Math.Round(@this.ServiceEntriesWhereWorkEffort.OfType<TimeEntry>().Sum(v => v.Cost), 2);
             @this.TotalMaterialCost = Math.Round(@this.WorkEffortInventoryAssignmentsWhereAssignment.Sum(v => v.CostOfGoodsSoldInApplicationCurrency), 2);
             @this.TotalSubContractedCost = Math.Round(@this.WorkEffortPurchaseOrderItemAssignmentsWhereAssignment.Sum(v => v.Quantity * v.UnitPurchasePrice), 2);
             @this.TotalCost = Math.Round(@this.TotalLabourCost + @this.TotalMaterialCost + @this.TotalSubContractedCost, 2);


### PR DESCRIPTION
## What

`WorkEffortTotalCostRule.DeriveWorkEffortTotalCost` computed `TotalLabourCost` by hard-casting **every** `ServiceEntriesWhereWorkEffort` entry to `TimeEntry`:

```csharp
@this.TotalLabourCost = Math.Round(@this.ServiceEntriesWhereWorkEffort.Sum(v => ((TimeEntry)v).Cost), 2);
```

`ServiceEntry` is the supertype carrying the `WorkEffort` role; `TimeEntry`, `MaterialsUsage` (has `Amount`, no `Cost`) and `ExpenseEntry` are all concrete subtypes. As soon as a non-`TimeEntry` service entry is attached to the work effort, `(TimeEntry)v` throws `InvalidCastException` and the entire cost derivation (which also feeds `TotalCost`) fails.

It now filters with `OfType<TimeEntry>()` before summing `Cost`. (`Math.Round` is left as-is — switching it to `Rounder.RoundDecimal` across all four cost lines is tracked separately as #52.)

## Test

New `WorkTaskTests.GivenWorkEffortWithNonTimeEntryServiceEntry_WhenDeriving_ThenTotalLabourCostExcludesIt`: a `WorkTask` with a `TimeEntry` **and** a `MaterialsUsage` on the same work effort, derived, asserting `TotalLabourCost == Math.Round(timeEntry.Cost, 2)`. Fails with `InvalidCastException` at `:45` before the fix; passes after.
