### PR TITLE
fix(apps): watch base OrderAdjustment edits in SalesInvoicePriceRule [BUG-D6]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesInvoicePriceRule` watched invoice-level adjustment *edits* only for the `DiscountAdjustment` and
+  `SurchargeAdjustment` subtypes, so editing an existing `Fee` / `ShippingAndHandlingCharge` /
+  `MiscellaneousCharge`'s `Amount` or `Percentage` left `TotalFee` / `TotalShippingAndHandling` / `TotalExtraCharge`
+  (and the grand totals) stale. It now watches the base `OrderAdjustment.Amount` / `Percentage` rerouted to the
+  invoice, covering all adjustment subtypes (mirrors the `PurchaseInvoicePriceRule` fix).
 - `AutomatedAgent.DisplayName` was written by two rules — `AutomatedAgentRule` (`= Name`, watching `Name`) and
   `AutomatedAgentDisplayNameRule` (`= UserName ?? "N/A"`, watching `UserName`) — so the displayed value was
   last-writer-wins (order-dependent), and clearing `UserName` could overwrite a valid `Name` with `"N/A"`.

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -2681,6 +2681,22 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedFeeAmountDeriveTotalFee()
+        {
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithInvoiceDate(this.Transaction.Now()).Build();
+            var fee = new FeeBuilder(this.Transaction).WithAmount(10).Build();
+            invoice.AddOrderAdjustment(fee);
+            this.Derive();
+
+            Assert.Equal(10, invoice.TotalFee);
+
+            fee.Amount = 20;
+            this.Derive();
+
+            Assert.Equal(20, invoice.TotalFee);
+        }
+
+        [Fact]
         public void OnChangedDerivationTriggerTriggeredByDiscountComponentPercentageCalculatePrice()
         {
             var product = new NonUnifiedGoodBuilder(this.Transaction).Build();

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Invoice/SalesInvoicePriceRule.cs
@@ -42,6 +42,8 @@ namespace Allors.Database.Domain
             m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
             m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.PriceableWhereSurchargeAdjustment.ObjectType.AsSalesInvoiceItem.SalesInvoiceWhereSalesInvoiceItem, m.SalesInvoice),
             m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
+            m.OrderAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
+            m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
         };
 
         public override void Derive(ICycle cycle, IEnumerable<IObject> matches)


### PR DESCRIPTION
## Summary

Confirmed latent sibling of **#22** (which fixed the identical gap in `PurchaseInvoicePriceRule`).

`SalesInvoicePriceRule` watched invoice-level `OrderAdjustments` **membership** and the **edit** of the `DiscountAdjustment` / `SurchargeAdjustment` subtypes — but `Amount`/`Percentage` live on the base `OrderAdjustment`, and the other subtypes (`Fee`, `ShippingAndHandlingCharge`, `MiscellaneousCharge`) were **not** watched for edits. So editing an existing Fee/Shipping/Misc adjustment left `TotalFee` / `TotalShippingAndHandling` / `TotalExtraCharge` (and the grand totals) stale.

## Fix

Add the base-`OrderAdjustment` edit patterns rerouted to the invoice (mirrors `PurchaseInvoicePriceRule`):

```csharp
m.OrderAdjustment.RolePattern(v => v.Amount, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.InvoiceWhereOrderAdjustment, m.SalesInvoice),
```

The supertype covers all adjustment subtypes; it overlaps the existing Discount/Surcharge patterns harmlessly (the rule resets totals to 0 and recomputes idempotently).

## Tests (TDD, RED → GREEN)

`SalesInvoicePriceRuleTests.ChangedFeeAmountDeriveTotalFee`: build a `SalesInvoice`, add a `Fee` (Amount 10), assert `TotalFee == 10`; set `fee.Amount = 20`, assert `TotalFee == 20`.

- **RED**: `Assert.Equal Expected: 20 Actual: 10` (the edit was unwatched).
- **GREEN** after the fix.

Gated on CI `CiDotnetAppsDatabaseTest`.