### PR TITLE
fix(apps): re-derive SerialisedItem ProductCategoriesDisplayName on category rename [BUG-49]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SerialisedItemProductCategoriesDisplayNameRule` builds a serialised item's `ProductCategoriesDisplayName` from each
+  owning category's `DisplayName` but watched only category *membership*, so renaming a product category left the
+  serialised item's `ProductCategoriesDisplayName` stale. It now also watches `ProductCategory.DisplayName` (rerouted
+  via `Products` → `UnifiedGood` → `SerialisedItems`).
 - `NonUnifiedPartSearchStringRule` folds `Brand.Name`, `Model.Name` and `ProductType.Name` into the part's
   `SearchString` but watched only the `Brand`/`Model`/`ProductType` *link* roles, so renaming a brand, model or product
   type in place left the parts' `SearchString` stale. It now also watches `Brand.Name`, `Model.Name` and

--- a/dotnet/Apps/Database/Domain.Tests/Product/SerialisedItemTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/SerialisedItemTests.cs
@@ -584,6 +584,25 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Contains("catname", serialisedItem.ProductCategoriesDisplayName);
         }
+
+        [Fact]
+        public void ChangedProductCategoryNameDeriveDisplayProductCategories()
+        {
+            var part = new UnifiedGoodBuilder(this.Transaction).Build();
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).Build();
+            part.AddSerialisedItem(serialisedItem);
+            this.Derive();
+
+            var category = new ProductCategoryBuilder(this.Transaction).WithName("catone").WithProduct(part).Build();
+            this.Derive();
+
+            Assert.Contains("catone", serialisedItem.ProductCategoriesDisplayName);
+
+            category.Name = "renamedcat";
+            this.Derive();
+
+            Assert.Contains("renamedcat", serialisedItem.ProductCategoriesDisplayName);
+        }
     }
 
     public class SerialisedItemOwnerDervivationTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedItemProductCategoriesDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedItemProductCategoriesDisplayNameRule.cs
@@ -19,6 +19,7 @@ namespace Allors.Database.Domain
             {
                 m.SerialisedItem.AssociationPattern(v=>v.AccountingTransactionsWhereFixedAsset),
                 m.Part.AssociationPattern(v=>v.ProductCategoriesWhereProduct, v=>v.SerialisedItems),
+                m.ProductCategory.RolePattern(v => v.DisplayName, v => v.Products.ObjectType.AsUnifiedGood.SerialisedItems),
                 m.SerialisedItem.RolePattern(v => v.DerivationTrigger),
             };
 


### PR DESCRIPTION
## Bug
For a `UnifiedGood` part, `SerialisedItemProductCategoriesDisplayNameRule` sets each serialised item's
`ProductCategoriesDisplayName` to `string.Join(", ", unifiedGood.ProductCategoriesWhereProduct.Select(v => v.DisplayName))`
— i.e. it reads each owning category's **`DisplayName`**. But its `Patterns` watched only category **membership**
(`m.Part.AssociationPattern(v => v.ProductCategoriesWhereProduct, v => v.SerialisedItems)`), an accounting trigger, and
the manual `DerivationTrigger`. Nothing fired when a category's `DisplayName` changed (e.g. the category was renamed),
so the serialised item's `ProductCategoriesDisplayName` went stale.

## Fix
Add one reroute pattern watching the category's `DisplayName` and navigating to the affected serialised items
(`ProductCategory.Products` is `UnifiedProduct[]`; cast to `UnifiedGood` for `SerialisedItems`):

```csharp
m.ProductCategory.RolePattern(v => v.DisplayName, v => v.Products.ObjectType.AsUnifiedGood.SerialisedItems),
```

Idiom precedents: `Cataloguesearchstringrule` watches `ProductCategory.DisplayName`; `ProductQuotePrintRule` /
`SalesOrderItemInventoryItemRule` use the `.ObjectType.AsUnifiedGood` path connector.

## Test (TDD)
New `SerialisedItemDisplayProductCategoriesRuleTests.ChangedProductCategoryNameDeriveDisplayProductCategories` — models
the shipped `ChangedProductCategoryAllProductsDeriveDisplayProductCategories` (membership-add) but exercises the
**rename** case: build a `UnifiedGood` + `SerialisedItem`, add it to `ProductCategory("catone")`, assert the
`ProductCategoriesDisplayName` contains `catone`, rename `category.Name = "renamedcat"`, derive, assert it contains
`renamedcat`.

- **RED** (pre-fix): `ProductCategoriesDisplayName` stayed `"catone"` → `Assert.Contains("renamedcat", …)` failed.
- **GREEN** after the fix.

(`ProductCategory.DisplayName` re-derives on own-`Name` change via `ProductCategoryDisplayNameRule` — already fixed in
a prior PR.)

## Scope
UnifiedGood-only — a pre-existing limitation of the rule (`Derive` only acts when the part `is UnifiedGood`); not
widened here.