### PR TITLE
fix(apps): watch base OrderAdjustment edits in Quote price [BUG-D3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `QuotePriceRule` watched only `DiscountAdjustment`/`SurchargeAdjustment` for quote-level adjustment `Amount`/
+  `Percentage` edits, so editing an existing Fee/Shipping/Misc charge's amount left the quote totals stale. It now also
+  watches `OrderAdjustment.Amount`/`Percentage` (the base type, rerouted via `QuoteWhereOrderAdjustment`), covering all
+  adjustment subtypes.
 - `PurchaseInvoicePriceRule`'s item-rollup loop summed every item total into the invoice except `item.TotalDiscount`,
   so the invoice `TotalDiscount` omitted per-line item discounts (it reflected only order-level discounts). It now adds
   `item.TotalDiscount`, matching `SalesInvoicePriceRule`. (Item discounts were already reflected in `TotalExVat`/

--- a/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/ProductQuoteTests.cs
@@ -304,6 +304,22 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(11M, quote.TotalVat);
         }
+
+        [Fact]
+        public void ChangedFeeAmountDeriveTotalFee()
+        {
+            var quote = new ProductQuoteBuilder(this.Transaction).WithIssueDate(this.Transaction.Now()).Build();
+            var fee = new FeeBuilder(this.Transaction).WithAmount(10).Build();
+            quote.AddOrderAdjustment(fee);
+            this.Derive();
+
+            Assert.Equal(10, quote.TotalFee);
+
+            fee.Amount = 20;
+            this.Derive();
+
+            Assert.Equal(20, quote.TotalFee);
+        }
     }
 
     public class ProductQuoteAwaitingApprovalRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/QuotePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/QuotePriceRule.cs
@@ -29,6 +29,8 @@ namespace Allors.Database.Domain
                 m.DiscountAdjustment.RolePattern(v => v.Amount, v => v.QuoteWhereOrderAdjustment),
                 m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.QuoteWhereOrderAdjustment),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.QuoteWhereOrderAdjustment),
+                m.OrderAdjustment.RolePattern(v => v.Amount, v => v.QuoteWhereOrderAdjustment),
+                m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.QuoteWhereOrderAdjustment),
                 m.QuoteItem.RolePattern(v => v.TotalBasePrice, v => v.QuoteWhereQuoteItem),
                 m.QuoteItem.RolePattern(v => v.TotalDiscount, v => v.QuoteWhereQuoteItem),
                 m.QuoteItem.RolePattern(v => v.TotalSurcharge, v => v.QuoteWhereQuoteItem),


### PR DESCRIPTION
## Bug
`QuotePriceRule`'s adjustment loop reads `orderAdjustment.Amount`/`Percentage` for every adjustment type, but its
`Patterns` watched them only on the `DiscountAdjustment`/`SurchargeAdjustment` subtypes. `Amount`/`Percentage` are
declared on the **base** `OrderAdjustment`, so editing an existing quote-level **Fee/Shipping/Misc** charge's amount
did not re-fire the rule — the quote totals went stale.

## Fix
One supertype pattern pair (covers Fee/Shipping/Misc + redundantly Discount/Surcharge):

```csharp
m.OrderAdjustment.RolePattern(v => v.Amount, v => v.QuoteWhereOrderAdjustment),
m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.QuoteWhereOrderAdjustment),
```

## Test (TDD)
New `ProductQuoteRuleTests.ChangedFeeAmountDeriveTotalFee`: a product quote + a `Fee(Amount=10)`; assert
`TotalFee == 10`; set `fee.Amount = 20`; derive; assert `TotalFee == 20`.

- **RED** (pre-fix): `TotalFee` stayed `10`.
- **GREEN** after the fix.

Cluster with #22 (PurchaseInvoice) / #D2 (PurchaseOrder). (The `:104` VAT-rate half was #09; the `=`→`+=` rollup that
also exists here is part of the consolidated order/quote rollup follow-up noted in #D2.)