### PR TITLE
fix(apps): re-derive SalesInvoice tax totals on per-item VatRate/IrpfRate change [BUG-04]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoicePriceRule` sums each item's VAT/IRPF (computed from the item's own `VatRate`/`IrpfRate`, set by the
+  item-regime rules) into the invoice totals, but watched only the invoice-level `DerivedVatRate` — so a change to an
+  item's `VatRate`/`IrpfRate` (e.g. overriding the item's VAT regime) left the invoice `TotalVat`/`TotalIrpf` stale. It
+  now also watches `SalesInvoiceItem.VatRate` and `IrpfRate` (rerouted to the invoice).
 - `PurchaseInvoicePriceRule` derives each item's VAT/IRPF from its `AssignedVatRegime`/`AssignedIrpfRegime` (falling
   back to the invoice regime) but watched neither item role — and, unlike the sales side, there is no separate
   item-regime rule — so overriding an item's VAT or IRPF regime left the item's tax and the invoice totals stale. It

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -2645,6 +2645,30 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedSalesInvoiceItemVatRateAndIrpfRateDeriveTotals()
+        {
+            var vatRegime = new VatRegimes(this.Transaction).BelgiumStandard;
+            var irpfRegime = new IrpfRegimes(this.Transaction).Assessable19;
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithInvoiceDate(this.Transaction.Now()).Build();
+            this.Derive();
+
+            var invoiceItem = new SalesInvoiceItemBuilder(this.Transaction).WithAssignedUnitPrice(100).WithQuantity(1).Build();
+            invoice.AddSalesInvoiceItem(invoiceItem);
+            this.Derive();
+
+            Assert.Equal(0, invoice.TotalVat);
+            Assert.Equal(0, invoice.TotalIrpf);
+
+            invoiceItem.AssignedVatRegime = vatRegime;
+            invoiceItem.AssignedIrpfRegime = irpfRegime;
+            this.Derive();
+
+            Assert.Equal(invoiceItem.UnitPrice * invoiceItem.VatRate.Rate / 100, invoice.TotalVat);
+            Assert.Equal(invoiceItem.UnitPrice * invoiceItem.IrpfRate.Rate / 100, invoice.TotalIrpf);
+        }
+
+        [Fact]
         public void OnChangedDerivationTriggerTriggeredByDiscountComponentPercentageCalculatePrice()
         {
             var product = new NonUnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
@@ -30,6 +30,8 @@ namespace Allors.Database.Domain
             m.SalesInvoiceItem.RolePattern(v => v.ProductFeatures, v => v.SalesInvoiceWhereSalesInvoiceItem),
             m.SalesInvoiceItem.RolePattern(v => v.Quantity, v => v .SalesInvoiceWhereSalesInvoiceItem),
             m.SalesInvoiceItem.RolePattern(v => v.AssignedUnitPrice, v => v.SalesInvoiceWhereSalesInvoiceItem),
+            m.SalesInvoiceItem.RolePattern(v => v.VatRate, v => v.SalesInvoiceWhereSalesInvoiceItem),
+            m.SalesInvoiceItem.RolePattern(v => v.IrpfRate, v => v.SalesInvoiceWhereSalesInvoiceItem),
             m.SalesInvoiceItem.RolePattern(v => v.DiscountAdjustments, v => v.SalesInvoiceWhereSalesInvoiceItem),
             m.DiscountAdjustment.RolePattern(v => v.Percentage, v => v.PriceableWhereDiscountAdjustment.ObjectType.AsSalesInvoiceItem.SalesInvoiceWhereSalesInvoiceItem, m.SalesInvoice),
             m.DiscountAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),


### PR DESCRIPTION
## Bug
The invoice-level `SalesInvoicePriceRule.CalculatePrices` computes each item's `UnitVat`/`UnitIrpf` from
`salesInvoiceItem.VatRate.Rate`/`IrpfRate.Rate` and sums `item.TotalVat`/`item.TotalIrpf` into the invoice totals.
Each item's `VatRate`/`IrpfRate` is set by dedicated item rules (`SalesInvoiceItemAssignedVatRegimeRule`,
`SalesInvoiceItemAssignedIrpfRegimeRule`). But the invoice rule's `Patterns` watched only the invoice-level
`DerivedVatRate` — **not** the item's `VatRate`/`IrpfRate`. So when an item's own rate changed (e.g. its VAT regime was
overridden → the item rule re-derived `item.VatRate`), the invoice rule didn't re-fire and `TotalVat`/`TotalIrpf` went
stale.

## Fix
Watch the item rates, rerouted to the invoice (the `SalesOrderItemPriceRule:27-28` / `QuoteItemPriceRule:28-29`
siblings watch the same roles directly, since they operate on the item):

```csharp
m.SalesInvoiceItem.RolePattern(v => v.VatRate, v => v.SalesInvoiceWhereSalesInvoiceItem),
m.SalesInvoiceItem.RolePattern(v => v.IrpfRate, v => v.SalesInvoiceWhereSalesInvoiceItem),
```

## Test (TDD)
New `SalesInvoicePriceRuleTests.ChangedSalesInvoiceItemVatRateAndIrpfRateDeriveTotals`: a ReadyForPosting invoice + an
item (`AssignedUnitPrice=100`, no regime ⇒ `TotalVat`/`TotalIrpf`=0); set `item.AssignedVatRegime=BelgiumStandard` and
`item.AssignedIrpfRegime=Assessable19` (the item rules update `item.VatRate`/`IrpfRate`); derive; assert
`invoice.TotalVat == UnitPrice*item.VatRate.Rate/100` and `TotalIrpf == UnitPrice*item.IrpfRate.Rate/100`.

- **RED** (pre-fix): the item's `VatRate` updated to 21% but `invoice.TotalVat` stayed `0`.
- **GREEN** after the fix.

Price-rule VAT/regime cluster — the sales-side counterpart of #03.