### PR TITLE
fix(apps): watch ServiceEntry.ThroughDate + fix hard-cast in WorkTask CanInvoice [BUG-54]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `WorkTaskCanInvoiceRule` blocks `CanInvoice` while any service entry lacks a `ThroughDate` but watched only service-
+  entry add/remove (via the time-sheet association), so filling in a `ThroughDate` left `CanInvoice` stale; it now also
+  watches `ServiceEntry.ThroughDate`. The same loop also hard-cast every `ServiceEntry` to `TimeEntry`, throwing
+  `InvalidCastException` once a non-time entry (e.g. a materials usage) was attached to a completed work task — it now
+  iterates `.OfType<TimeEntry>()`.
 - `WorkTaskCanInvoiceRule` also denies `CanInvoice` when the work task's `ExecutedBy` equals its `Customer`, but
   watched neither role, so reassigning either left `CanInvoice` stale. It now also watches `WorkTask.Customer` and
   `WorkTask.ExecutedBy`.

--- a/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/WorkEffort/Worktasktests.cs
@@ -1463,6 +1463,37 @@ namespace Allors.Database.Domain.Tests
 
             Assert.False(workTask.CanInvoice);
         }
+
+        [Fact]
+        public void ChangedServiceEntryThroughDateDeriveCanInvoice()
+        {
+            var workTask = new WorkTaskBuilder(this.Transaction).Build();
+            var timeEntry = new TimeEntryBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithWorkEffort(workTask).Build();
+            this.Derive();
+
+            workTask.WorkEffortState = new WorkEffortStates(this.Transaction).Completed;
+            this.Derive();
+
+            Assert.False(workTask.CanInvoice);
+
+            timeEntry.ThroughDate = timeEntry.FromDate;
+            this.Derive();
+
+            Assert.True(workTask.CanInvoice);
+        }
+
+        [Fact]
+        public void NonTimeEntryServiceEntryDoesNotBreakCanInvoice()
+        {
+            var workTask = new WorkTaskBuilder(this.Transaction).Build();
+            new MaterialsUsageBuilder(this.Transaction).WithWorkEffort(workTask).WithIsBillable(false).Build();
+            this.Derive();
+
+            workTask.WorkEffortState = new WorkEffortStates(this.Transaction).Completed;
+            this.Derive();
+
+            Assert.True(workTask.CanInvoice);
+        }
     }
 
     public class WorkEffortTotalLabourRevenueRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/WorkEffort/WorkTaskCanInvoiceRule.cs
@@ -24,6 +24,7 @@ namespace Allors.Database.Domain
             m.WorkTask.RolePattern(v => v.ExecutedBy),
             m.WorkEffort.RolePattern(v => v.WorkEffortState, v => v.WorkEffortWhereChild, m.WorkTask),
             m.TimeEntry.AssociationPattern(v => v.TimeSheetWhereTimeEntry, v => v.WorkEffort),
+            m.ServiceEntry.RolePattern(v => v.ThroughDate, v => v.WorkEffort.ObjectType.ServiceEntriesWhereWorkEffort.ObjectType.WorkEffort),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)
@@ -56,7 +57,7 @@ namespace Allors.Database.Domain
 
                 if (@this.CanInvoice)
                 {
-                    foreach (TimeEntry timeEntry in @this.ServiceEntriesWhereWorkEffort)
+                    foreach (var timeEntry in @this.ServiceEntriesWhereWorkEffort.OfType<TimeEntry>())
                     {
                         if (!timeEntry.ExistThroughDate)
                         {


### PR DESCRIPTION
## Bug
Two issues in `WorkTaskCanInvoiceRule`'s service-entry loop:

1. **Stale derivation (cited):** `CanInvoice` is set `false` if any service entry lacks a `ThroughDate`, but the
   `Patterns` watched only service-entry membership (the time-sheet association fires on add/remove). Filling in an
   entry's `ThroughDate` did not re-derive `CanInvoice`.
2. **Hard-cast crash (bundled latent, same shape as BUG-14):**
   `foreach (TimeEntry timeEntry in @this.ServiceEntriesWhereWorkEffort)` casts **every** `ServiceEntry` to `TimeEntry`
   → `InvalidCastException` once a non-time entry (e.g. a `MaterialsUsage`) is attached to a completed work task.

## Fix
```csharp
// 1. watch the value (verbatim from WorkTaskDeniedPermissionRule:26)
m.ServiceEntry.RolePattern(v => v.ThroughDate, v => v.WorkEffort.ObjectType.ServiceEntriesWhereWorkEffort.ObjectType.WorkEffort),

// 2. iterate only TimeEntries (matching the BUG-14 fix), preserving the original intent without crashing
foreach (var timeEntry in @this.ServiceEntriesWhereWorkEffort.OfType<TimeEntry>())
```

## Tests (TDD)
- `ChangedServiceEntryThroughDateDeriveCanInvoice` — completed task + a `TimeEntry` lacking `ThroughDate`
  (`CanInvoice==false`); set the `ThroughDate`; derive; `CanInvoice==true`. **RED:** stayed `false`.
- `NonTimeEntryServiceEntryDoesNotBreakCanInvoice` — attach a `MaterialsUsage`, set the task Completed, derive.
  **RED:** `InvalidCastException` (MaterialsUsage → TimeEntry).
- Both **GREEN** after the fix.

Third/last of the `#39/#40/#54` `WorkTaskCanInvoiceRule` trio.