### PR TITLE
fix(apps): include item discounts in PurchaseInvoice TotalDiscount [BUG-21]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoicePriceRule`'s item-rollup loop summed every item total into the invoice except `item.TotalDiscount`,
+  so the invoice `TotalDiscount` omitted per-line item discounts (it reflected only order-level discounts). It now adds
+  `item.TotalDiscount`, matching `SalesInvoicePriceRule`. (Item discounts were already reflected in `TotalExVat`/
+  `GrandTotal` via `item.TotalExVat`; only the `TotalDiscount` summary was under-reported.)
 - `SalesInvoicePriceRule` had the same adjustment-rollup bug as `PurchaseInvoicePriceRule`: each order-adjustment
   type's amount fed the `TotalExVat`/`TotalVat`/`TotalIncVat`/`TotalIrpf`/`GrandTotal` rollup via a per-type local
   assigned with `=` (last-wins), so with two or more same-type adjustments only the last was counted. The per-type

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -1268,6 +1268,22 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(200, invoice.TotalSurcharge);
             Assert.Equal(200, invoice.GrandTotal);
         }
+
+        [Fact]
+        public void ChangedInvoiceItemDiscountDeriveTotalDiscount()
+        {
+            var invoice = new PurchaseInvoiceBuilder(this.Transaction)
+                .WithBilledFrom(this.InternalOrganisation.ActiveSuppliers.First())
+                .WithInvoiceDate(this.Transaction.Now())
+                .Build();
+            var invoiceItem = new PurchaseInvoiceItemBuilder(this.Transaction).WithAssignedUnitPrice(100).WithQuantity(1).Build();
+            invoice.AddPurchaseInvoiceItem(invoiceItem);
+            invoiceItem.AddDiscountAdjustment(new DiscountAdjustmentBuilder(this.Transaction).WithAmount(10).Build());
+            this.Derive();
+
+            Assert.Equal(10, invoiceItem.TotalDiscount);
+            Assert.Equal(10, invoice.TotalDiscount);
+        }
     }
 
     [Trait("Category", "Security")]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
@@ -117,6 +117,7 @@ namespace Allors.Database.Domain
                 foreach (PurchaseInvoiceItem item in @this.ValidInvoiceItems)
                 {
                     @this.TotalBasePrice += item.TotalBasePrice;
+                    @this.TotalDiscount += item.TotalDiscount;
                     @this.TotalSurcharge += item.TotalSurcharge;
                     @this.TotalIrpf += item.TotalIrpf;
                     @this.TotalVat += item.TotalVat;


### PR DESCRIPTION
## Bug
`PurchaseInvoicePriceRule`'s item-rollup loop accumulates `item.TotalBasePrice`/`TotalSurcharge`/`TotalIrpf`/`TotalVat`/
`TotalExVat`/`TotalIncVat`/`GrandTotal` into the invoice totals — but never `@this.TotalDiscount += item.TotalDiscount`.
So the invoice `TotalDiscount` reflected only **order-level** discounts (added later in the adjustment loop), omitting
per-line item discounts. The sales sibling `SalesInvoicePriceRule` includes this line; the purchase rule omitted it.

(The financial totals `TotalExVat`/`TotalIncVat`/`GrandTotal` were unaffected — the item discount is already baked into
`item.TotalExVat` — so this was a `TotalDiscount` summary under-report, not a money error.)

## Fix
```csharp
@this.TotalDiscount += item.TotalDiscount;
```

## Test (TDD)
New `PurchaseInvoicePriceRuleTests.ChangedInvoiceItemDiscountDeriveTotalDiscount`: a Created purchase invoice + an item
(`AssignedUnitPrice=100`, `Quantity=1`) with a `DiscountAdjustment(Amount=10)`; assert `item.TotalDiscount == 10` and
`invoice.TotalDiscount == 10`.

- **RED** (pre-fix): `item.TotalDiscount == 10` but `invoice.TotalDiscount == 0`.
- **GREEN** after the fix.