### PR TITLE
fix(apps): re-derive SalesInvoice DerivedLocale on BillToCustomer/BilledFrom reassignment [BUG-26]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoiceReadyForPostingDerivedLocaleRule` derives `DerivedLocale` from `BillToCustomer`'s/`BilledFrom`'s locale
+  but watched only those parties' `Locale` leaf role (via the reverse path) and the invoice's own `Locale` — not the
+  invoice→`BillToCustomer`/`BilledFrom` links. Reassigning an invoice's `BillToCustomer` (or `BilledFrom`) therefore
+  left `DerivedLocale` based on the previous party. It now also watches `SalesInvoice.BillToCustomer` and
+  `SalesInvoice.BilledFrom` (same shape as the `DerivedCurrency` fix).
 - `SalesInvoiceReadyForPostingDerivedCurrencyRule` derives `DerivedCurrency` from `BillToCustomer`'s preferred
   currency/locale but watched only the customer party's leaf roles (via the reverse path) and the invoice's
   `BilledFrom`/`AssignedCurrency` — not the invoice→`BillToCustomer` link. Reassigning an invoice's `BillToCustomer`

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -1241,6 +1241,34 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedBillToCustomerDeriveDerivedLocale()
+        {
+            var localeGb = new LocaleBuilder(this.Transaction)
+                .WithCountry(new Countries(this.Transaction).FindBy(this.M.Country.IsoCode, "GB"))
+                .WithLanguage(new Languages(this.Transaction).FindBy(this.M.Language.IsoCode, "en"))
+                .Build();
+            var localeSe = new LocaleBuilder(this.Transaction)
+                .WithCountry(new Countries(this.Transaction).FindBy(this.M.Country.IsoCode, "SE"))
+                .WithLanguage(new Languages(this.Transaction).FindBy(this.M.Language.IsoCode, "sv"))
+                .Build();
+
+            var customer1 = new OrganisationBuilder(this.Transaction).WithName("customer1").WithLocale(localeGb).Build();
+            var customer2 = new OrganisationBuilder(this.Transaction).WithName("customer2").WithLocale(localeSe).Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer1).Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(customer2).Build();
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithBillToCustomer(customer1).Build();
+            this.Derive();
+
+            Assert.Equal(localeGb, invoice.DerivedLocale);
+
+            invoice.BillToCustomer = customer2;
+            this.Derive();
+
+            Assert.Equal(localeSe, invoice.DerivedLocale);
+        }
+
+        [Fact]
         public void ChangedAssignedCurrencyDeriveDerivedCurrency()
         {
             var invoice = new SalesInvoiceBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceReadyForPostingDerivedLocaleRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceReadyForPostingDerivedLocaleRule.cs
@@ -18,6 +18,8 @@ namespace Allors.Database.Domain
             this.Patterns = new Pattern[]
         {
             m.SalesInvoice.RolePattern(v => v.Locale),
+            m.SalesInvoice.RolePattern(v => v.BillToCustomer),
+            m.SalesInvoice.RolePattern(v => v.BilledFrom),
             m.Party.RolePattern(v => v.Locale, v => v.SalesInvoicesWhereBillToCustomer),
             m.Organisation.RolePattern(v => v.Locale, v => v.SalesInvoicesWhereBilledFrom),
         };


### PR DESCRIPTION
## Bug
`SalesInvoiceReadyForPostingDerivedLocaleRule` derives `DerivedLocale = Locale ?? BillToCustomer?.Locale ?? BilledFrom?.Locale`.
Its `Patterns` watched the invoice's own `Locale` and the party `Locale` leaf role (via the reverse paths
`SalesInvoicesWhereBillToCustomer` / `SalesInvoicesWhereBilledFrom`), but **not** the invoice→`BillToCustomer` /
`BilledFrom` link roles. So reassigning an invoice's `BillToCustomer` (or `BilledFrom`) to a different party left
`DerivedLocale` based on the previous party. Same shape as BUG-05 (`DerivedCurrency`).

## Fix
Add the two missing invoice→party link patterns:

```csharp
m.SalesInvoice.RolePattern(v => v.BillToCustomer),
m.SalesInvoice.RolePattern(v => v.BilledFrom),
```

## Test (TDD)
New `SalesInvoiceReadyForPostingRuleTests.ChangedBillToCustomerDeriveDerivedLocale` — two customers with locales en-GB
/ sv-SE; build a ReadyForPosting invoice with `BillToCustomer=customer1`, assert `DerivedLocale==localeGb`, set
`invoice.BillToCustomer=customer2`, derive, assert `DerivedLocale==localeSe`.

- **RED** (pre-fix): `DerivedLocale` stayed en-GB.
- **GREEN** after the fix.

The test exercises `BillToCustomer` reassignment; `BilledFrom` is the symmetric completion (read identically in the
Derive, watched only via the party-leaf reverse path) — reassigning `BilledFrom` needs a second internal organisation,
so it is covered by parity rather than a separate test.

Part of the `#05/#23/#25/#26` derived-currency/locale cluster.