### PR TITLE
fix(apps): watch PartyContactMechanism default/mechanism edits + reset GeneralEmail/ShippingInquiriesPhone [BUG-12][BUG-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ under a dated version heading.
 
 ### Fixed
 
+- `PartyRule` derives a party's default contact mechanisms (billing/shipping/general addresses, phones, emails) from
+  its `PartyContactMechanism`s, but watched only their membership/`ContactPurposes`/`FromDate`/`ThroughDate` — not
+  `UseAsDefault` or `ContactMechanism`. So toggling a contact mechanism's default flag, or swapping its actual
+  address/number, left every derived contact role stale. It now also watches `PartyContactMechanism.UseAsDefault` and
+  `ContactMechanism`. The same rule's reset block also omitted `GeneralEmail` and `ShippingInquiriesPhone` (the latter a
+  duplicated `ShippingAddress` reset), so those two retained stale values when the default mechanism changed; both are
+  now reset.
 - `PaymentRule` rejects a payment whose applications sum to more than its `Amount`, but watched only the
   `PaymentApplications` set and `Amount` — so editing an existing application's `AmountApplied` to push the aggregate
   over the payment amount was not re-validated. It now also watches `PaymentApplication.AmountApplied` (rerouted via

--- a/dotnet/Apps/Database/Domain.Tests/Relation/PartyRuleTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Relation/PartyRuleTests.cs
@@ -148,5 +148,67 @@ namespace Allors.Database.Domain.Tests
 
             Assert.DoesNotContain(partyContactMechanism, party.CurrentPartyContactMechanisms);
         }
+
+        [Fact]
+        public void ChangedPartyContactMechanismUseAsDefaultDeriveGeneralEmail()
+        {
+            var party = new PersonBuilder(this.Transaction).Build();
+            var partyContactMechanism = new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(party)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).GeneralEmail)
+                .WithContactMechanism(new EmailAddressBuilder(this.Transaction).Build())
+                .WithUseAsDefault(true)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(partyContactMechanism.ContactMechanism, party.GeneralEmail);
+
+            partyContactMechanism.UseAsDefault = false;
+            this.Derive();
+
+            Assert.False(party.ExistGeneralEmail);
+        }
+
+        [Fact]
+        public void ChangedPartyContactMechanismUseAsDefaultDeriveShippingInquiriesPhone()
+        {
+            var party = new PersonBuilder(this.Transaction).Build();
+            var partyContactMechanism = new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(party)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).ShippingInquiriesPhone)
+                .WithContactMechanism(new TelecommunicationsNumberBuilder(this.Transaction).WithContactNumber("1").Build())
+                .WithUseAsDefault(true)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(partyContactMechanism.ContactMechanism, party.ShippingInquiriesPhone);
+
+            partyContactMechanism.UseAsDefault = false;
+            this.Derive();
+
+            Assert.False(party.ExistShippingInquiriesPhone);
+        }
+
+        [Fact]
+        public void ChangedPartyContactMechanismContactMechanismDeriveGeneralCorrespondence()
+        {
+            var party = new PersonBuilder(this.Transaction).Build();
+            var address1 = new EmailAddressBuilder(this.Transaction).Build();
+            var partyContactMechanism = new PartyContactMechanismBuilder(this.Transaction)
+                .WithParty(party)
+                .WithContactPurpose(new ContactMechanismPurposes(this.Transaction).GeneralCorrespondence)
+                .WithContactMechanism(address1)
+                .WithUseAsDefault(true)
+                .Build();
+            this.Derive();
+
+            Assert.Equal(address1, party.GeneralCorrespondence);
+
+            var address2 = new EmailAddressBuilder(this.Transaction).Build();
+            partyContactMechanism.ContactMechanism = address2;
+            this.Derive();
+
+            Assert.Equal(address2, party.GeneralCorrespondence);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Relations/PartyRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Relations/PartyRule.cs
@@ -22,6 +22,8 @@ namespace Allors.Database.Domain
                 m.PartyContactMechanism.RolePattern(v => v.ContactPurposes, v => v.Party.ObjectType),
                 m.PartyContactMechanism.RolePattern(v => v.FromDate, v => v.Party.ObjectType),
                 m.PartyContactMechanism.RolePattern(v => v.ThroughDate, v => v.Party.ObjectType),
+                m.PartyContactMechanism.RolePattern(v => v.UseAsDefault, v => v.Party.ObjectType),
+                m.PartyContactMechanism.RolePattern(v => v.ContactMechanism, v => v.Party.ObjectType),
                 m.Party.AssociationPattern(v => v.PartyRelationshipsWhereParty),
                 m.PartyRelationship.RolePattern(v => v.FromDate, v => v.Parties),
                 m.PartyRelationship.RolePattern(v => v.ThroughDate, v => v.Parties),
@@ -37,6 +39,7 @@ namespace Allors.Database.Domain
                 @this.BillingInquiriesPhone = null;
                 @this.CellPhoneNumber = null;
                 @this.GeneralCorrespondence = null;
+                @this.GeneralEmail = null;
                 @this.GeneralFaxNumber = null;
                 @this.GeneralPhoneNumber = null;
                 @this.HeadQuarter = null;
@@ -49,7 +52,7 @@ namespace Allors.Database.Domain
                 @this.SalesOffice = null;
                 @this.ShippingAddress = null;
                 @this.ShippingInquiriesFax = null;
-                @this.ShippingAddress = null;
+                @this.ShippingInquiriesPhone = null;
 
                 foreach (var partyContactMechanism in @this.PartyContactMechanismsWhereParty)
                 {


### PR DESCRIPTION
One PR for two interdependent bugs in `PartyRule` (the backlog notes each must be fixed with the other — the reset only
runs when the rule re-fires, which needs the missing trigger).

## BUG-13 — unwatched `UseAsDefault` / `ContactMechanism`
`PartyRule` loops `PartyContactMechanismsWhereParty` and, for each with `UseAsDefault == true`, copies its
`ContactMechanism` into ~18 derived contact roles (by `ContactPurposes`). But its `Patterns` watched only PCM
membership + `ContactPurposes`/`FromDate`/`ThroughDate` — **neither `UseAsDefault` nor `ContactMechanism`**. So toggling
a contact mechanism's default flag, or swapping its actual address/number, left every derived contact role stale.

```csharp
m.PartyContactMechanism.RolePattern(v => v.UseAsDefault, v => v.Party.ObjectType),
m.PartyContactMechanism.RolePattern(v => v.ContactMechanism, v => v.Party.ObjectType),
```

## BUG-12 — reset block omits `GeneralEmail` / `ShippingInquiriesPhone`
The Derive nulls ~18 derived roles before re-reading them, but **omitted** `GeneralEmail` (set later) and
`ShippingInquiriesPhone` — line 52 was a **duplicated** `@this.ShippingAddress = null;` (copy-paste; it should have
been `ShippingInquiriesPhone`). So those two retained stale values when the default mechanism stopped supplying them.

- Added `@this.GeneralEmail = null;`.
- Replaced the duplicate line with `@this.ShippingInquiriesPhone = null;`.

## Tests (TDD)
`PartyRuleTests`:
- `ChangedPartyContactMechanismUseAsDefaultDeriveGeneralEmail` / `…DeriveShippingInquiriesPhone` — set up a default PCM
  supplying the role, then set `UseAsDefault = false`; assert the derived role becomes null. **Require both fixes**
  (the `UseAsDefault` trigger *and* the reset). RED → GREEN.
- `ChangedPartyContactMechanismContactMechanismDeriveGeneralCorrespondence` — swap the default PCM's `ContactMechanism`;
  assert `GeneralCorrespondence` tracks it (tests the `ContactMechanism` trigger alone). RED → GREEN.

All three RED on current code, GREEN after the fix.