### PR TITLE
fix(apps): watch SalesInvoiceItems in SerialisedItem SearchString [BUG-50]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SerialisedItemSearchStringRule` folds the owning sales-invoice number into the serialised item's `SearchString`
+  but, alone among the seven invoice/order/quote/request/shipment collections it reads, had no association pattern for
+  `SalesInvoiceItemsWhereSerialisedItem` — so putting a serialised item on a sales-invoice line left its `SearchString`
+  stale. It now watches `SalesInvoiceItemsWhereSerialisedItem`, consistent with the other collections.
 - `SerialisedItemProductCategoriesDisplayNameRule` builds a serialised item's `ProductCategoriesDisplayName` from each
   owning category's `DisplayName` but watched only category *membership*, so renaming a product category left the
   serialised item's `ProductCategoriesDisplayName` stale. It now also watches `ProductCategory.DisplayName` (rerouted

--- a/dotnet/Apps/Database/Domain.Tests/Product/SerialisedItemTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/SerialisedItemTests.cs
@@ -565,6 +565,31 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Contains("changedModelName", serialisedItem.SearchString);
         }
+
+        [Fact]
+        public void ChangedSalesInvoiceItemSerialisedItemDeriveSearchString()
+        {
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithSerialNumber("serialno").Build();
+            this.Derive();
+
+            Assert.DoesNotContain("searchinvno", serialisedItem.SearchString);
+
+            var customer = new OrganisationBuilder(this.Transaction).WithName("customer").Build();
+            var invoice = new SalesInvoiceBuilder(this.Transaction)
+                .WithInvoiceNumber("searchinvno")
+                .WithBillToCustomer(customer)
+                .WithSalesInvoiceType(new SalesInvoiceTypes(this.Transaction).SalesInvoice)
+                .Build();
+            var invoiceItem = new SalesInvoiceItemBuilder(this.Transaction)
+                .WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductItem)
+                .WithSerialisedItem(serialisedItem)
+                .WithQuantity(1)
+                .Build();
+            invoice.AddSalesInvoiceItem(invoiceItem);
+            this.Derive();
+
+            Assert.Contains("searchinvno", serialisedItem.SearchString);
+        }
     }
 
     public class SerialisedItemDisplayProductCategoriesRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedItemSearchStringRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/SerialisedItemSearchStringRule.cs
@@ -45,6 +45,7 @@ namespace Allors.Database.Domain
                 m.SerialisedItem.AssociationPattern(v => v.PurchaseOrderItemsWhereSerialisedItem),
                 m.SerialisedItem.AssociationPattern(v => v.QuoteItemsWhereSerialisedItem),
                 m.SerialisedItem.AssociationPattern(v => v.RequestItemsWhereSerialisedItem),
+                m.SerialisedItem.AssociationPattern(v => v.SalesInvoiceItemsWhereSerialisedItem),
                 m.SerialisedItem.AssociationPattern(v => v.SerialisedInventoryItemsWhereSerialisedItem),
                 m.SerialisedItem.AssociationPattern(v => v.ShipmentItemsWhereSerialisedItem),
             };


### PR DESCRIPTION
## Bug
`SerialisedItemSearchStringRule.Derive` folds seven inverse collections into the serialised item's `SearchString`,
including `SalesInvoiceItemsWhereSerialisedItem` (for the owning sales-invoice number). Six of the seven collections
have a matching `AssociationPattern` (PurchaseInvoiceItems, PurchaseOrderItems, QuoteItems, RequestItems,
SerialisedInventoryItems, ShipmentItems) — but `SalesInvoiceItemsWhereSerialisedItem` had **none**. So putting a
serialised item on a sales-invoice line did not re-fire the rule, leaving the item's `SearchString` stale.

## Fix
Add the one missing association pattern (in collection order, alongside its siblings; confirmed valid — also used in
`SerialisedItemDeniedPermissionRule:24`):

```csharp
m.SerialisedItem.AssociationPattern(v => v.SalesInvoiceItemsWhereSerialisedItem),
```

## Test (TDD)
New `SerialisedItemRuleTests.ChangedSalesInvoiceItemSerialisedItemDeriveSearchString`: build a
`SerialisedItem(SerialNumber="serialno")` and assert its `SearchString` does **not** contain `searchinvno`; build a
`SalesInvoice.WithInvoiceNumber("searchinvno")` + a `SalesInvoiceItem.WithSerialisedItem(...)`, add the item to the
invoice, derive; assert `SearchString` now **contains** `searchinvno`.

- **RED** (pre-fix): `SearchString` stayed `"S-2  SN: serialno S-2 serialno"` → `Assert.Contains("searchinvno", …)` failed.
- **GREEN** after the fix.

## Scope
None of the seven number-collections watch the **deep number value** (e.g. `SalesInvoice.InvoiceNumber` *edits* after
the link exists) — a uniform pre-existing limitation shared by all six siblings; the worklist marked that watch only
"optional". Out of scope for this targeted membership fix (fixing it for one collection but not the others would be
inconsistent).