### PR TITLE
fix(apps): re-derive WorkEffort TotalOtherRevenue on invoice-item type change [BUG-15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkEffortTotalOtherRevenueRule` summed non-discount work-effort invoice items' amounts into `TotalOtherRevenue`
+  (partitioning on `InvoiceItemType.IsDiscount`) but didn't watch `WorkEffortInvoiceItem.InvoiceItemType`, so
+  changing an item's invoice-item type left `TotalOtherRevenue` stale. It now also watches `InvoiceItemType`.
 - `PurchaseInvoiceAmountPaidRule` summed each payment application's `AmountApplied` into `AmountPaid` but watched
   only the application *set* (an association pattern), so editing an existing application's `AmountApplied` left
   `AmountPaid` stale. It now also watches `PaymentApplication.AmountApplied` (mirroring `SalesInvoiceStateRule`).

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -1701,6 +1701,32 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(3, workEffort.TotalOtherRevenue);
         }
+
+        [Fact]
+        public void ChangedWorkEffortInvoiceItemInvoiceItemTypeDeriveTotalOtherRevenue()
+        {
+            var workEffort = new WorkTaskBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var workEffortInvoiceItem = new WorkEffortInvoiceItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).Time)
+                .WithDescription("desc")
+                .WithAmount(1)
+                .Build();
+
+            new WorkEffortInvoiceItemAssignmentBuilder(this.Transaction)
+                .WithWorkEffortInvoiceItem(workEffortInvoiceItem)
+                .WithAssignment(workEffort)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(1, workEffort.TotalOtherRevenue);
+
+            workEffortInvoiceItem.InvoiceItemType = new InvoiceItemTypes(this.Transaction).Discount;
+            this.Derive();
+
+            Assert.Equal(0, workEffort.TotalOtherRevenue);
+        }
     }
 
     public class WorkEffortTotalSubContractedRevenueRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalOtherRevenueRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalOtherRevenueRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             {
                 m.WorkEffortInvoiceItemAssignment.RolePattern(v => v.Assignment, v => v.Assignment),
                 m.WorkEffortInvoiceItem.RolePattern(v => v.Amount, v => v.WorkEffortInvoiceItemAssignmentWhereWorkEffortInvoiceItem.ObjectType.Assignment),
+                m.WorkEffortInvoiceItem.RolePattern(v => v.InvoiceItemType, v => v.WorkEffortInvoiceItemAssignmentWhereWorkEffortInvoiceItem.ObjectType.Assignment),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`WorkEffortTotalOtherRevenueRule` derives `TotalOtherRevenue` as the sum of the **non-discount** work-effort invoice items' amounts:

```csharp
.Where(v => v.ExistWorkEffortInvoiceItem && !v.WorkEffortInvoiceItem.InvoiceItemType.IsDiscount && v.WorkEffortInvoiceItem.Amount.HasValue)
```

…partitioning on `InvoiceItemType.IsDiscount`. But the patterns watched only the assignment's `Assignment` and the item's `Amount` — not `InvoiceItemType`. So changing an item's invoice-item type (e.g. Time → Discount) left `TotalOtherRevenue` stale.

It now also watches `m.WorkEffortInvoiceItem.RolePattern(v => v.InvoiceItemType, …Assignment)`, mirroring the existing `Amount` pattern.

## Test

New `WorkEffortTotalOtherRevenueRuleTests.ChangedWorkEffortInvoiceItemInvoiceItemTypeDeriveTotalOtherRevenue`: a work effort with a `Time` invoice item `Amount = 1` (assert `TotalOtherRevenue == 1`), then `item.InvoiceItemType = Discount`, expecting `0`. Fails (`1`) before the fix; passes after.

Twin of #38 (`WorkEffortTotalDiscountRule`, opposite polarity).
