### PR TITLE
fix(apps): reset PurchaseOrder TotalFee/TotalShippingAndHandling before accumulation [BUG-08]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderPriceRule` accumulated `TotalFee` and `TotalShippingAndHandling` with `+=` but omitted both from
+  the reset block that re-zeroes the order totals at the start of each derivation, so every re-derive added the
+  fee/shipping charges again and the two totals grew without bound. Both are now reset to `0` before accumulation.
 - `EmploymentFromDateRule` validated overlapping employment periods using `ThroughDate` but watched only
   `FromDate`, so extending an employment's `ThroughDate` into a later employment's period never re-ran the overlap
   check and the conflict silently passed validation. It now also watches `ThroughDate`.

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -1120,6 +1120,31 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedDerivationTotalFeeAndTotalShippingAndHandlingDoNotAccumulate()
+        {
+            var part = new UnifiedGoodBuilder(this.Transaction).Build();
+
+            var order = new PurchaseOrderBuilder(this.Transaction).WithOrderDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var orderItem = new PurchaseOrderItemBuilder(this.Transaction).WithPart(part).WithQuantityOrdered(1).WithAssignedUnitPrice(1).Build();
+            order.AddPurchaseOrderItem(orderItem);
+            order.AddOrderAdjustment(new FeeBuilder(this.Transaction).WithAmount(10).Build());
+            order.AddOrderAdjustment(new ShippingAndHandlingChargeBuilder(this.Transaction).WithAmount(5).Build());
+            this.Derive();
+
+            Assert.Equal(10M, order.TotalFee);
+            Assert.Equal(5M, order.TotalShippingAndHandling);
+
+            // Force the price rule to re-derive; the fixed charges must not accumulate.
+            orderItem.QuantityOrdered = 2;
+            this.Derive();
+
+            Assert.Equal(10M, order.TotalFee);
+            Assert.Equal(5M, order.TotalShippingAndHandling);
+        }
+
+        [Fact]
         public void ChangedSalesOrderItemAssignedUnitPriceCalculatePrice()
         {
             var part = new UnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
@@ -105,6 +105,8 @@ namespace Allors.Database.Domain
             @this.TotalIrpf = 0;
             @this.TotalExVat = 0;
             @this.TotalExtraCharge = 0;
+            @this.TotalFee = 0;
+            @this.TotalShippingAndHandling = 0;
             @this.TotalIncVat = 0;
             @this.GrandTotal = 0;
             @this.TotalShippingAndHandlingInPreferredCurrency = 0;


### PR DESCRIPTION
## What

`PurchaseOrderPriceRule` accumulates `TotalFee` (`@this.TotalFee += fee`) and `TotalShippingAndHandling` (`@this.TotalShippingAndHandling += shipping`) in its order-adjustment loop, but the reset block that re-zeroes the order totals at the start of each derivation omitted both. So every re-derivation added the fee/shipping charges again and the two reporting roles grew without bound (`fee`, `2·fee`, `3·fee`, …).

(The local `fee`/`shipping` variables that feed `TotalExtraCharge`/`TotalExVat` are re-zeroed each pass, so only the two persistent totals drifted.) `SalesOrderPriceRule`/`QuotePriceRule` already reset both.

Fix: reset `@this.TotalFee = 0;` and `@this.TotalShippingAndHandling = 0;` in the reset block.

## Test

New `PurchaseOrderPriceRuleTests.ChangedDerivationTotalFeeAndTotalShippingAndHandlingDoNotAccumulate`: an order with an item plus a fixed `Fee(10)` and `ShippingAndHandlingCharge(5)`; derive (asserts `TotalFee == 10`, `TotalShippingAndHandling == 5`), then `orderItem.QuantityOrdered = 2` to re-fire the price rule, asserting the fixed charges stay `10`/`5`. Fails (`20`/`10`) before the fix; passes after.

Twin of #20 (`PurchaseInvoicePriceRule`). The separate `*InPreferredCurrency`-population bug #06 in this rule is out of scope.
