### PR TITLE
fix(apps): re-validate Payment over-application on AmountApplied edit [BUG-18]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ under a dated version heading.
 
 ### Fixed
 
+- `PaymentRule` rejects a payment whose applications sum to more than its `Amount`, but watched only the
+  `PaymentApplications` set and `Amount` — so editing an existing application's `AmountApplied` to push the aggregate
+  over the payment amount was not re-validated. It now also watches `PaymentApplication.AmountApplied` (rerouted via
+  `PaymentWherePaymentApplication`).
 - `SalesOrderProvisionalCurrencyRule` falls back to the bill-to customer's `Locale.Country.Currency` when no assigned
   or preferred currency exists, but watched only the customer's `PreferredCurrency` — so changing the customer's
   `Locale` alone left `DerivedCurrency` stale. It now also watches `Party.Locale` (rerouted via

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/PaymentApplicationTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/PaymentApplicationTests.cs
@@ -55,6 +55,44 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedPaymentApplicationAmountAppliedDerivePaymentAmountIsToSmall()
+        {
+            var contactMechanism = new ContactMechanisms(this.Transaction).Extent().FirstOrDefault();
+            var good = new Goods(this.Transaction).FindBy(this.M.Good.Name, "good1");
+
+            var customer = new PersonBuilder(this.Transaction).WithLastName("customer").Build();
+            new CustomerRelationshipBuilder(this.Transaction).WithCustomer(customer).Build();
+
+            var invoice = new SalesInvoiceBuilder(this.Transaction)
+                .WithBillToCustomer(customer)
+                .WithAssignedBillToContactMechanism(contactMechanism)
+                .WithSalesInvoiceItem(new SalesInvoiceItemBuilder(this.Transaction).WithProduct(good).WithQuantity(1).WithAssignedUnitPrice(1000M).WithInvoiceItemType(new InvoiceItemTypes(this.Transaction).ProductItem).Build())
+                .Build();
+
+            this.Transaction.Derive();
+
+            var receipt = new ReceiptBuilder(this.Transaction)
+                .WithAmount(100)
+                .WithEffectiveDate(this.Transaction.Now())
+                .Build();
+
+            var paymentApplication = new PaymentApplicationBuilder(this.Transaction)
+                .WithAmountApplied(50)
+                .WithInvoiceItem(invoice.InvoiceItems.ElementAt(0))
+                .Build();
+
+            receipt.AddPaymentApplication(paymentApplication);
+
+            var initialErrors = this.Derive().Errors.ToList();
+            Assert.Empty(initialErrors.FindAll(e => e.Message.Contains(ErrorMessages.PaymentAmountIsToSmall)));
+
+            paymentApplication.AmountApplied = 150;
+
+            var errors = this.Derive().Errors.ToList();
+            Assert.Single(errors.FindAll(e => e.Message.Contains(ErrorMessages.PaymentAmountIsToSmall)));
+        }
+
+        [Fact]
         public void DeriveOnCreateAtMostOneInvalidPaymentApplication()
         {
             var salesInvoice = new SalesInvoiceBuilder(this.Transaction).WithSalesExternalB2BInvoiceDefaults(this.InternalOrganisation).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PaymentRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/PaymentRule.cs
@@ -16,10 +16,11 @@ namespace Allors.Database.Domain
     public class PaymentRule : Rule
     {
         public PaymentRule(MetaPopulation m) : base(m, new Guid("4C7D0834-A7F2-4ED6-AC58-9B2DFD719ED9")) =>
-            this.Patterns = new[]
+            this.Patterns = new Pattern[]
             {
                 m.Payment.RolePattern(v => v.PaymentApplications),
                 m.Payment.RolePattern(v => v.Amount),
+                m.PaymentApplication.RolePattern(v => v.AmountApplied, v => v.PaymentWherePaymentApplication),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Bug
`PaymentRule` sums each `paymentApplication.AmountApplied` and adds `PaymentAmountIsToSmall` when the total exceeds
`Payment.Amount`. But its `Patterns` watched only the `PaymentApplications` set and `Payment.Amount` — **not**
`PaymentApplication.AmountApplied` value edits. So editing an existing application's amount to push the aggregate over
the payment amount was not re-validated. (Same shape as #02.)

## Fix
```csharp
m.PaymentApplication.RolePattern(v => v.AmountApplied, v => v.PaymentWherePaymentApplication),
```

Also switched `this.Patterns = new[] { … }` to `new Pattern[] { … }` — the implicitly-typed array no longer infers a
single element type once the (differently-typed) reroute pattern is added; `new Pattern[]` is the standard form.

## Test (TDD)
New `PaymentApplicationTests.ChangedPaymentApplicationAmountAppliedDerivePaymentAmountIsToSmall`: a `Receipt(Amount=100)`
+ one `PaymentApplication(AmountApplied=50)` on a 1000 invoice item; assert **no** `PaymentAmountIsToSmall`; set
`paymentApplication.AmountApplied = 150`; derive; assert exactly one `PaymentAmountIsToSmall`.

- **RED** (pre-fix): after the edit the aggregate error was absent (the rule didn't re-fire).
- **GREEN** after the fix.

The aggregate `PaymentAmountIsToSmall` is unique to `PaymentRule` (the per-application `PaymentApplicationRule` raises
different messages), so the assertion isolates this gap. Sibling of #02.