### PR TITLE
fix(apps): re-derive SerialisedInventoryItem DisplayName on part/facility rename [BUG-48]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SerialisedInventoryItemDisplayNameRule` had the same gap as `NonSerialisedInventoryItemDisplayNameRule`: its
+  `DisplayName` interpolates `Part.Name`/`Facility.Name` but watched only the `Part`/`Facility` links, so renaming the
+  part or facility left the display name stale. It now also watches `Part.Name` and `Facility.Name` (rerouted via
+  `InventoryItemsWherePart`/`InventoryItemsWhereFacility`).
 - `WorkRequirementFulfillmentRule` copied the fulfilled work requirement's `RequirementNumber`/`Description` into
   the fulfillment but watched only the `FullfilledBy` link, so editing the requirement left
   `WorkRequirementNumber`/`WorkRequirementDescription` stale. It now also watches the work requirement's

--- a/dotnet/Apps/Database/Domain.Tests/Product/SerializedInventoryItemTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/SerializedInventoryItemTests.cs
@@ -52,6 +52,43 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedPartNameAndFacilityNameDeriveDisplayName()
+        {
+            var serialItem = new SerialisedItemBuilder(this.Transaction).WithSerialNumber("1").Build();
+            var part = new NonUnifiedPartBuilder(this.Transaction)
+                .WithName("partone")
+                .WithInventoryItemKind(new InventoryItemKinds(this.Transaction).Serialised)
+                .WithProductIdentification(new PartNumberBuilder(this.Transaction)
+                    .WithIdentification("P1")
+                    .WithProductIdentificationType(new ProductIdentificationTypes(this.Transaction).Part).Build())
+                .WithSerialisedItem(serialItem)
+                .Build();
+            this.Transaction.Derive();
+
+            var facility = new FacilityBuilder(this.Transaction)
+                .WithName("facone")
+                .WithFacilityType(new FacilityTypes(this.Transaction).Warehouse)
+                .WithOwner(this.InternalOrganisation)
+                .Build();
+            this.Transaction.Derive();
+
+            var item = new SerialisedInventoryItemBuilder(this.Transaction)
+                .WithPart(part)
+                .WithFacility(facility)
+                .WithSerialisedItem(serialItem)
+                .Build();
+            this.Transaction.Derive();
+
+            Assert.Equal($"{part.Name} at {facility.Name} with state {item.SerialisedInventoryItemState?.Name}", item.DisplayName);
+
+            part.Name = "parttwo";
+            facility.Name = "factwo";
+            this.Transaction.Derive();
+
+            Assert.Equal($"{part.Name} at {facility.Name} with state {item.SerialisedInventoryItemState?.Name}", item.DisplayName);
+        }
+
+        [Fact]
         public void GivenInventoryItem_WhenBuild_ThenPostBuildRelationsMustExist()
         {
             // Arrange

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedInventoryItemDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedInventoryItemDisplayNameRule.cs
@@ -19,6 +19,8 @@ namespace Allors.Database.Domain
             {
                 m.SerialisedInventoryItem.RolePattern(v => v.Part),
                 m.SerialisedInventoryItem.RolePattern(v => v.Facility),
+                m.Part.RolePattern(v => v.Name, v => v.InventoryItemsWherePart, m.SerialisedInventoryItem),
+                m.Facility.RolePattern(v => v.Name, v => v.InventoryItemsWhereFacility, m.SerialisedInventoryItem),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`SerialisedInventoryItemDisplayNameRule` interpolates `Part.Name` and `Facility.Name` into `DisplayName`
(`"{Part?.Name} at {Facility?.Name} with state {SerialisedInventoryItemState?.Name}"`) but its `Patterns` watched
only the `Part`/`Facility` **links**. Renaming the part or facility left the display name stale until something else
re-triggered the rule. This is the twin of **BUG-46** (`NonSerialisedInventoryItemDisplayNameRule`, #207).

## Fix
Add two reroute patterns so a name change on the linked part/facility re-derives the inventory item:

```csharp
m.Part.RolePattern(v => v.Name, v => v.InventoryItemsWherePart, m.SerialisedInventoryItem),
m.Facility.RolePattern(v => v.Name, v => v.InventoryItemsWhereFacility, m.SerialisedInventoryItem),
```

## Test (TDD)
New `SerialisedInventoryItemTests.ChangedPartNameAndFacilityNameDeriveDisplayName`: builds a serialised part + custom
facility + serialised inventory item, asserts the initial `DisplayName`, renames both, derives, and asserts the
display name reflects both renames.

- **RED** (pre-fix): `Expected: "parttwo at factwo with state In good order"`, `Actual: "partone at facone with state In good order"`.
- **GREEN** after the fix.

## Scope
The **item-state** leg of the display name is deferred (consistent with BUG-46) — it needs inventory-transaction setup
to exercise and is a separate follow-up if pursued.