### PR TITLE
fix(apps): watch base OrderAdjustment edits in SalesOrderPriceRule [BUG-D7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ under a dated version heading.
 
 ### Fixed
 
+- `SalesOrderPriceRule` watched order-level adjustment *edits* only for the `DiscountAdjustment` and
+  `SurchargeAdjustment` subtypes, so editing an existing `Fee` / `ShippingAndHandlingCharge` /
+  `MiscellaneousCharge`'s `Amount` or `Percentage` left `TotalFee` / `TotalShippingAndHandling` / `TotalExtraCharge`
+  (and the grand totals) stale. It now watches the base `OrderAdjustment.Amount` / `Percentage` rerouted to the order,
+  covering all adjustment subtypes (mirrors the `PurchaseOrderPriceRule` fix).
 - `SalesInvoicePriceRule` watched invoice-level adjustment *edits* only for the `DiscountAdjustment` and
   `SurchargeAdjustment` subtypes, so editing an existing `Fee` / `ShippingAndHandlingCharge` /
   `MiscellaneousCharge`'s `Amount` or `Percentage` left `TotalFee` / `TotalShippingAndHandling` / `TotalExtraCharge`

--- a/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Order/Salesordertests.cs
@@ -4588,6 +4588,22 @@ namespace Allors.Database.Domain.Tests
 
             Assert.Equal(1.4M, order.TotalIncVat);
         }
+
+        [Fact]
+        public void OnChangedFeeAdjustmentAmountCalculatePrice()
+        {
+            var order = new SalesOrderBuilder(this.Transaction).WithOrderDate(this.Transaction.Now()).Build();
+            var fee = new FeeBuilder(this.Transaction).WithAmount(10).Build();
+            order.AddOrderAdjustment(fee);
+            this.Derive();
+
+            Assert.Equal(10, order.TotalFee);
+
+            fee.Amount = 20;
+            this.Derive();
+
+            Assert.Equal(20, order.TotalFee);
+        }
     }
 
     public class SalesOrderStateRuleTests : DomainTest, IClassFixture<Fixture>

--- a/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderPriceRule.cs
+++ b/dotnet/Apps/Database/Domain/Apps/Rules/Order/SalesOrderPriceRule.cs
@@ -28,6 +28,8 @@ namespace Allors.Database.Domain
                 m.DiscountAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
                 m.SurchargeAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
                 m.SurchargeAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
+                m.OrderAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
+                m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
                 m.SalesOrderItem.RolePattern(v => v.TotalBasePrice, v => v.SalesOrderWhereSalesOrderItem),
                 m.SalesOrderItem.RolePattern(v => v.TotalDiscount, v => v.SalesOrderWhereSalesOrderItem),
                 m.SalesOrderItem.RolePattern(v => v.TotalSurcharge, v => v.SalesOrderWhereSalesOrderItem),


### PR DESCRIPTION
## Summary

Confirmed latent sibling of **#D2a** (which fixed the identical gap in `PurchaseOrderPriceRule`) and the order-side twin of **#D6**.

`SalesOrderPriceRule` watched order-level `OrderAdjustments` **membership** and the **edit** of the `DiscountAdjustment` / `SurchargeAdjustment` subtypes — but `Amount`/`Percentage` live on the base `OrderAdjustment`, and the other subtypes (`Fee`, `ShippingAndHandlingCharge`, `MiscellaneousCharge`) were **not** watched for edits. So editing an existing Fee/Shipping/Misc adjustment left `TotalFee` / `TotalShippingAndHandling` / `TotalExtraCharge` (and the grand totals) stale.

## Fix

Add the base-`OrderAdjustment` edit patterns rerouted to the order (mirrors `PurchaseOrderPriceRule`):

```csharp
m.OrderAdjustment.RolePattern(v => v.Amount, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
m.OrderAdjustment.RolePattern(v => v.Percentage, v => v.OrderWhereOrderAdjustment, m.SalesOrder),
```

The supertype covers all adjustment subtypes; it overlaps the existing Discount/Surcharge patterns harmlessly (the rule resets totals to 0 and recomputes idempotently).

## Tests (TDD, RED → GREEN)

`SalesOrderPriceRuleTests.OnChangedFeeAdjustmentAmountCalculatePrice`: build a `SalesOrder`, add a `Fee` (Amount 10), assert `TotalFee == 10`; set `fee.Amount = 20`, assert `TotalFee == 20`.

- **RED**: `Assert.Equal Expected: 20 Actual: 10` (the edit was unwatched).
- **GREEN** after the fix.

This completes the adjustment-edit symmetry across all four price rules (PurchaseInvoice #22, SalesInvoice #D6, PurchaseOrder #D2a, Quote #D3, SalesOrder #D7). Gated on CI `CiDotnetAppsDatabaseTest`.