### PR TITLE
fix(apps): re-derive PurchaseInvoice item VAT/IRPF on item-regime override [BUG-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoicePriceRule` derives each item's VAT/IRPF from its `AssignedVatRegime`/`AssignedIrpfRegime` (falling
+  back to the invoice regime) but watched neither item role — and, unlike the sales side, there is no separate
+  item-regime rule — so overriding an item's VAT or IRPF regime left the item's tax and the invoice totals stale. It
+  now watches `PurchaseInvoiceItem.AssignedVatRegime` and `AssignedIrpfRegime`.
 - `WorkTaskCanInvoiceRule` blocks `CanInvoice` while any service entry lacks a `ThroughDate` but watched only service-
   entry add/remove (via the time-sheet association), so filling in a `ThroughDate` left `CanInvoice` stale; it now also
   watches `ServiceEntry.ThroughDate`. The same loop also hard-cast every `ServiceEntry` to `TimeEntry`, throwing

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -1226,6 +1226,33 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(newVatRate, invoiceItem.VatRate);
         }
+
+        [Fact]
+        public void ChangedPurchaseInvoiceItemAssignedVatRegimeAndIrpfRegimeDeriveDerivedRegimes()
+        {
+            var vatRegime = new VatRegimes(this.Transaction).BelgiumStandard;
+            var irpfRegime = new IrpfRegimes(this.Transaction).Assessable19;
+
+            var invoice = new PurchaseInvoiceBuilder(this.Transaction)
+                .WithBilledFrom(this.InternalOrganisation.ActiveSuppliers.First())
+                .WithInvoiceDate(this.Transaction.Now())
+                .Build();
+            this.Derive();
+
+            var invoiceItem = new PurchaseInvoiceItemBuilder(this.Transaction).WithAssignedUnitPrice(100).WithQuantity(1).Build();
+            invoice.AddPurchaseInvoiceItem(invoiceItem);
+            this.Derive();
+
+            Assert.NotEqual(vatRegime, invoiceItem.DerivedVatRegime);
+            Assert.NotEqual(irpfRegime, invoiceItem.DerivedIrpfRegime);
+
+            invoiceItem.AssignedVatRegime = vatRegime;
+            invoiceItem.AssignedIrpfRegime = irpfRegime;
+            this.Derive();
+
+            Assert.Equal(vatRegime, invoiceItem.DerivedVatRegime);
+            Assert.Equal(irpfRegime, invoiceItem.DerivedIrpfRegime);
+        }
     }
 
     [Trait("Category", "Security")]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
@@ -28,6 +28,8 @@ namespace Allors.Database.Domain
                 m.PurchaseInvoiceItem.RolePattern(v => v.Part, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
                 m.PurchaseInvoiceItem.RolePattern(v => v.Quantity, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
                 m.PurchaseInvoiceItem.RolePattern(v => v.AssignedUnitPrice, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
+                m.PurchaseInvoiceItem.RolePattern(v => v.AssignedVatRegime, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
+                m.PurchaseInvoiceItem.RolePattern(v => v.AssignedIrpfRegime, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
                 m.PurchaseInvoiceItem.RolePattern(v => v.DiscountAdjustments, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
                 m.PurchaseInvoiceItem.RolePattern(v => v.SurchargeAdjustments, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
                 m.DiscountAdjustment.RolePattern(v => v.Percentage, v => v.PriceableWhereDiscountAdjustment.ObjectType.AsPurchaseInvoiceItem.PurchaseInvoiceWherePurchaseInvoiceItem, m.PurchaseInvoice),


### PR DESCRIPTION
## Bug
`PurchaseInvoicePriceRule` computes, per item:

```csharp
item.DerivedVatRegime  = item.AssignedVatRegime  ?? @this.DerivedVatRegime;   // -> item.VatRate  -> TotalVat
item.DerivedIrpfRegime = item.AssignedIrpfRegime ?? @this.DerivedIrpfRegime;  // -> item.IrpfRate -> TotalIrpf
```

But its `Patterns` watched invoice-level `DerivedVatRate`/`DerivedIrpfRate` and item-level
`Part`/`Quantity`/`AssignedUnitPrice`/`Discount`/`Surcharge` — **neither** `PurchaseInvoiceItem.AssignedVatRegime` nor
`AssignedIrpfRegime`. Unlike the sales side (which has a dedicated item-regime rule), nothing re-fired when an item's
regime was overridden, so the item's VAT/IRPF and the invoice totals went stale.

## Fix
Add the two item-regime reroute patterns (matching the existing item-pattern idiom):

```csharp
m.PurchaseInvoiceItem.RolePattern(v => v.AssignedVatRegime, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
m.PurchaseInvoiceItem.RolePattern(v => v.AssignedIrpfRegime, v => v.PurchaseInvoiceWherePurchaseInvoiceItem),
```

## Test (TDD)
New `PurchaseInvoicePriceRuleTests.ChangedPurchaseInvoiceItemAssignedVatRegimeAndIrpfRegimeDeriveDerivedRegimes`: a
Created purchase invoice + an item with no item regimes (assert `DerivedVatRegime`/`DerivedIrpfRegime` are not the
targets); set `item.AssignedVatRegime = BelgiumStandard` and `item.AssignedIrpfRegime = Assessable19`; derive; assert
each item `Derived…Regime` now equals the assigned regime. Covers both patterns.

- **RED** (pre-fix): `item.DerivedVatRegime` stayed `null` after the override.
- **GREEN** after the fix.

First of the price-rule VAT/regime cluster.