### PR TITLE
fix(apps): re-derive ProductCategory descendant DisplayName on ancestor rename [BUG-32]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `ProductCategoryDisplayNameRule` had the same descendant-stale-on-ancestor-rename gap as
+  `PartCategoryDisplayNameRule`: its roleless `Name` pattern re-derived only the renamed category itself. It now
+  also watches `Name` rerouted to `ProductCategoriesWherePrimaryAncestor` (the descendants).
 - `WorkEffortTotalOtherRevenueRule` summed non-discount work-effort invoice items' amounts into `TotalOtherRevenue`
   (partitioning on `InvoiceItemType.IsDiscount`) but didn't watch `WorkEffortInvoiceItem.InvoiceItemType`, so
   changing an item's invoice-item type left `TotalOtherRevenue` stale. It now also watches `InvoiceItemType`.

--- a/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
@@ -129,6 +129,23 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedAncestorNameDeriveDisplayName()
+        {
+            var root = new ProductCategoryBuilder(this.Transaction).WithName("alpha").Build();
+            var mid = new ProductCategoryBuilder(this.Transaction).WithName("beta").WithPrimaryParent(root).Build();
+            var leaf = new ProductCategoryBuilder(this.Transaction).WithName("gamma").WithPrimaryParent(mid).Build();
+            this.Transaction.Derive();
+
+            Assert.Contains("alpha", leaf.DisplayName);
+
+            root.Name = "delta";
+            this.Transaction.Derive();
+
+            Assert.Contains("delta", leaf.DisplayName);
+            Assert.DoesNotContain("alpha", leaf.DisplayName);
+        }
+
+        [Fact]
         public void GivenProductCategory_WhenNewParentsAreInserted_ThenProductCategoriesWhereDescendantAreRecalculated()
         {
             var productCategory1 = new ProductCategoryBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategoryDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategoryDisplayNameRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.ProductCategory.RolePattern(v => v.Name),
+                m.ProductCategory.RolePattern(v => v.Name, v => v.ProductCategoriesWherePrimaryAncestor),
                 m.ProductCategory.RolePattern(v => v.PrimaryAncestors),
             };
 


### PR DESCRIPTION
## What

Twin of #203 (`PartCategoryDisplayNameRule`), for `ProductCategory`. The rule builds a category's `DisplayName` from its ancestor chain's names, but its patterns watched only the roleless `Name` (re-derives the renamed category itself) and `PrimaryAncestors`. So renaming an **ancestor** left descendants' display names stale.

It now also watches `m.ProductCategory.RolePattern(v => v.Name, v => v.ProductCategoriesWherePrimaryAncestor)`.

## Test

New `ProductCategoryTests.ChangedAncestorNameDeriveDisplayName` (mirror of #203): a `root("alpha")` → `mid("beta")` → `leaf("gamma")` chain (assert `leaf.DisplayName` contains `"alpha"`), then `root.Name = "delta"`, expecting `"delta"` and not `"alpha"`. Fails (stays `"alpha/beta/gamma"`) before the fix; passes after.
