### PR TITLE
fix(apps): re-derive WorkRequirementFulfillment number/description on requirement edit [BUG-53]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkRequirementFulfillmentRule` copied the fulfilled work requirement's `RequirementNumber`/`Description` into
+  the fulfillment but watched only the `FullfilledBy` link, so editing the requirement left
+  `WorkRequirementNumber`/`WorkRequirementDescription` stale. It now also watches the work requirement's
+  `RequirementNumber` and `Description` (rerouted to `WorkRequirementFulfillmentWhereFullfilledBy`).
 - `PartCategoryDisplayNameRule` builds a category's `DisplayName` from its ancestor chain's names but its roleless
   `Name` pattern re-derived only the renamed category itself, so renaming an ancestor left descendants' display
   names stale. It now also watches `Name` rerouted to `PartCategoriesWherePrimaryAncestor` (the descendants).

--- a/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/WorkRequirementTests.cs
@@ -84,5 +84,29 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(maintenance, workTask.WorkEffortPurpose);
         }
+
+        [Fact]
+        public void ChangedFullfilledByDescriptionDeriveWorkRequirementDescription()
+        {
+            var internalOrganisation = new Organisations(this.Transaction).Extent().First(o => o.IsInternalOrganisation);
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
+
+            var requirement = new WorkRequirementBuilder(this.Transaction)
+                .WithDescription("origdesc")
+                .WithFixedAsset(serialisedItem)
+                .Build();
+            this.Transaction.Derive();
+
+            requirement.CreateWorkTask();
+            this.Transaction.Derive(false);
+
+            var fulfillment = requirement.WorkRequirementFulfillmentWhereFullfilledBy;
+            Assert.Equal("origdesc", fulfillment.WorkRequirementDescription);
+
+            requirement.Description = "newdesc";
+            this.Transaction.Derive();
+
+            Assert.Equal("newdesc", fulfillment.WorkRequirementDescription);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkRequirementFulfillmentRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkRequirementFulfillmentRule.cs
@@ -18,6 +18,8 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
         {
             m.WorkRequirementFulfillment.RolePattern(v => v.FullfilledBy),
+            m.WorkRequirement.RolePattern(v => v.RequirementNumber, v => v.WorkRequirementFulfillmentWhereFullfilledBy),
+            m.WorkRequirement.RolePattern(v => v.Description, v => v.WorkRequirementFulfillmentWhereFullfilledBy),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`WorkRequirementFulfillmentRule` copies the fulfilled work requirement's `RequirementNumber` → `WorkRequirementNumber` and `Description` → `WorkRequirementDescription`, but it watched only the `FullfilledBy` link. So editing the fulfilled requirement left those copies stale.

It now also watches the work requirement's `RequirementNumber` and `Description`, rerouted to `WorkRequirementFulfillmentWhereFullfilledBy`. (`FullfilledBy` is typed `WorkRequirement`, so the patterns are on `m.WorkRequirement` with the inherited roles — confirmed compiling/green; minor adjustment from the backlog's `m.Requirement`.)

## Test

New `WorkRequirementTests.ChangedFullfilledByDescriptionDeriveWorkRequirementDescription` (modelled on the existing `…WhenCreateWorkTask…` test): a `WorkRequirement(Description="origdesc")` → `CreateWorkTask()` (creates the fulfillment) → assert `WorkRequirementDescription == "origdesc"`, then `requirement.Description = "newdesc"`, expecting it to update. Fails (`Expected "newdesc", Actual "origdesc"`) before the fix; passes after.

Paired with #205 (`RequirementServicedByNameRule`).
