### PR TITLE
fix(apps): re-derive Quote VAT/IRPF totals on rate change [BUG-09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ under a dated version heading.
 
 ### Fixed
 
+- `QuotePriceRule` computes the VAT/IRPF on quote-level adjustments (discount/surcharge/fee/shipping/misc) from the
+  quote's `DerivedVatRate`/`DerivedIrpfRate` but watched neither, so a VAT/IRPF regime or rate change left the quote
+  `TotalVat`/`TotalIrpf` stale. It now also watches `Quote.DerivedVatRate` and `DerivedIrpfRate`.
 - `SalesInvoicePriceRule` sums each item's VAT/IRPF (computed from the item's own `VatRate`/`IrpfRate`, set by the
   item-regime rules) into the invoice totals, but watched only the invoice-level `DerivedVatRate` — so a change to an
   item's `VatRate`/`IrpfRate` (e.g. overriding the item's VAT regime) left the invoice `TotalVat`/`TotalIrpf` stale. It

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -277,6 +277,33 @@ namespace Allors.Database.Domain.Tests
             var expected = $"ProductQuote: {quote.QuoteNumber} [{quote.Issuer?.DisplayName}]";
             Assert.Equal(expected, quote.WorkItemDescription);
         }
+
+        [Fact]
+        public void ChangedDerivedVatRateDeriveTotalVat()
+        {
+            var vatRegime = new VatRegimes(this.Transaction).SpainReduced;
+            vatRegime.VatRates.ElementAt(0).ThroughDate = this.Transaction.Now().AddDays(-1).Date;
+            this.Derive();
+
+            var newVatRate = new VatRateBuilder(this.Transaction).WithFromDate(this.Transaction.Now().Date).WithRate(11).Build();
+            vatRegime.AddVatRate(newVatRate);
+            this.Derive();
+
+            var quote = new ProductQuoteBuilder(this.Transaction)
+                .WithIssueDate(this.Transaction.Now().AddDays(-1).Date)
+                .WithAssignedVatRegime(vatRegime)
+                .Build();
+            var surcharge = new SurchargeAdjustmentBuilder(this.Transaction).WithAmount(100).Build();
+            quote.AddOrderAdjustment(surcharge);
+            this.Derive();
+
+            Assert.NotEqual(11M, quote.TotalVat);
+
+            quote.IssueDate = this.Transaction.Now().AddDays(1).Date;
+            this.Derive();
+
+            Assert.Equal(11M, quote.TotalVat);
+        }
     }
 
     public class ProductQuoteAwaitingApprovalRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/QuotePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/QuotePriceRule.cs
@@ -23,6 +23,8 @@ namespace Allors.Database.Domain
                 m.Quote.RolePattern(v => v.QuoteItems),
                 m.Quote.RolePattern(v => v.Receiver),
                 m.Quote.RolePattern(v => v.OrderAdjustments),
+                m.Quote.RolePattern(v => v.DerivedVatRate),
+                m.Quote.RolePattern(v => v.DerivedIrpfRate),
                 m.DiscountAdjustment.RolePattern(v => v.Percentage, v => v.QuoteWhereOrderAdjustment),
                 m.DiscountAdjustment.RolePattern(v => v.Amount, v => v.QuoteWhereOrderAdjustment),
                 m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.QuoteWhereOrderAdjustment),


### PR DESCRIPTION
## Bug
`QuotePriceRule` computes the VAT/IRPF on each quote-level adjustment from `@this.DerivedVatRate.Rate` /
`@this.DerivedIrpfRate.Rate`, gated on `ExistDerivedVatRegime`/`ExistDerivedIrpfRegime`. But its `Patterns` watched
`QuoteState`, `DerivationTrigger`, `ValidQuoteItems`, `QuoteItems`, `Receiver`, `OrderAdjustments` and item totals —
**neither** `DerivedVatRate` nor `DerivedIrpfRate`. So when the quote's VAT/IRPF rate changed (regime or rate period),
the adjustment VAT/IRPF and the quote `TotalVat`/`TotalIrpf` went stale. Twin of #07 (`PurchaseOrderPriceRule`).

## Fix
```csharp
m.Quote.RolePattern(v => v.DerivedVatRate),
m.Quote.RolePattern(v => v.DerivedIrpfRate),
```

## Test (TDD)
New `ProductQuoteRuleTests.ChangedDerivedVatRateDeriveTotalVat` — a `SpainReduced` regime whose first rate ends
yesterday plus a new 11% rate from today; a product quote issued yesterday with that regime and a surcharge adjustment
of 100; assert `TotalVat != 11`; move `IssueDate` to tomorrow (so `DerivedVatRate` flips to 11% — `QuoteCreatedVatRegimeRule`
watches `IssueDate`); derive; assert `TotalVat == 11`.

- **RED** (pre-fix): `DerivedVatRate` flipped to 11% but `TotalVat` stayed `10`.
- **GREEN** after the fix.

The test exercises the VAT leg; the `DerivedIrpfRate` pattern is the symmetric completion. This is the "VAT-rate half"
of the discovered sibling #D3.