### PR TITLE
fix(apps): re-derive WorkTask CanInvoice on child WorkEffortState change [BUG-39]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkTaskCanInvoiceRule` blocks a parent work task's `CanInvoice` until every child is Completed/Finished but watched
+  only the task's own `WorkEffortState`, so completing the last child did not flip the parent's `CanInvoice`. It now
+  also watches each child's `WorkEffortState` (rerouted via `WorkEffortWhereChild` to the parent `WorkTask`).
 - `SalesInvoicePriceRule` reads `InvoiceDate` (to select date-effective price components and as the currency-conversion
   date) and `DerivedCurrency` (the conversion source) but watched neither, so editing the invoice date — or a change to
   the derived currency — left item prices and the `*InPreferredCurrency` totals stale. It now also watches

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -1419,6 +1419,25 @@ namespace Allors.Database.Domain.Tests
 
             Assert.True(workTask.CanInvoice);
         }
+
+        [Fact]
+        public void ChangedChildWorkEffortStateDeriveCanInvoice()
+        {
+            var parent = new WorkTaskBuilder(this.Transaction).Build();
+            var child = new WorkTaskBuilder(this.Transaction).Build();
+            parent.AddChild(child);
+            this.Derive();
+
+            parent.WorkEffortState = new WorkEffortStates(this.Transaction).Completed;
+            this.Derive();
+
+            Assert.False(parent.CanInvoice);
+
+            child.WorkEffortState = new WorkEffortStates(this.Transaction).Completed;
+            this.Derive();
+
+            Assert.True(parent.CanInvoice);
+        }
     }
 
     public class WorkEffortTotalLabourRevenueRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
@@ -20,6 +20,7 @@ namespace Allors.Database.Domain
         {
             m.WorkTask.RolePattern(v => v.DerivationTrigger),
             m.WorkTask.RolePattern(v => v.WorkEffortState),
+            m.WorkEffort.RolePattern(v => v.WorkEffortState, v => v.WorkEffortWhereChild, m.WorkTask),
             m.TimeEntry.AssociationPattern(v => v.TimeSheetWhereTimeEntry, v => v.WorkEffort),
         };
 


### PR DESCRIPTION
## Bug
`WorkTaskCanInvoiceRule` only allows a parent work task to be invoiced if **every** child is Completed/Finished
(`foreach (var child in @this.Children) … child.WorkEffortState …`). But its `Patterns` watched only the task's **own**
`WorkEffortState` — nothing fired when a *child's* state changed, so completing the last child left the parent's
`CanInvoice` stale.

## Fix
Add one reroute pattern so a child's state change re-derives its parent:

```csharp
m.WorkEffort.RolePattern(v => v.WorkEffortState, v => v.WorkEffortWhereChild, m.WorkTask),
```

(`WorkEffort.Children` is the forward role; `WorkEffortWhereChild` — its inverse — reaches the parent.)

## Test (TDD)
New `WorkTaskCanInvoiceRuleTests.ChangedChildWorkEffortStateDeriveCanInvoice`: a parent WorkTask with one child; set
the parent Completed and assert `CanInvoice==false` (child still Created); set the child Completed; derive; assert
`CanInvoice==true`.

- **RED** (pre-fix): parent `CanInvoice` stayed `false` after the child completed.
- **GREEN** after the fix.

First of the `#39/#40/#54` `WorkTaskCanInvoiceRule` trio (same rule; landing as 3 sequential PRs).