### PR TITLE
fix(apps): re-derive SalesOrder DerivedCurrency on bill-to customer Locale change [BUG-45]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesOrderProvisionalCurrencyRule` falls back to the bill-to customer's `Locale.Country.Currency` when no assigned
+  or preferred currency exists, but watched only the customer's `PreferredCurrency` — so changing the customer's
+  `Locale` alone left `DerivedCurrency` stale. It now also watches `Party.Locale` (rerouted via
+  `SalesOrdersWhereBillToCustomer`), matching the sales-invoice currency rule.
 - `SalesOrderProvisionalShipToAddressRule` derives a provisional order's `DerivedShipToAddress` from the **ship-to**
   customer's `ShippingAddress`/`GeneralCorrespondence`, but watched `ShippingAddress` via the wrong reverse path
   (`SalesOrdersWhereBillToCustomer`, a copy-paste) and didn't watch `GeneralCorrespondence` at all. When the ship-to

--- a/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
@@ -2710,6 +2710,32 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedBillToCustomerLocaleOnlyDeriveDerivedCurrency()
+        {
+            var se = new Countries(this.Transaction).FindBy(this.M.Country.IsoCode, "SE");
+            var newLocale = new LocaleBuilder(this.Transaction)
+                .WithCountry(se)
+                .WithLanguage(new Languages(this.Transaction).FindBy(this.M.Language.IsoCode, "sv"))
+                .Build();
+
+            var customer = this.InternalOrganisation.ActiveCustomers.FirstOrDefault();
+            customer.RemoveLocale();
+            customer.RemovePreferredCurrency();
+
+            var order = new SalesOrderBuilder(this.Transaction).WithBillToCustomer(customer).Build();
+            this.Derive();
+
+            // no assigned/preferred currency, no locale -> falls back to TakenBy's currency.
+            Assert.NotEqual(se.Currency, order.DerivedCurrency);
+
+            // only the bill-to customer's Locale changes.
+            customer.Locale = newLocale;
+            this.Derive();
+
+            Assert.Equal(se.Currency, order.DerivedCurrency);
+        }
+
+        [Fact]
         public void ChangedBillToCustomerPreferredCurrencyDeriveDerivedCurrency()
         {
             var customer = this.InternalOrganisation.ActiveCustomers.FirstOrDefault();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderProvisionalCurrencyRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderProvisionalCurrencyRule.cs
@@ -24,6 +24,7 @@ namespace Allors.Database.Domain
                 m.SalesOrder.RolePattern(v => v.TakenBy),
                 m.SalesOrder.RolePattern(v => v.OrderDate),
                 m.Party.RolePattern(v => v.PreferredCurrency, v => v.SalesOrdersWhereBillToCustomer),
+                m.Party.RolePattern(v => v.Locale, v => v.SalesOrdersWhereBillToCustomer),
                 m.Organisation.RolePattern(v => v.PreferredCurrency, v => v.SalesOrdersWhereTakenBy),
             };
 


### PR DESCRIPTION
## Bug
`SalesOrderProvisionalCurrencyRule` derives:

```csharp
DerivedCurrency = AssignedCurrency ?? BillToCustomer?.PreferredCurrency ?? BillToCustomer?.Locale?.Country?.Currency ?? TakenBy?.PreferredCurrency;
```

Its `Patterns` watched `AssignedCurrency`, the `BillToCustomer`/`TakenBy` links and both parties' `PreferredCurrency` —
but **not `BillToCustomer.Locale`** (the 3rd fallback). So changing the bill-to customer's `Locale` alone left
`DerivedCurrency` stale. Directly analogous to #05 (the `SalesInvoiceReadyForPostingDerivedCurrencyRule`, which already
watches `Party.Locale`).

## Fix
```csharp
m.Party.RolePattern(v => v.Locale, v => v.SalesOrdersWhereBillToCustomer),
```

## Test (TDD)
New `SalesOrderProvisionalRuleTests.ChangedBillToCustomerLocaleOnlyDeriveDerivedCurrency`: settle a Provisional order
with a bill-to customer that has no assigned/preferred currency and no locale (`DerivedCurrency` = TakenBy's currency);
then change **only** `customer.Locale` to an SE locale; derive; assert `DerivedCurrency == se.Currency`.

- **RED** (pre-fix): `DerivedCurrency` stayed at the TakenBy fallback.
- **GREEN** after the fix.

The two shipped Locale tests (`ChangedBillToCustomerLocaleDeriveDerivedCurrency`,
`ChangedBillToCustomerDeriveCurrencyFromBillToCustomerLocale`) missed this because each also changes a watched role
(PreferredCurrency removal / BillToCustomer assignment) in the same derive, masking the Locale-watch gap.

Sibling of #05 (SalesInvoice currency rule).