### PR TITLE
fix(apps): re-validate Employment period overlap on ThroughDate change [BUG-35]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `EmploymentFromDateRule` validated overlapping employment periods using `ThroughDate` but watched only
+  `FromDate`, so extending an employment's `ThroughDate` into a later employment's period never re-ran the overlap
+  check and the conflict silently passed validation. It now also watches `ThroughDate`.
 - `PurchaseOrderItemStateRule` decided `PurchaseOrderItemShipmentState` (PartiallyReceived vs Received) from
   `QuantityReceived < QuantityOrdered` but its patterns never watched `QuantityOrdered`, so raising the ordered
   quantity on a revision left the shipment state stale (e.g. a fully-received item stayed `Received` instead of

--- a/dotnet/Apps/Database/Domain.Tests/Relation/EmploymentTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Relation/EmploymentTests.cs
@@ -188,5 +188,28 @@ namespace Allors.Database.Domain.Tests
 
             Assert.False(this.Derive().HasErrors);
         }
+
+        [Fact]
+        public void ChangedThroughDatePeriodActiveThrowValidationError()
+        {
+            var employee = new PersonBuilder(this.Transaction).WithLastName("employee").Build();
+            var employment = new EmploymentBuilder(this.Transaction)
+                .WithFromDate(this.Transaction.Now())
+                .WithThroughDate(this.Transaction.Now().AddDays(1))
+                .WithEmployee(employee)
+                .Build();
+
+            new EmploymentBuilder(this.Transaction)
+                .WithFromDate(this.Transaction.Now().AddDays(2))
+                .WithEmployee(employee)
+                .Build();
+
+            Assert.False(this.Derive().HasErrors);
+
+            employment.ThroughDate = this.Transaction.Now().AddDays(3);
+
+            var errors = this.Derive().Errors.ToList();
+            Assert.Single(errors.FindAll(e => e.Message.Contains(ErrorMessages.PeriodActive)));
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Relations/EmploymentFromDateRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Relations/EmploymentFromDateRule.cs
@@ -19,6 +19,7 @@ namespace Allors.Database.Domain
         this.Patterns = new Pattern[]
         {
             m.Employment.RolePattern(v => v.FromDate),
+            m.Employment.RolePattern(v => v.ThroughDate),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`EmploymentFromDateRule` validates that an employee doesn't have overlapping `Employment` periods, and that check reads `ThroughDate` — but the rule watched only `FromDate`. So extending an employment's `ThroughDate` so it overlaps a later employment's start never re-ran the overlap check, and the conflicting periods silently passed validation.

It now also watches `ThroughDate`. Twin of #194 (`CustomerRelationshipFromDateRule`).

## Test

New `EmploymentFromDateRuleTests.ChangedThroughDatePeriodActiveThrowValidationError` (mirror of #194, using `EmploymentBuilder`): employment `[Now, Now+1]` plus a second starting `Now+2` (no overlap → no error), then `employment.ThroughDate = Now+3` (now overlaps) → expect exactly one `PeriodActive` error. Fails (no error raised) before the fix; passes after.
