### PR TITLE
fix(apps): re-derive NonSerialisedInventoryItem DisplayName on part/facility rename [BUG-46]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `NonSerialisedInventoryItemDisplayNameRule` builds `DisplayName` from the item's `Part.Name` and `Facility.Name`
+  but watched only the `Part`/`Facility` links, so renaming the part or facility left `DisplayName` stale. It now
+  also watches `Part.Name` and `Facility.Name` (rerouted to `InventoryItemsWherePart`/`InventoryItemsWhereFacility`).
 - `WorkRequirementFulfillmentRule` copied the fulfilled work requirement's `RequirementNumber`/`Description` into
   the fulfillment but watched only the `FullfilledBy` link, so editing the requirement left
   `WorkRequirementNumber`/`WorkRequirementDescription` stale. It now also watches the work requirement's

--- a/dotnet/Apps/Database/Domain.Tests/Product/NonSerializedInventoryItemTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/NonSerializedInventoryItemTests.cs
@@ -96,6 +96,37 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedPartNameAndFacilityNameDeriveDisplayName()
+        {
+            var part = new NonUnifiedPartBuilder(this.Transaction)
+                .WithName("partone")
+                .WithProductIdentification(new PartNumberBuilder(this.Transaction)
+                    .WithIdentification("1")
+                    .WithProductIdentificationType(new ProductIdentificationTypes(this.Transaction).Part).Build())
+                .WithInventoryItemKind(new InventoryItemKinds(this.Transaction).NonSerialised)
+                .Build();
+            this.Transaction.Derive();
+
+            var facility = new FacilityBuilder(this.Transaction)
+                .WithName("facone")
+                .WithFacilityType(new FacilityTypes(this.Transaction).Warehouse)
+                .WithOwner(this.InternalOrganisation)
+                .Build();
+            this.Transaction.Derive();
+
+            var item = new NonSerialisedInventoryItemBuilder(this.Transaction).WithPart(part).WithFacility(facility).Build();
+            this.Transaction.Derive();
+
+            Assert.Equal($"{part.Name} at {facility.Name} with state {item.NonSerialisedInventoryItemState?.Name}", item.DisplayName);
+
+            part.Name = "parttwo";
+            facility.Name = "factwo";
+            this.Transaction.Derive();
+
+            Assert.Equal($"{part.Name} at {facility.Name} with state {item.NonSerialisedInventoryItemState?.Name}", item.DisplayName);
+        }
+
+        [Fact]
         public void GivenInventoryItemForPart_WhenDerived_ThenUnitOfMeasureIsPartUnitOfMeasure()
         {
             var uom = new UnitsOfMeasure(this.Transaction).Centimeter;

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/NonSerialisedInventoryItemDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/NonSerialisedInventoryItemDisplayNameRule.cs
@@ -19,6 +19,8 @@ namespace Allors.Database.Domain
             {
                 m.NonSerialisedInventoryItem.RolePattern(v => v.Part),
                 m.NonSerialisedInventoryItem.RolePattern(v => v.Facility),
+                m.Part.RolePattern(v => v.Name, v => v.InventoryItemsWherePart, m.NonSerialisedInventoryItem),
+                m.Facility.RolePattern(v => v.Name, v => v.InventoryItemsWhereFacility, m.NonSerialisedInventoryItem),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## What

`NonSerialisedInventoryItemDisplayNameRule` builds `DisplayName = $"{Part?.Name} at {Facility?.Name} with state {…State?.Name}"`, but it watched only the `Part` and `Facility` **links**. So renaming the part or facility left `DisplayName` stale.

It now also watches `Part.Name` and `Facility.Name`, rerouted to `InventoryItemsWherePart` / `InventoryItemsWhereFacility`.

The item-state leg of the finding is **deferred** (the item's state is rule-derived from quantity; exercising it needs inventory-transaction setup) — noted as a follow-up.

## Test

New `NonSerialisedInventoryItemTests.ChangedPartNameAndFacilityNameDeriveDisplayName`: a `NonUnifiedPart("partone")` + a custom `Facility("facone")` + a `NonSerialisedInventoryItem`; assert `DisplayName == "{part.Name} at {facility.Name} with state {state}"`, then rename `part.Name = "parttwo"` and `facility.Name = "factwo"`, deriving, asserting it reflects both. Fails (`Expected "parttwo at factwo…", Actual "partone at facone…"`) before the fix; passes only with both patterns.

Twin of #48 (`SerialisedInventoryItemDisplayNameRule`).
