### PR TITLE
fix(apps): accumulate same-type order adjustments in PurchaseInvoice rollup [BUG-19]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoicePriceRule` rolled each order-adjustment type's amount into the `TotalExVat`/`TotalVat`/`TotalIncVat`/
+  `TotalIrpf`/`GrandTotal` rollup via a per-type local assigned with `=` (last-wins), so with two or more same-type
+  adjustments (e.g. two surcharges) only the last flowed into those totals. The per-type locals now accumulate, so all
+  same-type adjustments are included. (The persistent `Total*` fields were already correct.)
 - `PurchaseOrderPriceRule` reset `TotalFeeInPreferredCurrency`, `TotalShippingAndHandlingInPreferredCurrency` and
   `TotalExtraChargeInPreferredCurrency` to 0 but never re-assigned them in the preferred-currency block, so they stayed
   permanently 0 even when the order carried fees/shipping/misc charges. They are now converted from the corresponding

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -1253,6 +1253,21 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(vatRegime, invoiceItem.DerivedVatRegime);
             Assert.Equal(irpfRegime, invoiceItem.DerivedIrpfRegime);
         }
+
+        [Fact]
+        public void ChangedOrderAdjustmentMultipleSameTypeDeriveGrandTotal()
+        {
+            var invoice = new PurchaseInvoiceBuilder(this.Transaction)
+                .WithBilledFrom(this.InternalOrganisation.ActiveSuppliers.First())
+                .WithInvoiceDate(this.Transaction.Now())
+                .Build();
+            invoice.AddOrderAdjustment(new SurchargeAdjustmentBuilder(this.Transaction).WithAmount(100).Build());
+            invoice.AddOrderAdjustment(new SurchargeAdjustmentBuilder(this.Transaction).WithAmount(100).Build());
+            this.Derive();
+
+            Assert.Equal(200, invoice.TotalSurcharge);
+            Assert.Equal(200, invoice.GrandTotal);
+        }
     }
 
     [Trait("Category", "Security")]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
@@ -145,96 +145,101 @@ namespace Allors.Database.Domain
                 {
                     if (orderAdjustment.GetType().Name.Equals(typeof(DiscountAdjustment).Name))
                     {
-                        discount = orderAdjustment.Percentage.HasValue ?
+                        var thisDiscount = orderAdjustment.Percentage.HasValue ?
                                         @this.TotalExVat * orderAdjustment.Percentage.Value / 100 :
                                         orderAdjustment.Amount ?? 0;
 
-                        @this.TotalDiscount += discount;
+                        discount += thisDiscount;
+                        @this.TotalDiscount += thisDiscount;
 
                         if (@this.ExistDerivedVatRegime)
                         {
-                            discountVat = discount * @this.DerivedVatRate.Rate / 100;
+                            discountVat += thisDiscount * @this.DerivedVatRate.Rate / 100;
                         }
 
                         if (@this.ExistDerivedIrpfRegime)
                         {
-                            discountIrpf = discount * @this.DerivedIrpfRate.Rate / 100;
+                            discountIrpf += thisDiscount * @this.DerivedIrpfRate.Rate / 100;
                         }
                     }
 
                     if (orderAdjustment.GetType().Name.Equals(typeof(SurchargeAdjustment).Name))
                     {
-                        surcharge = orderAdjustment.Percentage.HasValue ?
+                        var thisSurcharge = orderAdjustment.Percentage.HasValue ?
                                             @this.TotalExVat * orderAdjustment.Percentage.Value / 100 :
                                             orderAdjustment.Amount ?? 0;
 
-                        @this.TotalSurcharge += surcharge;
+                        surcharge += thisSurcharge;
+                        @this.TotalSurcharge += thisSurcharge;
 
                         if (@this.ExistDerivedVatRegime)
                         {
-                            surchargeVat = surcharge * @this.DerivedVatRate.Rate / 100;
+                            surchargeVat += thisSurcharge * @this.DerivedVatRate.Rate / 100;
                         }
 
                         if (@this.ExistDerivedIrpfRegime)
                         {
-                            surchargeIrpf = surcharge * @this.DerivedIrpfRate.Rate / 100;
+                            surchargeIrpf += thisSurcharge * @this.DerivedIrpfRate.Rate / 100;
                         }
                     }
 
                     if (orderAdjustment.GetType().Name.Equals(typeof(Fee).Name))
                     {
-                        fee = orderAdjustment.Percentage.HasValue ?
+                        var thisFee = orderAdjustment.Percentage.HasValue ?
                                     @this.TotalExVat * orderAdjustment.Percentage.Value / 100 :
                                     orderAdjustment.Amount ?? 0;
 
-                        @this.TotalFee += fee;
+                        fee += thisFee;
+                        @this.TotalFee += thisFee;
 
                         if (@this.ExistDerivedVatRegime)
                         {
-                            feeVat = fee * @this.DerivedVatRate.Rate / 100;
+                            feeVat += thisFee * @this.DerivedVatRate.Rate / 100;
                         }
 
                         if (@this.ExistDerivedIrpfRegime)
                         {
-                            feeIrpf = fee * @this.DerivedIrpfRate.Rate / 100;
+                            feeIrpf += thisFee * @this.DerivedIrpfRate.Rate / 100;
                         }
                     }
 
                     if (orderAdjustment.GetType().Name.Equals(typeof(ShippingAndHandlingCharge).Name))
                     {
-                        shipping = orderAdjustment.Percentage.HasValue ?
+                        var thisShipping = orderAdjustment.Percentage.HasValue ?
                                         @this.TotalExVat * orderAdjustment.Percentage.Value / 100 :
                                         orderAdjustment.Amount ?? 0;
 
-                        @this.TotalShippingAndHandling += shipping;
+                        shipping += thisShipping;
+                        @this.TotalShippingAndHandling += thisShipping;
 
                         if (@this.ExistDerivedVatRegime)
                         {
-                            shippingVat = shipping * @this.DerivedVatRate.Rate / 100;
+                            shippingVat += thisShipping * @this.DerivedVatRate.Rate / 100;
                         }
 
                         if (@this.ExistDerivedIrpfRegime)
                         {
-                            shippingIrpf = shipping * @this.DerivedIrpfRate.Rate / 100;
+                            shippingIrpf += thisShipping * @this.DerivedIrpfRate.Rate / 100;
                         }
                     }
 
                     if (orderAdjustment.GetType().Name.Equals(typeof(MiscellaneousCharge).Name))
                     {
-                        miscellaneous = orderAdjustment.Percentage.HasValue ?
+                        var thisMiscellaneous = orderAdjustment.Percentage.HasValue ?
                                         @this.TotalExVat * orderAdjustment.Percentage.Value / 100 :
                                         orderAdjustment.Amount ?? 0;
 
-                        @this.TotalExtraCharge += miscellaneous;
+                        miscellaneous += thisMiscellaneous;
+                        @this.TotalExtraCharge += thisMiscellaneous;
 
                         if (@this.ExistDerivedVatRegime)
                         {
-                            miscellaneousVat = miscellaneous * @this.DerivedVatRate.Rate / 100;
+                            miscellaneousVat += thisMiscellaneous * @this.DerivedVatRate.Rate / 100;
                         }
 
                         if (@this.ExistDerivedIrpfRegime)
                         {
-                            miscellaneousIrpf = miscellaneous * @this.DerivedIrpfRate.Rate / 100;
+                            miscellaneousIrpf += thisMiscellaneous * @this.DerivedIrpfRate.Rate / 100;
                         }
                     }
                 }


### PR DESCRIPTION
## Bug
In `PurchaseInvoicePriceRule`'s order-adjustment loop, the per-type locals `discount`/`surcharge`/`fee`/`shipping`/
`miscellaneous` (and their `*Vat`/`*Irpf` locals) are assigned with `=`, so each iteration overwrites the previous.
With **two or more same-type adjustments** (e.g. two surcharges) only the **last** survives in those locals — and the
end-of-method rollup (`totalExVat`/`totalVat`/`totalIncVat`/`totalIrpf`/`grandTotal`) reads them, so those totals
undercounted. (The persistent `@this.Total*` fields use `+=` and were already correct.)

## Fix
For each adjustment type, compute the per-adjustment amount into a `this<Type>` temp, then **accumulate** it into the
rollup local, the persistent total (behaviour unchanged), and the `*Vat`/`*Irpf` locals. The rollup expressions are
left untouched. E.g.:

```csharp
var thisSurcharge = orderAdjustment.Percentage.HasValue ? @this.TotalExVat * orderAdjustment.Percentage.Value / 100 : orderAdjustment.Amount ?? 0;
surcharge += thisSurcharge;
@this.TotalSurcharge += thisSurcharge;
if (@this.ExistDerivedVatRegime)  surchargeVat += thisSurcharge * @this.DerivedVatRate.Rate / 100;
if (@this.ExistDerivedIrpfRegime) surchargeIrpf += thisSurcharge * @this.DerivedIrpfRate.Rate / 100;
```

## Test (TDD)
New `PurchaseInvoicePriceRuleTests.ChangedOrderAdjustmentMultipleSameTypeDeriveGrandTotal`: a Created purchase invoice
with **two** `SurchargeAdjustment(100)`; assert `TotalSurcharge == 200` (persistent, already correct) and
`GrandTotal == 200` (the rollup).

- **RED** (pre-fix): `TotalSurcharge == 200` but `GrandTotal == 100` (only the last surcharge in the rollup).
- **GREEN** after the fix.

Twin of #24 (`SalesInvoicePriceRule`). The same `=`-rollup shape exists latently in `SalesOrderPriceRule` (unflagged)
and is covered for PurchaseOrder/Quote by #D2/#D3.