### PR TITLE
fix(apps): re-derive PurchaseInvoice AmountPaid on PaymentApplication.AmountApplied change [BUG-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoiceAmountPaidRule` summed each payment application's `AmountApplied` into `AmountPaid` but watched
+  only the application *set* (an association pattern), so editing an existing application's `AmountApplied` left
+  `AmountPaid` stale. It now also watches `PaymentApplication.AmountApplied` (mirroring `SalesInvoiceStateRule`).
 - `PurchaseInvoicePriceRule` accumulated `TotalFee` and `TotalShippingAndHandling` with `+=` but omitted both from
   the reset block, so every re-derive added the fee/shipping charges again and the two totals (and their derived
   `*InPreferredCurrency` counterparts) grew without bound. Both are now reset to `0` before accumulation.

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -416,6 +416,23 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedPaymentApplicationAmountAppliedDeriveAmountPaid()
+        {
+            var purchaseInvoice = new PurchaseInvoiceBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var paymentApplication = new PaymentApplicationBuilder(this.Transaction).WithInvoice(purchaseInvoice).WithAmountApplied(10).Build();
+            this.Derive();
+
+            Assert.Equal(10, purchaseInvoice.AmountPaid);
+
+            paymentApplication.AmountApplied = 7;
+            this.Derive();
+
+            Assert.Equal(7, purchaseInvoice.AmountPaid);
+        }
+
+        [Fact]
         public void ChangedPaymentApplicationInvoiceItemDeriveAmountPaid()
         {
             var purchaseInvoice = new PurchaseInvoiceBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoiceAmountPaidRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoiceAmountPaidRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.Invoice.AssociationPattern(v => v.PaymentApplicationsWhereInvoice, m.PurchaseInvoice),
+                m.PaymentApplication.RolePattern(v => v.AmountApplied, v => v.Invoice, m.PurchaseInvoice),
                 m.PurchaseInvoiceItem.RolePattern(v => v.AmountPaid, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
             };
 


### PR DESCRIPTION
## What

`PurchaseInvoiceAmountPaidRule` computes `AmountPaid` as the sum of each payment application's `AmountApplied`:

```csharp
@this.AmountPaid = @this.PaymentApplicationsWhereInvoice.Sum(v => v.AmountApplied);
```

…but its patterns watched only the application *set* (`m.Invoice.AssociationPattern(v => v.PaymentApplicationsWhereInvoice, …)`, which fires on add/remove) and item-level `AmountPaid` — not `PaymentApplication.AmountApplied`. So **editing an existing application's `AmountApplied`** left `AmountPaid` stale. `SalesInvoiceStateRule` already watches it.

It now also watches `m.PaymentApplication.RolePattern(v => v.AmountApplied, v => v.Invoice, m.PurchaseInvoice)`.

## Test

New `PurchaseInvoiceRuleTests.ChangedPaymentApplicationAmountAppliedDeriveAmountPaid`: apply `10` to a `PurchaseInvoice` (assert `AmountPaid == 10`), then edit the application's `AmountApplied = 7` and derive, expecting `AmountPaid == 7`. Fails (`10`) before the fix; passes after.
