### PR TITLE
fix(apps): re-derive ProductCategory for-sale rollups on item availability/state + membership edits [BUG-11][BUG-D1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,15 @@ under a dated version heading.
 
 ### Fixed
 
+- `ProductCategoryRule` derives `AllSerialisedItemsForSale` from its parts' `SerialisedItem`s (filtered by
+  `AvailableForSale`) and `AllNonSerialisedInventoryItemsForSale` from their `NonSerialisedInventoryItem`s (filtered by
+  `NonSerialisedInventoryItemState.AvailableForSale`), but watched neither those leaf flags/state nor part-level item
+  membership. So flipping a serialised item's `AvailableForSale`, changing a non-serialised inventory item's state, or
+  adding/removing inventory items on a part already in a category left both derived collections stale. It now also
+  watches `SerialisedItem.AvailableForSale`, `Part.SerialisedItems`,
+  `NonSerialisedInventoryItem.NonSerialisedInventoryItemState` and `Part.InventoryItemsWherePart`, each rerouted to the
+  owning product categories (including ancestors, via `ProductCategoriesWhereAllProduct`) along both the `UnifiedGood`
+  and `NonUnifiedPart` legs.
 - `PartyRule` derives a party's default contact mechanisms (billing/shipping/general addresses, phones, emails) from
   its `PartyContactMechanism`s, but watched only their membership/`ContactPurposes`/`FromDate`/`ThroughDate` — not
   `UseAsDefault` or `ContactMechanism`. So toggling a contact mechanism's default flag, or swapping its actual

--- a/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Product/ProductCategoryTests.cs
@@ -1304,5 +1304,49 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(4, productCategory1.AllNonSerialisedInventoryItemsForSale.Count());
             Assert.Contains(good.Part.InventoryItemsWherePart.ElementAt(0), productCategory1.AllNonSerialisedInventoryItemsForSale);
         }
+
+        [Fact]
+        public void ChangedSerialisedItemAvailableForSaleDeriveAllSerialisedItemsForSale()
+        {
+            var serialisedItem = new SerialisedItemBuilder(this.Transaction).WithSerialNumber("1").WithAvailableForSale(true).Build();
+            var good = new UnifiedGoodBuilder(this.Transaction)
+                .WithName("good")
+                .WithInventoryItemKind(new InventoryItemKinds(this.Transaction).Serialised)
+                .Build();
+            good.AddSerialisedItem(serialisedItem);
+
+            var productCategory = new ProductCategoryBuilder(this.Transaction).WithName("category").WithProduct(good).Build();
+            this.Derive();
+
+            Assert.Contains(serialisedItem, productCategory.AllSerialisedItemsForSale);
+
+            serialisedItem.AvailableForSale = false;
+            this.Derive();
+
+            Assert.DoesNotContain(serialisedItem, productCategory.AllSerialisedItemsForSale);
+        }
+
+        [Fact]
+        public void ChangedNonSerialisedInventoryItemStateDeriveAllNonSerialisedInventoryItemsForSale()
+        {
+            var good = new NonUnifiedGoodBuilder(this.Transaction)
+                .WithPart(new NonUnifiedPartBuilder(this.Transaction)
+                            .WithInventoryItemKind(new InventoryItemKinds(this.Transaction).NonSerialised)
+                            .Build())
+                .Build();
+            var productCategory = new ProductCategoryBuilder(this.Transaction).WithName("category").WithProduct(good).Build();
+            this.Derive();
+
+            Assert.NotEmpty(productCategory.AllNonSerialisedInventoryItemsForSale);
+
+            foreach (NonSerialisedInventoryItem inventoryItem in good.Part.InventoryItemsWherePart)
+            {
+                inventoryItem.NonSerialisedInventoryItemState = new NonSerialisedInventoryItemStates(this.Transaction).Scrap;
+            }
+
+            this.Derive();
+
+            Assert.Empty(productCategory.AllNonSerialisedInventoryItemsForSale);
+        }
     }
 }

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategoryRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Product/ProductCategoryRule.cs
@@ -27,6 +27,16 @@ namespace Allors.Database.Domain
                 m.ProductCategory.RolePattern(v => v.AllProducts, v => v.ProductCategoriesWhereDescendant),
                 m.ProductCategory.AssociationPattern(v => v.ProductCategoriesWherePrimaryParent),
                 m.ProductCategory.AssociationPattern(v => v.ProductCategoriesWhereSecondaryParent),
+                // AllSerialisedItemsForSale reads Part.SerialisedItems and SerialisedItem.AvailableForSale
+                m.SerialisedItem.RolePattern(v => v.AvailableForSale, v => v.PartWhereSerialisedItem.ObjectType.AsUnifiedGood.ProductCategoriesWhereAllProduct),
+                m.SerialisedItem.RolePattern(v => v.AvailableForSale, v => v.PartWhereSerialisedItem.ObjectType.AsNonUnifiedPart.NonUnifiedGoodsWherePart.ObjectType.ProductCategoriesWhereAllProduct),
+                m.Part.RolePattern(v => v.SerialisedItems, v => v.AsUnifiedGood.ProductCategoriesWhereAllProduct),
+                m.Part.RolePattern(v => v.SerialisedItems, v => v.AsNonUnifiedPart.NonUnifiedGoodsWherePart.ObjectType.ProductCategoriesWhereAllProduct),
+                // AllNonSerialisedInventoryItemsForSale reads Part.InventoryItemsWherePart and NonSerialisedInventoryItem.NonSerialisedInventoryItemState
+                m.NonSerialisedInventoryItem.RolePattern(v => v.NonSerialisedInventoryItemState, v => v.Part.ObjectType.AsUnifiedGood.ProductCategoriesWhereAllProduct),
+                m.NonSerialisedInventoryItem.RolePattern(v => v.NonSerialisedInventoryItemState, v => v.Part.ObjectType.AsNonUnifiedPart.NonUnifiedGoodsWherePart.ObjectType.ProductCategoriesWhereAllProduct),
+                m.Part.AssociationPattern(v => v.InventoryItemsWherePart, v => v.AsUnifiedGood.ProductCategoriesWhereAllProduct),
+                m.Part.AssociationPattern(v => v.InventoryItemsWherePart, v => v.AsNonUnifiedPart.NonUnifiedGoodsWherePart.ObjectType.ProductCategoriesWhereAllProduct),
             };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Summary

`ProductCategoryRule` derives two for-sale rollups over its parts:

- `AllSerialisedItemsForSale` = parts' `SerialisedItem`s filtered by `AvailableForSale`
- `AllNonSerialisedInventoryItemsForSale` = parts' `NonSerialisedInventoryItem`s filtered by `NonSerialisedInventoryItemState.AvailableForSale`

…but `this.Patterns` watched only category structure (`Products`/`AllProducts`/`Descendants`/parents). It watched **neither** the leaf for-sale flags/state **nor** part-level item membership. So:

- flipping a `SerialisedItem.AvailableForSale`,
- moving a `NonSerialisedInventoryItem` to a not-for-sale state (e.g. `Good` → `Scrap`), or
- adding/removing an inventory item on a part **already** in a category

left both derived collections **stale**.

## Fix

Add the missing patterns, each rerouted to the owning product categories — **including ancestors**, via the inverse of the derived `AllProducts` (`ProductCategoriesWhereAllProduct`) — along both the `UnifiedGood` and `NonUnifiedPart` legs:

- **[BUG-11]** `SerialisedItem.AvailableForSale` + `Part.SerialisedItems`
- **[BUG-D1]** `NonSerialisedInventoryItem.NonSerialisedInventoryItemState` + `Part.InventoryItemsWherePart`

The reroute idioms mirror existing rules (`ProposalPrintRule`/`ProductQuotePrintRule` for the NonUnifiedPart leg, `SalesOrderItemInventoryItemRule` for the Part-source `AsUnifiedGood` leg, `UnifiedGoodSearchStringRule` for `ProductCategoriesWhereAllProduct`).

## Tests (TDD, RED → GREEN)

Two new tests in `ProductCategoryRuleTests`, covering both reroute legs:

- `ChangedSerialisedItemAvailableForSaleDeriveAllSerialisedItemsForSale` — UnifiedGood leg; flips `AvailableForSale` and asserts the item leaves `AllSerialisedItemsForSale`.
- `ChangedNonSerialisedInventoryItemStateDeriveAllNonSerialisedInventoryItemsForSale` — NonUnifiedPart leg; flips state `Good` → `Scrap` and asserts the item leaves `AllNonSerialisedInventoryItemsForSale`.

Both fail on un-fixed code (the rule didn't re-fire) and pass after the fix. Locally: `Passed: 2`. Gated on CI `CiDotnetAppsDatabaseTest`.