### PR TITLE
fix(apps): watch base OrderAdjustment edits in PurchaseInvoice price [BUG-22]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseInvoicePriceRule` watched only `DiscountAdjustment`/`SurchargeAdjustment` for invoice-level adjustment
+  `Amount`/`Percentage` edits, so editing an existing Fee/Shipping/Misc charge's amount left the invoice totals stale.
+  It now also watches `OrderAdjustment.Amount`/`Percentage` (the base type, rerouted via `InvoiceWhereOrderAdjustment`),
+  covering all adjustment subtypes.
 - `PurchaseInvoicePriceRule`'s item-rollup loop summed every item total into the invoice except `item.TotalDiscount`,
   so the invoice `TotalDiscount` omitted per-line item discounts (it reflected only order-level discounts). It now adds
   `item.TotalDiscount`, matching `SalesInvoicePriceRule`. (Item discounts were already reflected in `TotalExVat`/

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PurchaseInvoiceTests.cs
@@ -1284,6 +1284,25 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(10, invoiceItem.TotalDiscount);
             Assert.Equal(10, invoice.TotalDiscount);
         }
+
+        [Fact]
+        public void ChangedFeeAmountDeriveTotalFee()
+        {
+            var invoice = new PurchaseInvoiceBuilder(this.Transaction)
+                .WithBilledFrom(this.InternalOrganisation.ActiveSuppliers.First())
+                .WithInvoiceDate(this.Transaction.Now())
+                .Build();
+            var fee = new FeeBuilder(this.Transaction).WithAmount(10).Build();
+            invoice.AddOrderAdjustment(fee);
+            this.Derive();
+
+            Assert.Equal(10, invoice.TotalFee);
+
+            fee.Amount = 20;
+            this.Derive();
+
+            Assert.Equal(20, invoice.TotalFee);
+        }
     }
 
     [Trait("Category", "Security")]

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PurchaseInvoicePriceRule.cs
@@ -41,6 +41,8 @@ namespace Allors.Database.Domain
                 m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.PriceableWhereSurchargeAdjustment.ObjectType.AsPurchaseInvoiceItem.PurchaseInvoiceWherePurchaseInvoiceItem, m.PurchaseInvoice),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
+                m.OrderAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
+                m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`PurchaseInvoicePriceRule`'s adjustment loop reads `orderAdjustment.Amount`/`Percentage` for every adjustment type, but
its `Patterns` watched `Amount`/`Percentage` only on the `DiscountAdjustment`/`SurchargeAdjustment` subtypes.
`Amount`/`Percentage` are declared on the **base** `OrderAdjustment`, so editing an existing invoice-level
**Fee/Shipping/Misc** charge's amount/percentage did not re-fire the rule — the invoice totals went stale.

## Fix
Add one supertype pattern pair (covers Fee/Shipping/Misc + redundantly Discount/Surcharge):

```csharp
m.OrderAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.PurchaseInvoice),
```

## Test (TDD)
New `PurchaseInvoicePriceRuleTests.ChangedFeeAmountDeriveTotalFee`: a Created purchase invoice + a `Fee(Amount=10)`;
assert `TotalFee == 10`; set `fee.Amount = 20`; derive; assert `TotalFee == 20`.

- **RED** (pre-fix): `TotalFee` stayed `10`.
- **GREEN** after the fix.

Cluster with #D2 (PurchaseOrder) / #D3 (Quote). SalesInvoice has the same gap — candidate Dn.