### PR TITLE
fix(apps): re-derive SalesInvoice prices on InvoiceDate/DerivedCurrency change [BUG-25]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoicePriceRule` reads `InvoiceDate` (to select date-effective price components and as the currency-conversion
+  date) and `DerivedCurrency` (the conversion source) but watched neither, so editing the invoice date — or a change to
+  the derived currency — left item prices and the `*InPreferredCurrency` totals stale. It now also watches
+  `SalesInvoice.InvoiceDate` and `SalesInvoice.DerivedCurrency` (the latter complements the `DerivedCurrency` re-derivation fix).
 - `SalesInvoiceReadyForPostingDerivedCurrencyRule` derives `DerivedCurrency` from `BillToCustomer`'s preferred
   currency/locale but watched only the customer party's leaf roles (via the reverse path) and the invoice's
   `BilledFrom`/`AssignedCurrency` — not the invoice→`BillToCustomer` link. Reassigning an invoice's `BillToCustomer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,6 @@ under a dated version heading.
   invoice→`BillToCustomer`/`BilledFrom` links. Reassigning an invoice's `BillToCustomer` (or `BilledFrom`) therefore
   left `DerivedLocale` based on the previous party. It now also watches `SalesInvoice.BillToCustomer` and
   `SalesInvoice.BilledFrom` (same shape as the `DerivedCurrency` fix).
->>>>>>> origin/main
 - `SalesInvoiceReadyForPostingDerivedCurrencyRule` derives `DerivedCurrency` from `BillToCustomer`'s preferred
   currency/locale but watched only the customer party's leaf roles (via the reverse path) and the invoice's
   `BilledFrom`/`AssignedCurrency` — not the invoice→`BillToCustomer` link. Reassigning an invoice's `BillToCustomer`

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -2572,6 +2572,32 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedInvoiceDateDerivePrice()
+        {
+            var product = new NonUnifiedGoodBuilder(this.Transaction).Build();
+
+            new BasePriceBuilder(this.Transaction)
+                .WithProduct(product)
+                .WithPrice(1)
+                .WithFromDate(this.Transaction.Now().AddDays(2))
+                .Build();
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithInvoiceDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var invoiceItem = new SalesInvoiceItemBuilder(this.Transaction).WithProduct(product).WithQuantity(1).Build();
+            invoice.AddSalesInvoiceItem(invoiceItem);
+            this.Derive();
+
+            Assert.Equal(0, invoice.TotalIncVat);
+
+            invoice.InvoiceDate = this.Transaction.Now().AddDays(3);
+            this.Derive();
+
+            Assert.Equal(1, invoice.TotalIncVat);
+        }
+
+        [Fact]
         public void OnChangedDerivationTriggerTriggeredByDiscountComponentPercentageCalculatePrice()
         {
             var product = new NonUnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
@@ -24,6 +24,8 @@ namespace Allors.Database.Domain
             m.SalesInvoice.RolePattern(v => v.OrderAdjustments),
             m.SalesInvoice.RolePattern(v => v.DerivedVatRate),
             m.SalesInvoice.RolePattern(v => v.DerivedIrpfRate),
+            m.SalesInvoice.RolePattern(v => v.InvoiceDate),
+            m.SalesInvoice.RolePattern(v => v.DerivedCurrency),
             m.SalesInvoiceItem.RolePattern(v => v.Product, v => v.SalesInvoiceWhereSalesInvoiceItem),
             m.SalesInvoiceItem.RolePattern(v => v.ProductFeatures, v => v.SalesInvoiceWhereSalesInvoiceItem),
             m.SalesInvoiceItem.RolePattern(v => v.Quantity, v => v .SalesInvoiceWhereSalesInvoiceItem),


### PR DESCRIPTION
## Bug
`SalesInvoicePriceRule` uses `@this.InvoiceDate` to select the applicable (date-effective) price components
(`v.FromDate <= InvoiceDate && (!v.ExistThroughDate || v.ThroughDate >= InvoiceDate)`) and as the currency-conversion
date, and `@this.DerivedCurrency` as the conversion source for every `*InPreferredCurrency` total. Its `Patterns`
watched `SalesInvoiceState`, `DerivationTrigger`, `ValidInvoiceItems`, `BillToCustomer`, `OrderAdjustments`,
`DerivedVatRate`, `DerivedIrpfRate` and item-level roles — but **neither `InvoiceDate` nor `DerivedCurrency`**. So
editing the invoice date (changing which price components apply) or a change to the derived currency left item prices
and the `*InPreferredCurrency` totals stale.

## Fix
Add the two invoice-level scalar patterns:

```csharp
m.SalesInvoice.RolePattern(v => v.InvoiceDate),
m.SalesInvoice.RolePattern(v => v.DerivedCurrency),
```

## Test (TDD)
New `SalesInvoicePriceRuleTests.ChangedInvoiceDateDerivePrice` — a `BasePrice` valid only from `now+2 days`; build an
invoice with `InvoiceDate=now` + a product item and assert `TotalIncVat==0` (price not yet effective); set
`invoice.InvoiceDate=now+3 days` (into the price's validity window); derive; assert `TotalIncVat==1`.

- **RED** (pre-fix): `TotalIncVat` stayed 0 — changing `InvoiceDate` did not re-run the price rule.
- **GREEN** after the fix.

The test exercises the `InvoiceDate` leg (date-effective price-component selection — the cleanest observable). The
`DerivedCurrency` leg is the symmetric completion: it is the conversion source for the `*InPreferredCurrency` totals
and is now re-derived by BUG-05's fix, so the price rule must re-run when it changes (exercising it directly would
require seeding an `ExchangeRate`).

Part of the `#05/#23/#25/#26` derived-currency/locale cluster; complements #05.