### PR TITLE
fix(apps): re-derive SalesInvoice DueDate/PaymentDays on store/customer/payment-terms change [BUG-23]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoiceDueDateRule` computes `PaymentDays`/`DueDate` from `PaymentNetDays` — a getter that reads the
+  customer relationship and the store — but watched only `InvoiceDate`/`SalesTerms`. Reassigning `BillToCustomer`,
+  `BilledFrom` or `Store`, or editing `Store.PaymentNetDays`, left `PaymentDays`/`DueDate` stale. It now also watches
+  `SalesInvoice.BillToCustomer`/`BilledFrom`/`Store` and `Store.PaymentNetDays` (rerouted via `SalesInvoicesWhereStore`).
 - `SalesInvoiceReadyForPostingDerivedCurrencyRule` derives `DerivedCurrency` from `BillToCustomer`'s preferred
   currency/locale but watched only the customer party's leaf roles (via the reverse path) and the invoice's
   `BilledFrom`/`AssignedCurrency` — not the invoice→`BillToCustomer` link. Reassigning an invoice's `BillToCustomer`

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -1673,6 +1673,25 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedStorePaymentNetDaysDerivePaymentDays()
+        {
+            var store = new Stores(this.Transaction).Extent().First(v => Equals(v.InternalOrganisation, this.InternalOrganisation));
+            store.PaymentNetDays = 7;
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithStore(store).WithInvoiceDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            Assert.Equal(7, invoice.PaymentDays);
+            Assert.Equal(invoice.InvoiceDate.AddDays(7), invoice.DueDate);
+
+            store.PaymentNetDays = 14;
+            this.Derive();
+
+            Assert.Equal(14, invoice.PaymentDays);
+            Assert.Equal(invoice.InvoiceDate.AddDays(14), invoice.DueDate);
+        }
+
+        [Fact]
         public void DeriveCustomers()
         {
             var customer1 = this.InternalOrganisation.ActiveCustomers.FirstOrDefault();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceDueDateRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoiceDueDateRule.cs
@@ -20,6 +20,10 @@ namespace Allors.Database.Domain
             m.SalesInvoice.RolePattern(v => v.InvoiceDate),
             m.SalesInvoice.RolePattern(v => v.SalesTerms),
             m.SalesTerm.RolePattern(v => v.TermValue, v => v.InvoiceWhereSalesTerm, m.SalesInvoice),
+            m.SalesInvoice.RolePattern(v => v.BillToCustomer),
+            m.SalesInvoice.RolePattern(v => v.BilledFrom),
+            m.SalesInvoice.RolePattern(v => v.Store),
+            m.Store.RolePattern(v => v.PaymentNetDays, v => v.SalesInvoicesWhereStore),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`SalesInvoiceDueDateRule` sets `PaymentDays = PaymentNetDays` and `DueDate = InvoiceDate.AddDays(PaymentNetDays)`.
`PaymentNetDays` (a getter on `SalesInvoice`) resolves in order: (1) a `PaymentNetDays` SalesTerm; (2) the
`CustomerRelationship` between `BillToCustomer` and `BilledFrom`; (3) `Store.PaymentNetDays`; (4) `0`.

The rule's `Patterns` watched only `InvoiceDate`, `SalesTerms` and `SalesTerm.TermValue` — i.e. branch (1). Branches
(2) and (3), which depend on `BillToCustomer`, `BilledFrom`, `Store` and `Store.PaymentNetDays`, were unwatched — so
reassigning the customer / billed-from / store, or editing the store's payment-net-days, left `PaymentDays`/`DueDate`
stale.

## Fix
Add the four prescribed patterns (the last exists verbatim in `SalesInvoicePrintRule:41`):

```csharp
m.SalesInvoice.RolePattern(v => v.BillToCustomer),
m.SalesInvoice.RolePattern(v => v.BilledFrom),
m.SalesInvoice.RolePattern(v => v.Store),
m.Store.RolePattern(v => v.PaymentNetDays, v => v.SalesInvoicesWhereStore),
```

## Test (TDD)
New `SalesInvoiceRuleTests.ChangedStorePaymentNetDaysDerivePaymentDays` — exercises branch (3): set the store's
`PaymentNetDays=7`, build an invoice on that store (no SalesTerms ⇒ falls through to the store), assert
`PaymentDays==7` and `DueDate==InvoiceDate+7`; set `store.PaymentNetDays=14`; derive; assert `PaymentDays==14` /
`DueDate==InvoiceDate+14`.

- **RED** (pre-fix): `PaymentDays` stayed 7.
- **GREEN** after the fix.

The test directly exercises the `Store.PaymentNetDays` leg; the `BillToCustomer`/`BilledFrom`/`Store` link patterns
close the getter's other branches by parity with the same getter logic.

Part of the `#05/#23/#25/#26` derived-currency/locale cluster.