### PR TITLE
fix(apps): re-derive ProductCategory SearchString on catalogue name/description edit [BUG-47]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `ProductCategorySearchStringRule` folds the owning catalogue's `Name`/`Description` into the category's
+  `SearchString` but watched only catalogue *membership* (the `CatalogueWhereProductCategory` association), so editing
+  `Catalogue.Name`/`Description` left the categories' `SearchString` stale. It now also watches `Catalogue.Name` and
+  `Catalogue.Description` (rerouted to `ProductCategories`).
 - `SerialisedInventoryItemDisplayNameRule` had the same gap as `NonSerialisedInventoryItemDisplayNameRule`: its
   `DisplayName` interpolates `Part.Name`/`Facility.Name` but watched only the `Part`/`Facility` links, so renaming the
   part or facility left the display name stale. It now also watches `Part.Name` and `Facility.Name` (rerouted via

--- a/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
@@ -1030,6 +1030,28 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedCatalogueNameAndDescriptionDeriveSearchString()
+        {
+            var productCategory = new ProductCategoryBuilder(this.Transaction).WithName("cat").Build();
+            var catalogue = new CatalogueBuilder(this.Transaction)
+                .WithName("alpha")
+                .WithDescription("charlie")
+                .WithProductCategory(productCategory)
+                .Build();
+            this.Derive();
+
+            Assert.Contains("alpha", productCategory.SearchString);
+            Assert.Contains("charlie", productCategory.SearchString);
+
+            catalogue.Name = "bravo";
+            catalogue.Description = "delta";
+            this.Derive();
+
+            Assert.Contains("bravo", productCategory.SearchString);
+            Assert.Contains("delta", productCategory.SearchString);
+        }
+
+        [Fact]
         public void ChangedCategoryImageDeriveCategoryImage()
         {
             var noImageAvailableImage = this.Transaction.GetSingleton().Settings.NoImageAvailableImage;

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategorySearchStringRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategorySearchStringRule.cs
@@ -28,6 +28,8 @@ namespace Allors.Database.Domain
                 m.LocalisedText.RolePattern(v => v.Text, v => v.ProductCategoryWhereLocalisedDescription.ObjectType),
 
                 m.ProductCategory.AssociationPattern(v => v.CatalogueWhereProductCategory),
+                m.Catalogue.RolePattern(v => v.Name, v => v.ProductCategories),
+                m.Catalogue.RolePattern(v => v.Description, v => v.ProductCategories),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`ProductCategorySearchStringRule` folds the owning catalogue's `Name` and `Description` into each member category's
`SearchString` (`CatalogueWhereProductCategory?.Name` / `?.Description`), but its `Patterns` watched only catalogue
**membership** (`m.ProductCategory.AssociationPattern(v => v.CatalogueWhereProductCategory)`). Editing
`Catalogue.Name` or `Catalogue.Description` therefore left every member category's `SearchString` stale until
something else re-triggered the rule.

## Fix
Add two reroute patterns so a name/description edit on the catalogue re-derives its member categories:

```csharp
m.Catalogue.RolePattern(v => v.Name, v => v.ProductCategories),
m.Catalogue.RolePattern(v => v.Description, v => v.ProductCategories),
```

(`Catalogue.ProductCategories` is the OneToMany forward role, inverse of the watched `CatalogueWhereProductCategory`.)

## Test (TDD)
New `ProductCategoryRuleTests.ChangedCatalogueNameAndDescriptionDeriveSearchString`: links a `ProductCategory` to a
`Catalogue(Name="alpha", Description="charlie")`, asserts the `SearchString` contains both, renames the catalogue to
`bravo`/`delta`, derives, and asserts the `SearchString` reflects the new values.

- **RED** (pre-fix): `SearchString` stayed `"cat cat Public alpha charlie"` → `Assert.Contains("bravo", …)` failed.
- **GREEN** after the fix.

## Scope
The `CatScope?.Name` leg of the search string is **deferred** (latent sibling): `CatScope` is a shared `Scope`
enumeration singleton and reaching the category from a scope is a 2-hop path — renaming a shared enum in a test is
unrepresentative. Noted as a future candidate only if a realistic scope-rename scenario is identified.