### PR TITLE
fix(apps): re-derive WorkTask CanInvoice on ExecutedBy/Customer change [BUG-40]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkTaskCanInvoiceRule` also denies `CanInvoice` when the work task's `ExecutedBy` equals its `Customer`, but
+  watched neither role, so reassigning either left `CanInvoice` stale. It now also watches `WorkTask.Customer` and
+  `WorkTask.ExecutedBy`.
 - `WorkTaskCanInvoiceRule` blocks a parent work task's `CanInvoice` until every child is Completed/Finished but watched
   only the task's own `WorkEffortState`, so completing the last child did not flip the parent's `CanInvoice`. It now
   also watches each child's `WorkEffortState` (rerouted via `WorkEffortWhereChild` to the parent `WorkTask`).

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -1438,6 +1438,31 @@ namespace Allors.Database.Domain.Tests
 
             Assert.True(parent.CanInvoice);
         }
+
+        [Fact]
+        public void ChangedExecutedByAndCustomerDeriveCanInvoice()
+        {
+            var customer = new OrganisationBuilder(this.Transaction).WithName("customer").Build();
+            var other = new OrganisationBuilder(this.Transaction).WithName("other").Build();
+
+            var workTask = new WorkTaskBuilder(this.Transaction).WithCustomer(customer).WithExecutedBy(customer).Build();
+            this.Derive();
+
+            workTask.WorkEffortState = new WorkEffortStates(this.Transaction).Completed;
+            this.Derive();
+
+            Assert.False(workTask.CanInvoice);
+
+            workTask.ExecutedBy = other;
+            this.Derive();
+
+            Assert.True(workTask.CanInvoice);
+
+            workTask.Customer = other;
+            this.Derive();
+
+            Assert.False(workTask.CanInvoice);
+        }
     }
 
     public class WorkEffortTotalLabourRevenueRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
@@ -20,6 +20,8 @@ namespace Allors.Database.Domain
         {
             m.WorkTask.RolePattern(v => v.DerivationTrigger),
             m.WorkTask.RolePattern(v => v.WorkEffortState),
+            m.WorkTask.RolePattern(v => v.Customer),
+            m.WorkTask.RolePattern(v => v.ExecutedBy),
             m.WorkEffort.RolePattern(v => v.WorkEffortState, v => v.WorkEffortWhereChild, m.WorkTask),
             m.TimeEntry.AssociationPattern(v => v.TimeSheetWhereTimeEntry, v => v.WorkEffort),
         };


### PR DESCRIPTION
## Bug
`WorkTaskCanInvoiceRule` sets `CanInvoice = false` when `@this.ExistExecutedBy && @this.ExecutedBy.Equals(@this.Customer)`
(a guard so a customer doing its own work isn't invoiced). But its `Patterns` watched **neither** `Customer` nor
`ExecutedBy`, so reassigning either role left `CanInvoice` stale. The sibling `WorkTaskDeniedPermissionRule:22-23`
already watches both.

## Fix
Add the two role patterns (verbatim from `WorkTaskDeniedPermissionRule`):

```csharp
m.WorkTask.RolePattern(v => v.Customer),
m.WorkTask.RolePattern(v => v.ExecutedBy),
```

## Test (TDD)
New `WorkTaskCanInvoiceRuleTests.ChangedExecutedByAndCustomerDeriveCanInvoice`: a Completed work task with
`Customer == ExecutedBy` (assert `CanInvoice==false`); change `ExecutedBy` to a different party (assert
`CanInvoice==true`); change `Customer` to match the new `ExecutedBy` (assert `CanInvoice==false`). The single test
requires **both** patterns — the `ExecutedBy` mutation exercises the ExecutedBy watch, the `Customer` mutation the
Customer watch.

- **RED** (pre-fix): `CanInvoice` stayed `false` after `ExecutedBy` changed away from `Customer`.
- **GREEN** after the fix.

Second of the `#39/#40/#54` `WorkTaskCanInvoiceRule` trio (same rule; landing as 3 sequential PRs).