### PR TITLE
fix(apps): re-derive Requirement ServicedByName on serviced-organisation rename [BUG-51]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `RequirementServicedByNameRule` copied the serviced organisation's `DisplayName` into `ServicedByName` but
+  watched only the `ServicedBy` link, so renaming the organisation left `ServicedByName` stale. It now also watches
+  `Organisation.DisplayName` (rerouted to `RequirementsWhereServicedBy`).
 - `WorkEffortTotalOtherRevenueRule` summed non-discount work-effort invoice items' amounts into `TotalOtherRevenue`
   (partitioning on `InvoiceItemType.IsDiscount`) but didn't watch `WorkEffortInvoiceItem.InvoiceItemType`, so
   changing an item's invoice-item type left `TotalOtherRevenue` stale. It now also watches `InvoiceItemType`.

--- a/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
@@ -84,5 +84,26 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(maintenance, workTask.WorkEffortPurpose);
         }
+
+        [Fact]
+        public void ChangedServicedByDisplayNameDeriveServicedByName()
+        {
+            var organisation = this.InternalOrganisation;
+
+            var requirement = new WorkRequirementBuilder(this.Transaction)
+                .WithDescription("req")
+                .WithServicedBy(organisation)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Equal(organisation.DisplayName, requirement.ServicedByName);
+
+            var before = organisation.DisplayName;
+            organisation.Name = "renamedservicedby";
+            this.Transaction.Derive();
+
+            Assert.NotEqual(before, organisation.DisplayName);
+            Assert.Equal(organisation.DisplayName, requirement.ServicedByName);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/RequirementServicedByNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/RequirementServicedByNameRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
         {
             m.Requirement.RolePattern(v => v.ServicedBy),
+            m.Organisation.RolePattern(v => v.DisplayName, v => v.RequirementsWhereServicedBy),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`RequirementServicedByNameRule` derives `ServicedByName = @this.ServicedBy?.DisplayName`, reading the serviced organisation's `DisplayName` — but it watched only the `ServicedBy` link. So renaming the organisation (its `DisplayName` re-derives from `Name`) left `ServicedByName` stale.

It now also watches `m.Organisation.RolePattern(v => v.DisplayName, v => v.RequirementsWhereServicedBy)`.

## Test

New `WorkRequirementTests.ChangedServicedByDisplayNameDeriveServicedByName`: a `WorkRequirement` with `ServicedBy = this.InternalOrganisation` (assert `ServicedByName == org.DisplayName`), then rename the org's `Name` and derive, asserting `ServicedByName` tracks the org's new `DisplayName` (plus a sanity `Assert.NotEqual` that the `DisplayName` actually changed). `ServicedBy` must be an org with a `RequirementSequence` (a plain org NREs in `WorkRequirementServicedByRule`), hence the internal organisation. Fails (stays `"internalOrganisation"`) before the fix; passes after.

Paired with #53 (`WorkRequirementFulfillmentRule`).
