### PR TITLE
fix(apps): roll GL balances up from level-5 children, not level-3 parent [BUG-16][BUG-17][BUG-D4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,15 @@ under a dated version heading.
 
 ### Fixed
 
+- `OrganisationGlAccountBalanceAmountRule` rolled GL balances up incorrectly. A level-4 balance aggregated its
+  level-3 **parent** instead of its level-5 **children** (`generalLedgerAccount.Parent` instead of
+  `GeneralLedgerAccountsWhereParent`); when a level-5 child's detail changed, the rule only bumped a
+  `DerivationTrigger` that **no rule watched** (a dead no-op), so the level-4 balance never reflected the change; and
+  the up-roll guard tested `generalLedgerAccount.ExistParent` while dereferencing the unrelated
+  `organisationGlAccount.SubsidiaryOf`, risking a null-reference. The rule now aggregates a level-4 balance from its
+  level-5 children, recomputes the parent (level-4) balance directly when a child detail changes, and guards
+  `ExistSubsidiaryOf`. The shipped acceptance test
+  `OrganisationGlAccountWhenLevel5AccountAmountChangesThenLevel4AmountShouldReflectThis` is un-skipped.
 - `ProductCategoryRule` derives `AllSerialisedItemsForSale` from its parts' `SerialisedItem`s (filtered by
   `AvailableForSale`) and `AllNonSerialisedInventoryItemsForSale` from their `NonSerialisedInventoryItem`s (filtered by
   `NonSerialisedInventoryItemState.AvailableForSale`), but watched neither those leaf flags/state nor part-level item

--- a/dotnet/Apps/Database/Domain.Tests/Accounting/OrganisationGlAccountBalanceTests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Accounting/OrganisationGlAccountBalanceTests.cs
@@ -135,7 +135,7 @@ namespace Allors.Database.Domain.Tests
             Assert.Equal(100, organisationGlAccountBalance.Amount);
         }
 
-        [Fact(Skip = "Investigate")]
+        [Fact]
         public void OrganisationGlAccountWhenLevel5AccountAmountChangesThenLevel4AmountShouldReflectThis()
         {
             var internalOrganisation = new OrganisationBuilder(this.Transaction).WithInternalOrganisationDefaults().Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/OrganisationGlAccountBalanceAmountRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Accounting/OrganisationGlAccountBalanceAmountRule.cs
@@ -40,7 +40,12 @@ namespace Allors.Database.Domain
                     {
                         if (generalLedgerAccount.RgsLevel == 4)
                         {
-                            var subDetails = internalOrganisation.AccountingTransactionsWhereInternalOrganisation.Where(v => v.AccountingPeriod == accountingPeriod).SelectMany(v => v.AccountingTransactionDetails.Where(v => v.GeneralLedgerAccount.Equals(generalLedgerAccount.Parent))).ToList();
+                            // A level-4 balance aggregates the details booked on its level-5 children
+                            // (GeneralLedgerAccountsWhereParent), together with any booked on the level-4 account itself.
+                            var subDetails = internalOrganisation.AccountingTransactionsWhereInternalOrganisation
+                                .Where(t => t.AccountingPeriod == accountingPeriod)
+                                .SelectMany(t => t.AccountingTransactionDetails.Where(d => generalLedgerAccount.GeneralLedgerAccountsWhereParent.Contains(d.GeneralLedgerAccount)))
+                                .ToList();
 
                             var allDetails = details.Concat(subDetails).ToList();
 
@@ -50,10 +55,28 @@ namespace Allors.Database.Domain
                         {
                             this.CalculateAmounts(organisationGlAccountBalance, details);
 
-                            if (generalLedgerAccount.ExistParent)
+                            // Roll the change up into the parent (level-4) balance, which aggregates this account's
+                            // siblings. The parent is reached through OrganisationGlAccount.SubsidiaryOf.
+                            if (organisationGlAccount.ExistSubsidiaryOf)
                             {
-                                organisationGlAccount.SubsidiaryOf.OrganisationGlAccountBalancesWhereOrganisationGlAccount.ToList()
-                                    .ForEach(v => v.DerivationTrigger = Guid.NewGuid());
+                                var parentOrganisationGlAccount = organisationGlAccount.SubsidiaryOf;
+                                var parentGeneralLedgerAccount = parentOrganisationGlAccount.GeneralLedgerAccount;
+
+                                var parentBalance = parentOrganisationGlAccount
+                                    .OrganisationGlAccountBalancesWhereOrganisationGlAccount
+                                    .FirstOrDefault(v => v.AccountingPeriod.Equals(accountingPeriod));
+
+                                if (parentBalance != null)
+                                {
+                                    var parentDetails = internalOrganisation.AccountingTransactionsWhereInternalOrganisation
+                                        .Where(t => t.AccountingPeriod == accountingPeriod)
+                                        .SelectMany(t => t.AccountingTransactionDetails.Where(d =>
+                                            d.GeneralLedgerAccount.Equals(parentGeneralLedgerAccount)
+                                            || parentGeneralLedgerAccount.GeneralLedgerAccountsWhereParent.Contains(d.GeneralLedgerAccount)))
+                                        .ToList();
+
+                                    this.CalculateAmounts(parentBalance, parentDetails);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

`OrganisationGlAccountBalanceAmountRule` rolled GL account balances up the RGS hierarchy incorrectly. Three coupled defects in one rule:

- **[BUG-16]** A level-4 balance aggregated its level-3 **parent** instead of its level-5 **children** — `d.GeneralLedgerAccount.Equals(generalLedgerAccount.Parent)` climbs *up* the tree. It should aggregate `generalLedgerAccount.GeneralLedgerAccountsWhereParent` (the children).
- **[BUG-D4]** When a level-5 child's detail changed, the rule only bumped `OrganisationGlAccountBalance.DerivationTrigger = Guid.NewGuid()` to make the parent re-derive — but **no rule watches that trigger** (and this rule matches `AccountingTransactionDetail`, not the balance), so it was a dead no-op. The level-4 balance never reflected child changes.
- **[BUG-17]** The up-roll guard tested `generalLedgerAccount.ExistParent` while dereferencing the unrelated `organisationGlAccount.SubsidiaryOf` — independent optional roles, so a null `SubsidiaryOf` could throw.

## Fix

- Level-4 branch aggregates own details **+ level-5 children** (`GeneralLedgerAccountsWhereParent`).
- The else-branch drops the dead trigger and **directly recomputes the parent (level-4) balance** — own + children — in the same derivation pass.
- The guard now tests `ExistSubsidiaryOf` (the role it dereferences).

## Tests (TDD, RED → GREEN)

Un-skipped the shipped acceptance test `OrganisationGlAccountWhenLevel5AccountAmountChangesThenLevel4AmountShouldReflectThis` (was `[Fact(Skip = "Investigate")]`). It books 100 Debit / 200 Credit on two level-5 children and asserts the level-4 balance = Debit 100 / Credit 200 / Amount −100.

- **RED** on current code: `Assert.Equal Expected: 100 Actual: 0` (level-4 never updated).
- **GREEN** after the fix. The two pre-existing tests in the class still pass (no regression): `Passed: 3`.

Gated on CI `CiDotnetAppsDatabaseTest`.