### PR TITLE
fix(apps): re-derive PurchaseOrderItem shipment state on QuantityOrdered change [BUG-28]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderItemStateRule` decided `PurchaseOrderItemShipmentState` (PartiallyReceived vs Received) from
+  `QuantityReceived < QuantityOrdered` but its patterns never watched `QuantityOrdered`, so raising the ordered
+  quantity on a revision left the shipment state stale (e.g. a fully-received item stayed `Received` instead of
+  dropping back to `PartiallyReceived`). It now watches `PurchaseOrderItem.QuantityOrdered`.
 - `RequestForQuoteSearchStringRule` had the same wrong reroute as the other request search rules: it watched
   `ContactMechanism.DisplayName` via `QuotesWhereFullfillContactMechanism` (the Quote inverse) instead of
   `RequestsWhereFullfillContactMechanism`, so renaming a request's `FullfillContactMechanism` left its

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -1008,6 +1008,32 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedQuantityOrderedDerivePurchaseOrderItemShipmentState()
+        {
+            var order = new PurchaseOrderBuilder(this.Transaction)
+                .WithPurchaseOrderState(new PurchaseOrderStates(this.Transaction).Sent)
+                .Build();
+            this.Derive();
+
+            var orderItem = new PurchaseOrderItemBuilder(this.Transaction)
+                .WithIsReceivable(true)
+                .WithQuantityOrdered(1)
+                .Build();
+            order.AddPurchaseOrderItem(orderItem);
+            this.Derive();
+
+            new ShipmentReceiptBuilder(this.Transaction).WithOrderItem(orderItem).WithQuantityAccepted(1).Build();
+            this.Derive();
+
+            Assert.Equal(new PurchaseOrderItemShipmentStates(this.Transaction).Received, orderItem.PurchaseOrderItemShipmentState);
+
+            orderItem.QuantityOrdered = 2;
+            this.Derive();
+
+            Assert.Equal(new PurchaseOrderItemShipmentStates(this.Transaction).PartiallyReceived, orderItem.PurchaseOrderItemShipmentState);
+        }
+
+        [Fact]
         public void ChangedPurchaseOrderPaymentStateDerivePurchaseOrderState()
         {
             var order = new PurchaseOrderBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderItemStateRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderItemStateRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.PurchaseOrderItem.RolePattern(v => v.IsReceivable),
+                m.PurchaseOrderItem.RolePattern(v => v.QuantityOrdered),
                 m.PurchaseOrderItem.RolePattern(v => v.QuantityReturned),
                 m.PurchaseOrder.RolePattern(v => v.PurchaseOrderState, v => v.PurchaseOrderItems),
                 m.ShipmentReceipt.RolePattern(v => v.QuantityAccepted, v => v.OrderItem, m.PurchaseOrderItem),


### PR DESCRIPTION
## What

`PurchaseOrderItemStateRule` decided `PurchaseOrderItemShipmentState` (PartiallyReceived vs Received) from `QuantityReceived < QuantityOrdered` (line 123), but its `Patterns` array never watched `QuantityOrdered`. Raising the ordered quantity on a revision therefore left the shipment state stale — e.g. a fully-received item stayed `Received` instead of dropping back to `PartiallyReceived`.

It now watches `PurchaseOrderItem.QuantityOrdered`.

## Test

New `PurchaseOrderStateRuleTests.ChangedQuantityOrderedDerivePurchaseOrderItemShipmentState`: a receivable item with `QuantityOrdered = 1` fully received (`ShipmentReceipt` `QuantityAccepted = 1`) → `Received`; then `QuantityOrdered = 2`, derive, expect `PartiallyReceived`. Fails (state stays `Received`) before the fix; passes after.
