### PR TITLE
fix(apps): re-derive PartCategory descendant DisplayName on ancestor rename [BUG-30]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `PartCategoryDisplayNameRule` builds a category's `DisplayName` from its ancestor chain's names but its roleless
+  `Name` pattern re-derived only the renamed category itself, so renaming an ancestor left descendants' display
+  names stale. It now also watches `Name` rerouted to `PartCategoriesWherePrimaryAncestor` (the descendants).
 - `WorkEffortTotalOtherRevenueRule` summed non-discount work-effort invoice items' amounts into `TotalOtherRevenue`
   (partitioning on `InvoiceItemType.IsDiscount`) but didn't watch `WorkEffortInvoiceItem.InvoiceItemType`, so
   changing an item's invoice-item type left `TotalOtherRevenue` stale. It now also watches `InvoiceItemType`.

--- a/dotnet/Apps/Database/Domain.Tests/Product/PartCategoryRuleTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/PartCategoryRuleTests.cs
@@ -124,5 +124,22 @@ namespace Allors.Database.Domain.Tests
             Assert.Contains(partCategory11, partCategory1.Descendants);
             Assert.Contains(partCategory111, partCategory1.Descendants);
         }
+
+        [Fact]
+        public void ChangedAncestorNameDeriveDisplayName()
+        {
+            var root = new PartCategoryBuilder(this.Transaction).WithName("alpha").Build();
+            var mid = new PartCategoryBuilder(this.Transaction).WithName("beta").WithPrimaryParent(root).Build();
+            var leaf = new PartCategoryBuilder(this.Transaction).WithName("gamma").WithPrimaryParent(mid).Build();
+            this.Derive();
+
+            Assert.Contains("alpha", leaf.DisplayName);
+
+            root.Name = "delta";
+            this.Derive();
+
+            Assert.Contains("delta", leaf.DisplayName);
+            Assert.DoesNotContain("alpha", leaf.DisplayName);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/PartCategoryDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/PartCategoryDisplayNameRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.PartCategory.RolePattern(v => v.Name),
+                m.PartCategory.RolePattern(v => v.Name, v => v.PartCategoriesWherePrimaryAncestor),
                 m.PartCategory.RolePattern(v => v.PrimaryAncestors),
             };
 


### PR DESCRIPTION
## What

`PartCategoryDisplayNameRule` builds a category's `DisplayName` from its ancestor chain's names (`primaryAncestors.Select(v => v.Name)` joined by `/`). But the patterns were:

```csharp
m.PartCategory.RolePattern(v => v.Name),             // roleless → re-derives only the renamed category itself
m.PartCategory.RolePattern(v => v.PrimaryAncestors),
```

So renaming an **ancestor** updated that ancestor's own `DisplayName` but not its descendants' — they kept the stale ancestor name in their path.

It now also watches `m.PartCategory.RolePattern(v => v.Name, v => v.PartCategoriesWherePrimaryAncestor)` (re-derive the descendants on a name change).

## Test

New `PartCategoryRuleTests.ChangedAncestorNameDeriveDisplayName`: a `root("alpha")` → `mid("beta")` → `leaf("gamma")` chain (assert `leaf.DisplayName` contains `"alpha"`), then `root.Name = "delta"`, expecting `leaf.DisplayName` to contain `"delta"` and not `"alpha"`. Fails (stays `"alpha/beta/gamma"`) before the fix; passes after.

Twin of #32 (`ProductCategoryDisplayNameRule`).
