### PR TITLE
fix(apps): re-validate CustomerRelationship period overlap on ThroughDate change [BUG-34]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `CustomerRelationshipFromDateRule` validated overlapping customer-relationship periods using `ThroughDate` but
+  watched only `FromDate`, so extending a relationship's `ThroughDate` into a later relationship's period never
+  re-ran the overlap check and the conflicting periods silently passed validation. It now also watches `ThroughDate`.
 - `PurchaseOrderItemStateRule` decided `PurchaseOrderItemShipmentState` (PartiallyReceived vs Received) from
   `QuantityReceived < QuantityOrdered` but its patterns never watched `QuantityOrdered`, so raising the ordered
   quantity on a revision left the shipment state stale (e.g. a fully-received item stayed `Received` instead of

--- a/dotnet/Apps/Database/Domain.Tests/Relation/CustomerRelationshipTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Relation/CustomerRelationshipTests.cs
@@ -395,5 +395,28 @@ namespace Allors.Database.Domain.Tests
 
             Assert.False(this.Derive().HasErrors);
         }
+
+        [Fact]
+        public void ChangedThroughDatePeriodActiveThrowValidationError()
+        {
+            var customer = new PersonBuilder(this.Transaction).WithLastName("customer").Build();
+            var relationship = new CustomerRelationshipBuilder(this.Transaction)
+                .WithFromDate(this.Transaction.Now())
+                .WithThroughDate(this.Transaction.Now().AddDays(1))
+                .WithCustomer(customer)
+                .Build();
+
+            new CustomerRelationshipBuilder(this.Transaction)
+                .WithFromDate(this.Transaction.Now().AddDays(2))
+                .WithCustomer(customer)
+                .Build();
+
+            Assert.False(this.Derive().HasErrors);
+
+            relationship.ThroughDate = this.Transaction.Now().AddDays(3);
+
+            var errors = this.Derive().Errors.ToList();
+            Assert.Single(errors.FindAll(e => e.Message.Contains(ErrorMessages.PeriodActive)));
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Relations/CustomerRelationshipFromDateRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Relations/CustomerRelationshipFromDateRule.cs
@@ -19,6 +19,7 @@ namespace Allors.Database.Domain
         this.Patterns = new Pattern[]
         {
             m.CustomerRelationship.RolePattern(v => v.FromDate),
+            m.CustomerRelationship.RolePattern(v => v.ThroughDate),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`CustomerRelationshipFromDateRule` validates that a customer doesn't have overlapping `CustomerRelationship` periods, and that check reads `ThroughDate` — but the rule watched only `FromDate`. So extending a relationship's `ThroughDate` so it overlaps a later relationship's start never re-ran the overlap check, and the conflicting periods silently passed validation.

It now also watches `ThroughDate`.

## Test

New `CustomerRelationshipFromDateRuleTests.ChangedThroughDatePeriodActiveThrowValidationError` (modelled on the existing `PeriodNotActive`): a relationship `[Now, Now+1]` plus a second one starting `Now+2` (no overlap → no error), then `relationship.ThroughDate = Now+3` (now overlaps) → expect exactly one `PeriodActive` error. Fails (no error raised) before the fix; passes after.

Twin of #35 (`EmploymentFromDateRule`).
