### PR TITLE
fix(apps): re-derive AccountingTransaction DerivedTotalAmount on detail Amount/BalanceSide change [BUG-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `AccountingTransactionDerivedTotalAmountRule` summed the debit-side details' amounts into `DerivedTotalAmount`
+  but watched only the detail *set*, so editing a detail's `Amount` or `BalanceSide` in place left
+  `DerivedTotalAmount` stale. It now also watches `AccountingTransactionDetail.Amount` and `.BalanceSide`.
 - `PurchaseInvoiceAmountPaidRule` summed each payment application's `AmountApplied` into `AmountPaid` but watched
   only the application *set* (an association pattern), so editing an existing application's `AmountApplied` left
   `AmountPaid` stale. It now also watches `PaymentApplication.AmountApplied` (mirroring `SalesInvoiceStateRule`).

--- a/dotnet/Apps/Database/Domain.Tests/Accounting/AccountingTransactionTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Accounting/AccountingTransactionTests.cs
@@ -6,6 +6,8 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System;
+    using System.Linq;
     using Xunit;
 
     [Trait("Category", "Security")]
@@ -73,6 +75,51 @@ namespace Allors.Database.Domain.Tests
             this.Derive();
 
             Assert.Contains(this.deleteRevocation, transaction.Revocations);
+        }
+    }
+
+    public class AccountingTransactionDerivedTotalAmountRuleTests : DomainTest, IClassFixture<Fixture>
+    {
+        public AccountingTransactionDerivedTotalAmountRuleTests(Fixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void ChangedAccountingTransactionDetailAmountAndBalanceSideDeriveDerivedTotalAmount()
+        {
+            var organisationGlAccount = new OrganisationGlAccounts(this.Transaction).Extent().ToArray().First();
+
+            var accountingPeriod = new AccountingPeriodBuilder(this.Transaction)
+                .WithInternalOrganisation(organisationGlAccount.InternalOrganisation)
+                .WithFrequency(new TimeFrequencies(this.Transaction).Day)
+                .Build();
+
+            var detail = new AccountingTransactionDetailBuilder(this.Transaction)
+                .WithAmount(100)
+                .WithBalanceSide(new BalanceSides(this.Transaction).Debit)
+                .WithGeneralLedgerAccount(organisationGlAccount.GeneralLedgerAccount)
+                .Build();
+
+            var accountingTransaction = new AccountingTransactionBuilder(this.Transaction)
+                .WithAccountingTransactionType(new AccountingTransactionTypes(this.Transaction).Internal)
+                .WithInternalOrganisation(organisationGlAccount.InternalOrganisation)
+                .WithAccountingPeriod(accountingPeriod)
+                .WithDescription("Test")
+                .WithTransactionDate(DateTime.Now)
+                .WithEntryDate(DateTime.Now.AddHours(1))
+                .WithAccountingTransactionDetail(detail)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(100, accountingTransaction.DerivedTotalAmount);
+
+            detail.Amount = 150;
+            this.Derive();
+
+            Assert.Equal(150, accountingTransaction.DerivedTotalAmount);
+
+            detail.BalanceSide = new BalanceSides(this.Transaction).Credit;
+            this.Derive();
+
+            Assert.Equal(0, accountingTransaction.DerivedTotalAmount);
         }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/AccountingTransactionDerivedTotalAmountRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/AccountingTransactionDerivedTotalAmountRule.cs
@@ -18,6 +18,8 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.AccountingTransaction.RolePattern(v => v.AccountingTransactionDetails),
+                m.AccountingTransactionDetail.RolePattern(v => v.Amount, v => v.AccountingTransactionWhereAccountingTransactionDetail),
+                m.AccountingTransactionDetail.RolePattern(v => v.BalanceSide, v => v.AccountingTransactionWhereAccountingTransactionDetail),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`AccountingTransactionDerivedTotalAmountRule` derives `DerivedTotalAmount` as the sum of the **debit-side** details' amounts:

```csharp
@this.DerivedTotalAmount = @this.AccountingTransactionDetails
    .Where(v => v.ExistBalanceSide && v.BalanceSide.Equals(Debit)).Sum(v => v.Amount);
```

…reading each detail's `BalanceSide` and `Amount`. But the patterns watched only the detail *set* (`m.AccountingTransaction.RolePattern(v => v.AccountingTransactionDetails)`). So **editing a detail's `Amount` or `BalanceSide` in place** left `DerivedTotalAmount` stale.

It now also watches `AccountingTransactionDetail.Amount` and `.BalanceSide` (rerouted via `AccountingTransactionWhereAccountingTransactionDetail`).

## Test

New `AccountingTransactionDerivedTotalAmountRuleTests.ChangedAccountingTransactionDetailAmountAndBalanceSideDeriveDerivedTotalAmount`: a transaction with one Debit detail `Amount = 100` (assert `DerivedTotalAmount == 100`), then `detail.Amount = 150` (assert `== 150` — needs the Amount pattern), then `detail.BalanceSide = Credit` (assert `== 0` — needs the BalanceSide pattern). Fails (`Expected: 150, Actual: 100`) before the fix; passes only with both patterns.
