### PR TITLE
fix(apps): re-derive WorkEffort TotalDiscount on invoice-item type change [BUG-38]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkEffortTotalDiscountRule` summed discount work-effort invoice items' amounts into `TotalDiscount`
+  (partitioning on `InvoiceItemType.IsDiscount`) but didn't watch `WorkEffortInvoiceItem.InvoiceItemType`, so
+  changing an item's invoice-item type left `TotalDiscount` stale. It now also watches `InvoiceItemType`.
 - `AccountingTransactionDerivedTotalAmountRule` summed the debit-side details' amounts into `DerivedTotalAmount`
   but watched only the detail *set*, so editing a detail's `Amount` or `BalanceSide` in place left
   `DerivedTotalAmount` stale. It now also watches `AccountingTransactionDetail.Amount` and `.BalanceSide`.

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -2077,4 +2077,35 @@ namespace Allors.Database.Domain.Tests
             Assert.DoesNotContain(revisePermission, workTask.Revocations.SelectMany(v => v.DeniedPermissions));
         }
     }
+
+    public class WorkEffortTotalDiscountRuleTests : DomainTest, IClassFixture<Fixture>
+    {
+        public WorkEffortTotalDiscountRuleTests(Fixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void ChangedWorkEffortInvoiceItemInvoiceItemTypeDeriveTotalDiscount()
+        {
+            var workEffort = new WorkTaskBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var workEffortInvoiceItem = new WorkEffortInvoiceItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).Discount)
+                .WithDescription("desc")
+                .WithAmount(1)
+                .Build();
+
+            new WorkEffortInvoiceItemAssignmentBuilder(this.Transaction)
+                .WithWorkEffortInvoiceItem(workEffortInvoiceItem)
+                .WithAssignment(workEffort)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(1, workEffort.TotalDiscount);
+
+            workEffortInvoiceItem.InvoiceItemType = new InvoiceItemTypes(this.Transaction).Time;
+            this.Derive();
+
+            Assert.Equal(0, workEffort.TotalDiscount);
+        }
+    }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalDiscountRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkEffortTotalDiscountRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             {
                 m.WorkEffortInvoiceItemAssignment.RolePattern(v => v.Assignment, v => v.Assignment),
                 m.WorkEffortInvoiceItem.RolePattern(v => v.Amount, v => v.WorkEffortInvoiceItemAssignmentWhereWorkEffortInvoiceItem.ObjectType.Assignment),
+                m.WorkEffortInvoiceItem.RolePattern(v => v.InvoiceItemType, v => v.WorkEffortInvoiceItemAssignmentWhereWorkEffortInvoiceItem.ObjectType.Assignment),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

Twin of #201 (`WorkEffortTotalOtherRevenueRule`), opposite polarity. `WorkEffortTotalDiscountRule` derives `TotalDiscount` as the sum of the **discount** work-effort invoice items' amounts (`v.WorkEffortInvoiceItem.InvoiceItemType.IsDiscount`), but the patterns watched only the assignment's `Assignment` and the item's `Amount` — not `InvoiceItemType`. So changing an item's invoice-item type left `TotalDiscount` stale.

It now also watches `m.WorkEffortInvoiceItem.RolePattern(v => v.InvoiceItemType, …Assignment)`.

## Test

New `WorkEffortTotalDiscountRuleTests.ChangedWorkEffortInvoiceItemInvoiceItemTypeDeriveTotalDiscount` (new class): a work effort with a `Discount` invoice item `Amount = 1` (assert `TotalDiscount == 1`), then `item.InvoiceItemType = Time`, expecting `0`. Fails (`1`) before the fix; passes after.
