### PR TITLE
fix(apps): round WorkEffort cost totals away from zero [BUG-52]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkEffortTotalCostRule` rounded its four cost totals with `Math.Round` (banker's / to-even) instead of
+  `Rounder.RoundDecimal` (away-from-zero), the money-rounding convention used elsewhere. For `TotalMaterialCost`,
+  whose input (`Quantity × weighted-average cost`) can land on a half-cent, this under-rounded by a cent
+  (e.g. `0.125` → `0.12` instead of `0.13`). All four totals now use `Rounder.RoundDecimal`.
 - `WorkEffortTotalCostRule` computed `TotalLabourCost` by hard-casting **every** `ServiceEntriesWhereWorkEffort`
   entry to `TimeEntry` (`((TimeEntry)v).Cost`). As soon as a non-`TimeEntry` service entry (e.g. a `MaterialsUsage`
   or `ExpenseEntry`) was attached to the work effort, the cast threw an `InvalidCastException` and the entire cost

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -10,6 +10,7 @@ namespace Allors.Database.Domain.Tests
     using System.IO;
     using System.Linq;
     using Resources;
+    using TestPopulation;
     using Xunit;
 
     public class WorkTaskTests : DomainTest, IClassFixture<Fixture>
@@ -173,6 +174,57 @@ namespace Allors.Database.Domain.Tests
 
             // Assert
             Assert.Equal(Math.Round(timeEntry.Cost, 2), workOrder.TotalLabourCost);
+        }
+
+        [Fact]
+        public void ChangedWorkEffortInventoryAssignmentDeriveTotalMaterialCostRoundedAwayFromZero()
+        {
+            this.InternalOrganisation.IsAutomaticallyReceived = true;
+            var defaultFacility = this.InternalOrganisation.StoresWhereInternalOrganisation.Single().DefaultFacility;
+
+            var supplier = new OrganisationBuilder(this.Transaction).WithName("supplier").Build();
+            new SupplierRelationshipBuilder(this.Transaction).WithSupplier(supplier).WithInternalOrganisation(this.InternalOrganisation).Build();
+
+            var customer = new OrganisationBuilder(this.Transaction).WithName("Org1").Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithCustomer(customer).WithInternalOrganisation(this.InternalOrganisation).Build();
+
+            var part = new UnifiedGoodBuilder(this.Transaction).WithNonSerialisedDefaults(this.InternalOrganisation).Build();
+            this.Transaction.Derive();
+
+            // Establish a weighted-average cost of 0.25 by receiving one unit at 0.25.
+            var purchaseOrder = new PurchaseOrderBuilder(this.Transaction)
+                .WithTakenViaSupplier(supplier)
+                .WithStoredInFacility(defaultFacility)
+                .Build();
+            this.Transaction.Derive();
+
+            var purchaseItem = new PurchaseOrderItemBuilder(this.Transaction).WithPart(part).WithQuantityOrdered(1).WithAssignedUnitPrice(0.25M).Build();
+            purchaseOrder.AddPurchaseOrderItem(purchaseItem);
+            this.Transaction.Derive();
+
+            purchaseOrder.SetReadyForProcessing();
+            this.Transaction.Derive();
+
+            purchaseOrder.Send();
+            this.Transaction.Derive();
+
+            purchaseItem.QuickReceive();
+            this.Transaction.Derive();
+
+            Assert.Equal(0.25M, part.PartWeightedAverage.AverageCostInApplicationCurrency);
+
+            var workTask = new WorkTaskBuilder(this.Transaction).WithName("Task").WithCustomer(customer).WithTakenBy(this.InternalOrganisation).Build();
+            this.Transaction.Derive();
+
+            // 0.5 * 0.25 = 0.125 - a half-cent that exposes banker's (Math.Round) vs away-from-zero (Rounder) rounding.
+            new WorkEffortInventoryAssignmentBuilder(this.Transaction)
+                .WithAssignment(workTask)
+                .WithInventoryItem(part.InventoryItemsWherePart.First())
+                .WithQuantity(0.5M)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Equal(0.13M, workTask.TotalMaterialCost);
         }
 
         [Fact]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalCostRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalCostRule.cs
@@ -42,10 +42,10 @@ namespace Allors.Database.Domain
     {
         public static void DeriveWorkEffortTotalCost(this WorkEffort @this, IValidation validation)
         {
-            @this.TotalLabourCost = Math.Round(@this.ServiceEntriesWhereWorkEffort.OfType<TimeEntry>().Sum(v => v.Cost), 2);
-            @this.TotalMaterialCost = Math.Round(@this.WorkEffortInventoryAssignmentsWhereAssignment.Sum(v => v.CostOfGoodsSoldInApplicationCurrency), 2);
-            @this.TotalSubContractedCost = Math.Round(@this.WorkEffortPurchaseOrderItemAssignmentsWhereAssignment.Sum(v => v.Quantity * v.UnitPurchasePrice), 2);
-            @this.TotalCost = Math.Round(@this.TotalLabourCost + @this.TotalMaterialCost + @this.TotalSubContractedCost, 2);
+            @this.TotalLabourCost = Rounder.RoundDecimal(@this.ServiceEntriesWhereWorkEffort.OfType<TimeEntry>().Sum(v => v.Cost), 2);
+            @this.TotalMaterialCost = Rounder.RoundDecimal(@this.WorkEffortInventoryAssignmentsWhereAssignment.Sum(v => v.CostOfGoodsSoldInApplicationCurrency), 2);
+            @this.TotalSubContractedCost = Rounder.RoundDecimal(@this.WorkEffortPurchaseOrderItemAssignmentsWhereAssignment.Sum(v => v.Quantity * v.UnitPurchasePrice), 2);
+            @this.TotalCost = Rounder.RoundDecimal(@this.TotalLabourCost + @this.TotalMaterialCost + @this.TotalSubContractedCost, 2);
         }
     }
 }


### PR DESCRIPTION
## What

`WorkEffortTotalCostRule` rounded its four cost totals with `Math.Round` (default `MidpointRounding.ToEven`, banker's) instead of `Rounder.RoundDecimal` (`AwayFromZero`), the money-rounding helper used throughout the codebase.

Of the four totals, only `TotalMaterialCost` can actually differ: its input `Σ CostOfGoodsSoldInApplicationCurrency` = `Quantity (decimal) × weighted-average cost (scale-2)` can land on a half-cent, where banker's under-rounds by a cent (`0.125` → `0.12` vs `0.13`). The other three sum scale-2 / integer inputs, so `Math.Round` was a no-op there — they're changed for consistency/defence.

## Test

New `WorkTaskTests.ChangedWorkEffortInventoryAssignmentDeriveTotalMaterialCostRoundedAwayFromZero`: receives one unit of a non-serialised good at unit cost `0.25` (→ `PartWeightedAverage.AverageCostInApplicationCurrency = 0.25`), then a `WorkEffortInventoryAssignment` of `Quantity = 0.5` (→ `CostOfGoodsSold = 0.125`), asserting `TotalMaterialCost == 0.13`. Fails with `0.12` before the fix; passes after.

Same rule as #191 (`InvalidCastException` fix), different lines.
