### PR TITLE
fix(apps): re-derive Part PartCategoriesDisplayName on ancestor category rename [BUG-31]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PartPartCategoriesDisplayNameRule` renders a part's `PartCategoriesDisplayName` as the full primary-ancestor path
+  (`grandparent/parent/child`) but watched only `PartCategory.Name` rerouted to that category's *own* parts, so
+  renaming a non-direct ancestor category left descendant categories' parts' `PartCategoriesDisplayName` stale. It now
+  also watches `PartCategory.Name` rerouted via `PartCategoriesWherePrimaryAncestor` to the descendant categories' parts.
 - `SerialisedItemSearchStringRule` folds the owning sales-invoice number into the serialised item's `SearchString`
   but, alone among the seven invoice/order/quote/request/shipment collections it reads, had no association pattern for
   `SalesInvoiceItemsWhereSerialisedItem` — so putting a serialised item on a sales-invoice line left its `SearchString`

--- a/dotnet/Apps/Database/Domain.Tests/Product/PartTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/PartTests.cs
@@ -373,6 +373,29 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal("parent/child", nonUnifiedPart.PartCategoriesDisplayName);
         }
+
+        [Fact]
+        public void ChangedPartCategoryAncestorNameDerivePartCategoriesDisplayName()
+        {
+            var nonUnifiedPart = new NonUnifiedPartBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var partCategory1 = new PartCategoryBuilder(this.Transaction).WithName("parent").Build();
+            this.Derive();
+
+            var partCategory2 = new PartCategoryBuilder(this.Transaction).WithName("child").WithPrimaryParent(partCategory1).Build();
+            this.Derive();
+
+            partCategory2.AddPart(nonUnifiedPart);
+            this.Derive();
+
+            Assert.Equal("parent/child", nonUnifiedPart.PartCategoriesDisplayName);
+
+            partCategory1.Name = "renamedparent";
+            this.Derive();
+
+            Assert.Equal("renamedparent/child", nonUnifiedPart.PartCategoriesDisplayName);
+        }
     }
 
     public class PartDefaultFacilityNameRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/PartPartCategoriesDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/PartPartCategoriesDisplayNameRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.PartCategory.RolePattern(v => v.Name, v => v.Parts),
+                m.PartCategory.RolePattern(v => v.Name, v => v.PartCategoriesWherePrimaryAncestor.ObjectType.Parts),
                 m.PartCategory.RolePattern(v => v.PrimaryParent, v => v.Parts),
                 m.PartCategory.RolePattern(v => v.Parts, v => v.Parts)
             };


### PR DESCRIPTION
## Bug
`PartPartCategoriesDisplayNameRule` renders a part's `PartCategoriesDisplayName` as the full primary-ancestor path
(e.g. `grandparent/parent/child`). Its `Patterns` watched `PartCategory.Name` rerouted to `v => v.Parts` (the renamed
category's **own** parts), plus `PrimaryParent`/`Parts`. So renaming the **direct** category is covered, but renaming a
**non-direct ancestor** did not re-derive the descendant categories' parts — their `PartCategoriesDisplayName` kept the
old ancestor name.

## Fix
Add one reroute pattern (mirrors BUG-32's ancestor fix, one hop further to `.Parts`):

```csharp
m.PartCategory.RolePattern(v => v.Name, v => v.PartCategoriesWherePrimaryAncestor.ObjectType.Parts),
```

`PartCategory.PrimaryAncestors` is the derived transitive primary-parent chain; `PartCategoriesWherePrimaryAncestor`
(its inverse) yields the descendant categories, and `.Parts` their parts.

## Test (TDD)
New `PartPartCategoriesDisplayNameRuleTests.ChangedPartCategoryAncestorNameDerivePartCategoriesDisplayName` — models
the shipped `ChangedPartCategoryNameDerivePartCategoriesDisplayName` but renames the **ancestor**: a part in `child`
(PrimaryParent `parent`); assert `PartCategoriesDisplayName == "parent/child"`; rename `parent.Name = "renamedparent"`;
derive; assert `== "renamedparent/child"`.

- **RED** (pre-fix): stayed `"parent/child"`.
- **GREEN** after the fix.

Twin of #33 (`ProductProductCategoriesDisplayNameRule`).