### PR TITLE
fix(apps): reset PurchaseInvoice TotalFee/TotalShippingAndHandling before accumulation [BUG-20]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoicePriceRule` accumulated `TotalFee` and `TotalShippingAndHandling` with `+=` but omitted both from
+  the reset block, so every re-derive added the fee/shipping charges again and the two totals (and their derived
+  `*InPreferredCurrency` counterparts) grew without bound. Both are now reset to `0` before accumulation.
 - `EmploymentFromDateRule` validated overlapping employment periods using `ThroughDate` but watched only
   `FromDate`, so extending an employment's `ThroughDate` into a later employment's period never re-ran the overlap
   check and the conflict silently passed validation. It now also watches `ThroughDate`.

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -985,6 +985,39 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedDerivationTotalFeeAndTotalShippingAndHandlingDoNotAccumulate()
+        {
+            var supplier = this.InternalOrganisation.ActiveSuppliers.ElementAt(0);
+            var part = new UnifiedGoodBuilder(this.Transaction).Build();
+
+            new SupplierOfferingBuilder(this.Transaction)
+                .WithPart(part)
+                .WithSupplier(supplier)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddDays(-1))
+                .Build();
+
+            var invoice = new PurchaseInvoiceBuilder(this.Transaction).WithBilledFrom(supplier).WithInvoiceDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var invoiceItem = new PurchaseInvoiceItemBuilder(this.Transaction).WithPart(part).WithQuantity(1).Build();
+            invoice.AddPurchaseInvoiceItem(invoiceItem);
+            invoice.AddOrderAdjustment(new FeeBuilder(this.Transaction).WithAmount(10).Build());
+            invoice.AddOrderAdjustment(new ShippingAndHandlingChargeBuilder(this.Transaction).WithAmount(5).Build());
+            this.Derive();
+
+            Assert.Equal(10M, invoice.TotalFee);
+            Assert.Equal(5M, invoice.TotalShippingAndHandling);
+
+            // Force the price rule to re-derive; the fixed charges must not accumulate.
+            invoiceItem.Quantity = 2;
+            this.Derive();
+
+            Assert.Equal(10M, invoice.TotalFee);
+            Assert.Equal(5M, invoice.TotalShippingAndHandling);
+        }
+
+        [Fact]
         public void ChangedDiscountAdjustmentPercentageCalculatePrice()
         {
             var supplier = this.InternalOrganisation.ActiveSuppliers.ElementAt(0);

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
@@ -108,6 +108,8 @@ namespace Allors.Database.Domain
                 @this.TotalIncVat = 0;
                 @this.TotalIrpf = 0;
                 @this.TotalExtraCharge = 0;
+                @this.TotalFee = 0;
+                @this.TotalShippingAndHandling = 0;
                 @this.GrandTotal = 0;
 
                 foreach (PurchaseInvoiceItem item in @this.ValidInvoiceItems)


### PR DESCRIPTION
## What

Twin of #196 (`PurchaseOrderPriceRule`), for invoices. `PurchaseInvoicePriceRule` accumulates `TotalFee` (`@this.TotalFee += fee`) and `TotalShippingAndHandling` (`@this.TotalShippingAndHandling += shipping`) in its order-adjustment loop and writes them back rounded, but the reset block that re-zeroes the invoice totals omitted both. So every re-derivation added the fee/shipping charges again and the two reporting roles grew without bound — and because `TotalFeeInPreferredCurrency`/`TotalShippingAndHandlingInPreferredCurrency` are derived from them, those drifted too.

Fix: reset `@this.TotalFee = 0;` and `@this.TotalShippingAndHandling = 0;` in the reset block.

## Test

New `PurchaseInvoicePriceRuleTests.ChangedDerivationTotalFeeAndTotalShippingAndHandlingDoNotAccumulate`: an invoice with an item plus a fixed `Fee(10)` and `ShippingAndHandlingCharge(5)`; derive (asserts `TotalFee == 10`, `TotalShippingAndHandling == 5`), then `invoiceItem.Quantity = 2` to re-fire the price rule, asserting the fixed charges stay `10`/`5`. Fails (`20`/`10`) before the fix; passes after.

The separate missing-edit-pattern bug #22 in this rule is out of scope.
