### PR TITLE
fix(apps): populate PurchaseOrder *InPreferredCurrency charge totals [BUG-06]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderPriceRule` reset `TotalFeeInPreferredCurrency`, `TotalShippingAndHandlingInPreferredCurrency` and
+  `TotalExtraChargeInPreferredCurrency` to 0 but never re-assigned them in the preferred-currency block, so they stayed
+  permanently 0 even when the order carried fees/shipping/misc charges. They are now converted from the corresponding
+  base-currency totals (mirroring `SalesOrderPriceRule`). (`TotalListPriceInPreferredCurrency` has no source on a
+  purchase order — there is no `TotalListPrice` role — so it correctly remains 0.)
 - `QuotePriceRule` computes the VAT/IRPF on quote-level adjustments (discount/surcharge/fee/shipping/misc) from the
   quote's `DerivedVatRate`/`DerivedIrpfRate` but watched neither, so a VAT/IRPF regime or rate change left the quote
   `TotalVat`/`TotalIrpf` stale. It now also watches `Quote.DerivedVatRate` and `DerivedIrpfRate`.

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -1173,6 +1173,27 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedOrderAdjustmentDeriveTotalFeeInPreferredCurrency()
+        {
+            var order = new PurchaseOrderBuilder(this.Transaction)
+                .WithOrderedBy(this.InternalOrganisation)
+                .WithOrderDate(this.Transaction.Now())
+                .Build();
+            order.AddOrderAdjustment(new FeeBuilder(this.Transaction).WithAmount(10).Build());
+            order.AddOrderAdjustment(new ShippingAndHandlingChargeBuilder(this.Transaction).WithAmount(5).Build());
+            this.Derive();
+
+            Assert.Equal(10M, order.TotalFee);
+            Assert.Equal(5M, order.TotalShippingAndHandling);
+            Assert.Equal(15M, order.TotalExtraCharge);
+
+            // DerivedCurrency == OrderedBy.PreferredCurrency, so conversion is identity.
+            Assert.Equal(order.TotalFee, order.TotalFeeInPreferredCurrency);
+            Assert.Equal(order.TotalShippingAndHandling, order.TotalShippingAndHandlingInPreferredCurrency);
+            Assert.Equal(order.TotalExtraCharge, order.TotalExtraChargeInPreferredCurrency);
+        }
+
+        [Fact]
         public void ChangedSalesOrderItemAssignedUnitPriceCalculatePrice()
         {
             var part = new UnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
@@ -253,6 +253,9 @@ namespace Allors.Database.Domain
                 @this.TotalIncVatInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalIncVat, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
                 @this.TotalIrpfInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalIrpf, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
                 @this.GrandTotalInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.GrandTotal, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
+                @this.TotalFeeInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalFee, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
+                @this.TotalShippingAndHandlingInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalShippingAndHandling, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
+                @this.TotalExtraChargeInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(fee + shipping + miscellaneous, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
             }
 
             @this.TotalBasePrice = Rounder.RoundDecimal(@this.TotalBasePrice, 2);


### PR DESCRIPTION
## Bug
`PurchaseOrderPriceRule`'s reset block zeroes `TotalFeeInPreferredCurrency`, `TotalShippingAndHandlingInPreferredCurrency`,
`TotalExtraChargeInPreferredCurrency` (and `TotalListPriceInPreferredCurrency`). The preferred-currency block then
assigns 8 totals (BasePrice/Discount/Surcharge/ExVat/Vat/IncVat/Irpf/GrandTotal) but **never re-assigns those charge
totals** — so they stayed permanently 0 even when the order carried fees/shipping/misc charges.
`SalesOrderPriceRule:209-247` populates them.

## Fix
Add the conversions inside the existing `if (ExistOrderDate && ExistDerivedCurrency && ExistOrderedBy)` block:

```csharp
@this.TotalFeeInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalFee, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
@this.TotalShippingAndHandlingInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(@this.TotalShippingAndHandling, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
@this.TotalExtraChargeInPreferredCurrency = Rounder.RoundDecimal(Currencies.ConvertCurrency(fee + shipping + miscellaneous, @this.OrderDate, @this.DerivedCurrency, @this.OrderedBy.PreferredCurrency), 2);
```

**Scope:** the worklist listed four totals, but PurchaseOrder has **no `TotalListPrice` role** (only SalesOrder/Quote/
SalesInvoice declare it; this rule never computes one), so `TotalListPriceInPreferredCurrency` has no source to convert
and correctly remains 0. The real defect is the Fee/Shipping/ExtraCharge trio.

## Test (TDD)
New `PurchaseOrderPriceRuleTests.ChangedOrderAdjustmentDeriveTotalFeeInPreferredCurrency` (modeled on the merged #08
fee/shipping test): a Created purchase order `WithOrderedBy(InternalOrganisation)` + `Fee(10)` +
`ShippingAndHandlingCharge(5)`; derive; assert `TotalFee/TotalShippingAndHandling/TotalExtraCharge == 10/5/15`, then
assert each `…InPreferredCurrency` equals its base total (identity, since `DerivedCurrency == OrderedBy.PreferredCurrency`).

- **RED** (pre-fix): `TotalFeeInPreferredCurrency` stayed `0`.
- **GREEN** after the fix.

Pairs with the already-merged #08 (Fee/Shipping reset-block fix).