### PR TITLE
fix(apps): re-derive SalesOrder DerivedShipToAddress via ship-to customer [BUG-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesOrderProvisionalShipToAddressRule` derives a provisional order's `DerivedShipToAddress` from the **ship-to**
+  customer's `ShippingAddress`/`GeneralCorrespondence`, but watched `ShippingAddress` via the wrong reverse path
+  (`SalesOrdersWhereBillToCustomer`, a copy-paste) and didn't watch `GeneralCorrespondence` at all. When the ship-to
+  customer differed from the bill-to customer, changing its shipping address (or general correspondence) left
+  `DerivedShipToAddress` stale. It now watches both via `SalesOrdersWhereShipToCustomer`.
 - `QuotePriceRule` watched only `DiscountAdjustment`/`SurchargeAdjustment` for quote-level adjustment `Amount`/
   `Percentage` edits, so editing an existing Fee/Shipping/Misc charge's amount left the quote totals stale. It now also
   watches `OrderAdjustment.Amount`/`Percentage` (the base type, rerouted via `QuoteWhereOrderAdjustment`), covering all

--- a/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
@@ -2531,6 +2531,56 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedShipToCustomerShippingAddressDeriveDerivedShipToAddressWhenShipToDiffersFromBillTo()
+        {
+            var billToCustomer = this.InternalOrganisation.ActiveCustomers.FirstOrDefault();
+
+            var shipToCustomer = new PersonBuilder(this.Transaction).WithLastName("shipto").Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(shipToCustomer).WithInternalOrganisation(this.InternalOrganisation).Build();
+            shipToCustomer.RemoveShippingAddress();
+            shipToCustomer.RemoveGeneralCorrespondence();
+
+            var order = new SalesOrderBuilder(this.Transaction)
+                .WithTakenBy(this.InternalOrganisation)
+                .WithBillToCustomer(billToCustomer)
+                .WithShipToCustomer(shipToCustomer)
+                .Build();
+            this.Derive();
+
+            Assert.False(order.ExistDerivedShipToAddress);
+
+            shipToCustomer.ShippingAddress = new PostalAddressBuilder(this.Transaction).WithAddress1("Haverwerf 15").Build();
+            this.Derive();
+
+            Assert.Equal(shipToCustomer.ShippingAddress, order.DerivedShipToAddress);
+        }
+
+        [Fact]
+        public void ChangedShipToCustomerGeneralCorrespondenceDeriveDerivedShipToAddress()
+        {
+            var shipToCustomer = new PersonBuilder(this.Transaction).WithLastName("shipto").Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithFromDate(this.Transaction.Now()).WithCustomer(shipToCustomer).WithInternalOrganisation(this.InternalOrganisation).Build();
+
+            var order = new SalesOrderBuilder(this.Transaction)
+                .WithTakenBy(this.InternalOrganisation)
+                .WithShipToCustomer(shipToCustomer)
+                .Build();
+            this.Derive();
+
+            var addr1 = new PostalAddressBuilder(this.Transaction).WithAddress1("addr1").Build();
+            shipToCustomer.GeneralCorrespondence = addr1;
+            this.Derive();
+
+            Assert.Equal(addr1, order.DerivedShipToAddress);
+
+            var addr2 = new PostalAddressBuilder(this.Transaction).WithAddress1("addr2").Build();
+            shipToCustomer.GeneralCorrespondence = addr2;
+            this.Derive();
+
+            Assert.Equal(addr2, order.DerivedShipToAddress);
+        }
+
+        [Fact]
         public void ChangedBillToCustomerDeriveDerivedLocaleFromBillToCustomerLocale()
         {
             var swedishLocale = new LocaleBuilder(this.Transaction)

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderProvisionalShipToAddressRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderProvisionalShipToAddressRule.cs
@@ -20,7 +20,8 @@ namespace Allors.Database.Domain
                 m.SalesOrder.RolePattern(v => v.SalesOrderState),
                 m.SalesOrder.RolePattern(v => v.AssignedShipToAddress),
                 m.SalesOrder.RolePattern(v => v.ShipToCustomer),
-                m.Party.RolePattern(v => v.ShippingAddress, v => v.SalesOrdersWhereBillToCustomer),
+                m.Party.RolePattern(v => v.ShippingAddress, v => v.SalesOrdersWhereShipToCustomer),
+                m.Party.RolePattern(v => v.GeneralCorrespondence, v => v.SalesOrdersWhereShipToCustomer),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`SalesOrderProvisionalShipToAddressRule` derives a provisional order's `DerivedShipToAddress` from the **ship-to**
customer's `ShippingAddress`/`GeneralCorrespondence`:

```csharp
@this.DerivedShipToAddress = @this.AssignedShipToAddress ?? @this.ShipToCustomer?.ShippingAddress ?? @this.ShipToCustomer?.GeneralCorrespondence as PostalAddress;
```

But the `ShippingAddress` pattern rerouted via **`SalesOrdersWhereBillToCustomer`** — the wrong party (copy-paste; the
sibling `SalesOrderProvisionalShipmentMethodRule:24` correctly uses `SalesOrdersWhereShipToCustomer`) — and
`GeneralCorrespondence` was **not watched at all**.

The bug hid because `BillToCustomer` defaults to `ShipToCustomer`: when they're the same party the wrong reroute
coincidentally fires (the shipped same-party test passed). It only manifests when the **ship-to customer differs from
the bill-to customer**.

## Fix
```csharp
m.Party.RolePattern(v => v.ShippingAddress, v => v.SalesOrdersWhereShipToCustomer),        // was SalesOrdersWhereBillToCustomer
m.Party.RolePattern(v => v.GeneralCorrespondence, v => v.SalesOrdersWhereShipToCustomer),  // new
```

## Tests (TDD)
Two new `SalesOrderProvisionalRuleTests`:
- `ChangedShipToCustomerShippingAddressDeriveDerivedShipToAddressWhenShipToDiffersFromBillTo` — explicit, distinct
  bill-to/ship-to; set the ship-to customer's `ShippingAddress`; assert `DerivedShipToAddress` becomes it. **RED**: stayed null.
- `ChangedShipToCustomerGeneralCorrespondenceDeriveDerivedShipToAddress` — set/change the ship-to customer's
  `GeneralCorrespondence`; assert `DerivedShipToAddress` tracks it. **RED**: stayed null.

Both **GREEN** after the fix. The shipped same-party test still passes (the corrected ship-to reroute fires for it too).