### PR TITLE
fix(apps): re-derive SalesInvoice DerivedCurrency on BillToCustomer reassignment [BUG-05]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoiceReadyForPostingDerivedCurrencyRule` derives `DerivedCurrency` from `BillToCustomer`'s preferred
+  currency/locale but watched only the customer party's leaf roles (via the reverse path) and the invoice's
+  `BilledFrom`/`AssignedCurrency` — not the invoice→`BillToCustomer` link. Reassigning an invoice's `BillToCustomer`
+  therefore left `DerivedCurrency` based on the previous customer. It now also watches `SalesInvoice.BillToCustomer`.
 - `ProductProductCategoriesDisplayNameRule` renders a product's `ProductCategoriesDisplayName` as the full
   primary-ancestor path (`grandparent/parent/child`) but watched only `ProductCategory.Name` rerouted to that
   category's *own* products, so renaming a non-direct ancestor category left descendant categories' products'

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -1304,6 +1304,28 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedBillToCustomerDeriveDerivedCurrency()
+        {
+            var euro = new Currencies(this.Transaction).FindBy(this.M.Currency.IsoCode, "EUR");
+            var swedishKrona = new Currencies(this.Transaction).FindBy(this.M.Currency.IsoCode, "SEK");
+
+            var customer1 = new OrganisationBuilder(this.Transaction).WithName("customer1").WithPreferredCurrency(euro).Build();
+            var customer2 = new OrganisationBuilder(this.Transaction).WithName("customer2").WithPreferredCurrency(swedishKrona).Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer1).Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer2).Build();
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithBillToCustomer(customer1).Build();
+            this.Derive();
+
+            Assert.Equal(euro, invoice.DerivedCurrency);
+
+            invoice.BillToCustomer = customer2;
+            this.Derive();
+
+            Assert.Equal(swedishKrona, invoice.DerivedCurrency);
+        }
+
+        [Fact]
         public void ChangedAssignedVatRegimeDeriveDerivedVatRegime()
         {
             var invoice = new SalesInvoiceBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceReadyForPostingDerivedCurrencyRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceReadyForPostingDerivedCurrencyRule.cs
@@ -19,6 +19,7 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
         {
             m.SalesInvoice.RolePattern(v => v.BilledFrom),
+            m.SalesInvoice.RolePattern(v => v.BillToCustomer),
             m.SalesInvoice.RolePattern(v => v.AssignedCurrency),
             m.SalesInvoice.RolePattern(v => v.InvoiceDate),
             m.Party.RolePattern(v => v.Locale, v => v.SalesInvoicesWhereBillToCustomer),


### PR DESCRIPTION
## Bug
`SalesInvoiceReadyForPostingDerivedCurrencyRule` derives:

```csharp
DerivedCurrency = AssignedCurrency ?? BillToCustomer?.PreferredCurrency ?? BillToCustomer?.Locale?.Country?.Currency ?? BilledFrom?.PreferredCurrency;
```

Its `Patterns` watched the invoice's `BilledFrom`/`AssignedCurrency`/`InvoiceDate`, the **customer party's** `Locale`/
`PreferredCurrency` (via the reverse path `SalesInvoicesWhereBillToCustomer`), and `BilledFrom.PreferredCurrency` — but
**not** the invoice→`BillToCustomer` link. Note the asymmetry: `BilledFrom` is watched, `BillToCustomer` is not. So
reassigning an invoice's `BillToCustomer` to a different party (with a different preferred currency/locale) left
`DerivedCurrency` based on the previous customer.

## Fix
Add the missing invoice→customer link pattern (mirrors the existing `BilledFrom` pattern):

```csharp
m.SalesInvoice.RolePattern(v => v.BillToCustomer),
```

## Test (TDD)
New `SalesInvoiceReadyForPostingRuleTests.ChangedBillToCustomerDeriveDerivedCurrency` — models the shipped
`Changed…DeriveDerivedCurrency` tests but exercises the **reassignment**: two customers with preferred currencies EUR
and SEK; build a ReadyForPosting invoice with `BillToCustomer=customer1`, assert `DerivedCurrency==EUR`; set
`invoice.BillToCustomer=customer2`; derive; assert `DerivedCurrency==SEK`.

- **RED** (pre-fix): `DerivedCurrency` stayed EUR.
- **GREEN** after the fix.

## Cluster
First of the `#05/#23/#25/#26` derived-currency/locale cluster; the sibling rules (DerivedLocale; SalesOrder /
PurchaseInvoice equivalents) will be checked for the same `BillToCustomer`/`BilledFrom` link-watch gap on their rows.