### PR TITLE
fix(apps): re-derive AccountingTransaction delete revocation on ExportAccounting change [BUG-41]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `AccountingTransactionDeniedPermissionRule` toggles the delete revocation from `IsDeletable`
+  (`InternalOrganisation.ExportAccounting && !Exported`) but watched only `Exported`, so toggling the internal
+  organisation's `ExportAccounting` left the delete permission stale. It now also watches
+  `InternalOrganisation.ExportAccounting`.
 - `PurchaseInvoicePriceRule` accumulated `TotalFee` and `TotalShippingAndHandling` with `+=` but omitted both from
   the reset block, so every re-derive added the fee/shipping charges again and the two totals (and their derived
   `*InPreferredCurrency` counterparts) grew without bound. Both are now reset to `0` before accumulation.

--- a/dotnet/Apps/Database/Domain.Tests/Accounting/AccountingTransactionTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Accounting/AccountingTransactionTests.cs
@@ -60,5 +60,19 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Contains(this.deleteRevocation, transaction.Revocations);
         }
+
+        [Fact]
+        public void OnChangedInternalOrganisationExportAccountingDeriveDeletePermission()
+        {
+            var transaction = new AccountingTransactionBuilder(this.Transaction).Build();
+            this.Derive();
+
+            Assert.DoesNotContain(this.deleteRevocation, transaction.Revocations);
+
+            this.InternalOrganisation.ExportAccounting = false;
+            this.Derive();
+
+            Assert.Contains(this.deleteRevocation, transaction.Revocations);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/AccountingTransactionDeniedPermissionRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/AccountingTransactionDeniedPermissionRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
         {
             m.AccountingTransaction.RolePattern(v => v.Exported),
+            m.InternalOrganisation.RolePattern(v => v.ExportAccounting, v => v.AccountingTransactionsWhereInternalOrganisation),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`AccountingTransactionDeniedPermissionRule` adds/removes the `AccountingTransactionDeleteRevocation` based on `IsDeletable`:

```csharp
public bool IsDeletable => this.InternalOrganisation.ExportAccounting && !this.Exported;
```

…but its `Patterns` watched only `Exported`. So toggling the internal organisation's `ExportAccounting` never re-derived the revocation, leaving the delete permission stale (e.g. turning off accounting export left existing transactions wrongly deletable).

It now also watches `InternalOrganisation.ExportAccounting` (rerouted to `AccountingTransactionsWhereInternalOrganisation`).

## Test

New `AccountingTransactionDeniedPermissionRuleTests.OnChangedInternalOrganisationExportAccountingDeriveDeletePermission` (Security tier): build a transaction (default `ExportAccounting = true` → deletable, no revocation), then set `ExportAccounting = false` and derive, expecting the delete revocation to be added. Fails (revocation absent) before the fix; passes after.
