### PR TITLE
fix(apps): re-derive Product ProductCategoriesDisplayName on ancestor category rename [BUG-33]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `ProductProductCategoriesDisplayNameRule` renders a product's `ProductCategoriesDisplayName` as the full
+  primary-ancestor path (`grandparent/parent/child`) but watched only `ProductCategory.Name` rerouted to that
+  category's *own* products, so renaming a non-direct ancestor category left descendant categories' products'
+  `ProductCategoriesDisplayName` stale. It now also watches `ProductCategory.Name` rerouted via
+  `ProductCategoriesWherePrimaryAncestor` to the descendant categories' products.
 - `SerialisedItemSearchStringRule` folds the owning sales-invoice number into the serialised item's `SearchString`
   but, alone among the seven invoice/order/quote/request/shipment collections it reads, had no association pattern for
   `SalesInvoiceItemsWhereSerialisedItem` — so putting a serialised item on a sales-invoice line left its `SearchString`

--- a/dotnet/Apps/Database/Domain.Tests/Product/UnifiedGoodTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/UnifiedGoodTests.cs
@@ -218,6 +218,29 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal("parent/child", nonUnifiedGood.ProductCategoriesDisplayName);
         }
+
+        [Fact]
+        public void ChangedProductCategoryAncestorNameDeriveProductCategoriesDisplayName()
+        {
+            var nonUnifiedGood = new NonUnifiedGoodBuilder(this.Transaction).Build();
+            this.Derive();
+
+            var partCategory1 = new ProductCategoryBuilder(this.Transaction).WithName("parent").Build();
+            this.Derive();
+
+            var partCategory2 = new ProductCategoryBuilder(this.Transaction).WithName("child").WithPrimaryParent(partCategory1).Build();
+            this.Derive();
+
+            partCategory2.AddProduct(nonUnifiedGood);
+            this.Derive();
+
+            Assert.Equal("parent/child", nonUnifiedGood.ProductCategoriesDisplayName);
+
+            partCategory1.Name = "renamedparent";
+            this.Derive();
+
+            Assert.Equal("renamedparent/child", nonUnifiedGood.ProductCategoriesDisplayName);
+        }
     }
 
     [Trait("Category", "Security")]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductProductCategoriesDisplayNameRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductProductCategoriesDisplayNameRule.cs
@@ -18,6 +18,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
             {
                 m.ProductCategory.RolePattern(v => v.Name, v => v.Products),
+                m.ProductCategory.RolePattern(v => v.Name, v => v.ProductCategoriesWherePrimaryAncestor.ObjectType.Products),
                 m.ProductCategory.RolePattern(v => v.PrimaryParent, v => v.Products),
                 m.ProductCategory.RolePattern(v => v.Products, v => v.Products)
             };


### PR DESCRIPTION
## Bug
`ProductProductCategoriesDisplayNameRule` renders a product's `ProductCategoriesDisplayName` as the full
primary-ancestor path (e.g. `grandparent/parent/child`). Its `Patterns` watched `ProductCategory.Name` rerouted to
`v => v.Products` (the renamed category's **own** products), plus `PrimaryParent`/`Products`. So renaming the
**direct** category is covered, but renaming a **non-direct ancestor** did not re-derive the descendant categories'
products — their `ProductCategoriesDisplayName` kept the old ancestor name.

## Fix
Add one reroute pattern (mirrors BUG-32's ancestor fix, one hop further to `.Products`; twin of #31's Part variant):

```csharp
m.ProductCategory.RolePattern(v => v.Name, v => v.ProductCategoriesWherePrimaryAncestor.ObjectType.Products),
```

`ProductCategory.PrimaryAncestors` is the derived transitive primary-parent chain;
`ProductCategoriesWherePrimaryAncestor` (its inverse) yields the descendant categories, and `.Products` their products.

## Test (TDD)
New `ProductProductCategoriesDisplayNameRuleTests.ChangedProductCategoryAncestorNameDeriveProductCategoriesDisplayName`
— models the shipped `ChangedProductCategoryNameDeriveProductCategoriesDisplayName` but renames the **ancestor**: a
product in `child` (PrimaryParent `parent`); assert `ProductCategoriesDisplayName == "parent/child"`; rename
`parent.Name = "renamedparent"`; derive; assert `== "renamedparent/child"`.

- **RED** (pre-fix): stayed `"parent/child"`.
- **GREEN** after the fix.

Twin of #31 (`PartPartCategoriesDisplayNameRule`).