### PR TITLE
fix(apps): re-derive PurchaseOrder VAT/IRPF totals on rate change [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderPriceRule` computes the VAT/IRPF on order-level adjustments (discount/surcharge/fee/shipping/misc) from
+  the order's `DerivedVatRate`/`DerivedIrpfRate` but watched neither, so a VAT/IRPF regime or rate change left the
+  order `TotalVat`/`TotalIrpf` stale. It now also watches `PurchaseOrder.DerivedVatRate` and `DerivedIrpfRate` (as the
+  sales invoice rule does).
 - `SalesInvoicePriceRule` sums each item's VAT/IRPF (computed from the item's own `VatRate`/`IrpfRate`, set by the
   item-regime rules) into the invoice totals, but watched only the invoice-level `DerivedVatRate` — so a change to an
   item's `VatRate`/`IrpfRate` (e.g. overriding the item's VAT regime) left the invoice `TotalVat`/`TotalIrpf` stale. It

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -569,6 +569,34 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(newVatRate, order.DerivedVatRate);
         }
+
+        [Fact]
+        public void ChangedDerivedVatRateDeriveTotalVat()
+        {
+            var vatRegime = new VatRegimes(this.Transaction).SpainReduced;
+            vatRegime.VatRates.ElementAt(0).ThroughDate = this.Transaction.Now().AddDays(-1).Date;
+            this.Derive();
+
+            var newVatRate = new VatRateBuilder(this.Transaction).WithFromDate(this.Transaction.Now().Date).WithRate(11).Build();
+            vatRegime.AddVatRate(newVatRate);
+            this.Derive();
+
+            var order = new PurchaseOrderBuilder(this.Transaction)
+                .WithTakenViaSupplier(this.InternalOrganisation.ActiveSuppliers.First())
+                .WithOrderDate(this.Transaction.Now().AddDays(-1).Date)
+                .WithAssignedVatRegime(vatRegime)
+                .Build();
+            var surcharge = new SurchargeAdjustmentBuilder(this.Transaction).WithAmount(100).Build();
+            order.AddOrderAdjustment(surcharge);
+            this.Derive();
+
+            Assert.NotEqual(11M, order.TotalVat);
+
+            order.OrderDate = this.Transaction.Now().AddDays(1).Date;
+            this.Derive();
+
+            Assert.Equal(11M, order.TotalVat);
+        }
     }
 
     public class PurchaseOrderAwaitingApprovalLevel1RuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
@@ -21,6 +21,8 @@ namespace Allors.Database.Domain
                 m.PurchaseOrder.RolePattern(v => v.ValidOrderItems),
                 m.PurchaseOrder.RolePattern(v => v.TakenViaSupplier),
                 m.PurchaseOrder.RolePattern(v => v.OrderAdjustments),
+                m.PurchaseOrder.RolePattern(v => v.DerivedVatRate),
+                m.PurchaseOrder.RolePattern(v => v.DerivedIrpfRate),
                 m.PurchaseOrderItem.RolePattern(v => v.Part, v => v.PurchaseOrderWherePurchaseOrderItem),
                 m.PurchaseOrderItem.RolePattern(v => v.QuantityOrdered, v => v.PurchaseOrderWherePurchaseOrderItem),
                 m.PurchaseOrderItem.RolePattern(v => v.AssignedUnitPrice, v => v.PurchaseOrderWherePurchaseOrderItem),


### PR DESCRIPTION
## Bug
`PurchaseOrderPriceRule` computes the VAT/IRPF on each order-level adjustment (discount/surcharge/fee/shipping/misc)
from `@this.DerivedVatRate.Rate` / `@this.DerivedIrpfRate.Rate`, gated on `ExistDerivedVatRegime`/`ExistDerivedIrpfRegime`.
But its `Patterns` watched `DerivationTrigger`, `ValidOrderItems`, `TakenViaSupplier`, `OrderAdjustments` and item-level
roles — **neither** `DerivedVatRate` nor `DerivedIrpfRate`. So when the order's VAT/IRPF rate changed (its regime
changed, or the applicable rate period changed), the adjustment VAT/IRPF and the order `TotalVat`/`TotalIrpf` went
stale. The sales invoice rule already watches these (`SalesInvoicePriceRule:25-26`).

## Fix
```csharp
m.PurchaseOrder.RolePattern(v => v.DerivedVatRate),
m.PurchaseOrder.RolePattern(v => v.DerivedIrpfRate),
```

## Test (TDD)
New `PurchaseOrderCreatedRuleTests.ChangedDerivedVatRateDeriveTotalVat` — models the shipped
`ChangedOrderDateDeriveVatRate`: a `SpainReduced` regime whose first rate ends yesterday plus a new 11% rate from
today; a purchase order dated yesterday with that regime and a surcharge adjustment of 100; assert `TotalVat != 11`;
move `OrderDate` to tomorrow (so `DerivedVatRate` flips to 11%); derive; assert `TotalVat == 11` (100 × 11%).

- **RED** (pre-fix): `DerivedVatRate` flipped to 11% but `TotalVat` stayed `10`.
- **GREEN** after the fix.

The test exercises the VAT leg; the `DerivedIrpfRate` pattern is the symmetric completion (read identically for IRPF
on the same adjustments). Twin of #09 (`QuotePriceRule`).