### PR TITLE
fix(apps): watch base OrderAdjustment edits in PurchaseOrder price [BUG-D2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PurchaseOrderPriceRule` watched only `DiscountAdjustment`/`SurchargeAdjustment` for order-level adjustment
+  `Amount`/`Percentage` edits, so editing an existing Fee/Shipping/Misc charge's amount left the order totals stale. It
+  now also watches `OrderAdjustment.Amount`/`Percentage` (the base type, rerouted via `OrderWhereOrderAdjustment`),
+  covering all adjustment subtypes.
 - `PurchaseInvoicePriceRule`'s item-rollup loop summed every item total into the invoice except `item.TotalDiscount`,
   so the invoice `TotalDiscount` omitted per-line item discounts (it reflected only order-level discounts). It now adds
   `item.TotalDiscount`, matching `SalesInvoicePriceRule`. (Item discounts were already reflected in `TotalExVat`/

--- a/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/PurchaseOrderTests.cs
@@ -1194,6 +1194,25 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedFeeAmountDeriveTotalFee()
+        {
+            var order = new PurchaseOrderBuilder(this.Transaction)
+                .WithOrderedBy(this.InternalOrganisation)
+                .WithOrderDate(this.Transaction.Now())
+                .Build();
+            var fee = new FeeBuilder(this.Transaction).WithAmount(10).Build();
+            order.AddOrderAdjustment(fee);
+            this.Derive();
+
+            Assert.Equal(10, order.TotalFee);
+
+            fee.Amount = 20;
+            this.Derive();
+
+            Assert.Equal(20, order.TotalFee);
+        }
+
+        [Fact]
         public void ChangedSalesOrderItemAssignedUnitPriceCalculatePrice()
         {
             var part = new UnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/PurchaseOrderPriceRule.cs
@@ -36,6 +36,8 @@ namespace Allors.Database.Domain
                 m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.PriceableWhereSurchargeAdjustment.ObjectType.AsPurchaseOrderItem.PurchaseOrderWherePurchaseOrderItem, m.PurchaseOrder),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
+                m.OrderAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
+                m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug (D2a)
`PurchaseOrderPriceRule`'s adjustment loop reads `orderAdjustment.Amount`/`Percentage` for every adjustment type, but
its `Patterns` watched them only on the `DiscountAdjustment`/`SurchargeAdjustment` subtypes. `Amount`/`Percentage` are
declared on the **base** `OrderAdjustment`, so editing an existing order-level **Fee/Shipping/Misc** charge's amount
did not re-fire the rule — the order totals went stale.

## Fix
One supertype pattern pair (covers Fee/Shipping/Misc + redundantly Discount/Surcharge):

```csharp
m.OrderAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.PurchaseOrder),
```

## Test (TDD)
New `PurchaseOrderPriceRuleTests.ChangedFeeAmountDeriveTotalFee`: a purchase order `WithOrderedBy(InternalOrganisation)`
+ a `Fee(Amount=10)`; assert `TotalFee == 10`; set `fee.Amount = 20`; derive; assert `TotalFee == 20`.

- **RED** (pre-fix): `TotalFee` stayed `10`.
- **GREEN** after the fix.

## D2(b) VERIFY — resolved
The `=`-not-`+=` same-type-adjustment rollup is **confirmed real** (proven by #19/#24, where two surcharges
undercounted `GrandTotal`). The identical shape exists in `PurchaseOrderPriceRule`, `QuotePriceRule` and
`SalesOrderPriceRule`. To fix it consistently it's **deferred to one consolidated follow-up `Dn`** across the
order/quote price rules, keeping this PR single-concern (the edit-pattern fix).

Cluster with #22 (PurchaseInvoice) / #D3 (Quote).