### PR TITLE
fix(workspace): remove session-origin composites role instead of adding [BUG-07]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- Removing an item from a session-origin many-valued role now removes it. `Strategy.removeCompositesRole`
+  routed the `Origin.Session` case to `sessionOriginState.addCompositesRole`, so the item was re-added instead
+  of removed; it now calls `removeCompositesRole`, matching the `Origin.Database` case.
 - Workspace objects are JSON-serializable again. `PrototypeObjectFactory` built each object's `toJSON` to call
   the non-existent `this.strategy.ToJSON()` (PascalCase), so `object.toJSON()` / `JSON.stringify(object)` threw
   `TypeError: this.strategy.ToJSON is not a function`. It now calls the real lowercase `this.strategy.toJSON()`

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
@@ -1,3 +1,4 @@
+import { C1 } from '@allors/default/workspace/domain';
 import { Fixture, name_c1A, name_c2A } from '../fixture';
 import '../matchers';
 
@@ -100,4 +101,22 @@ test('addCompositesRoleWrongRoleType', async () => {
   }
 
   expect(hasErrors).toBeTruthy();
+});
+
+test('removeCompositesRoleSession', async () => {
+  const { workspace, m } = fixture;
+  const session = workspace.createSession();
+
+  const c1a = session.create<C1>(m.C1);
+  const c1b = session.create<C1>(m.C1);
+  const c1c = session.create<C1>(m.C1);
+
+  c1a.addSessionC1Many2Many(c1b);
+  c1a.addSessionC1Many2Many(c1c);
+
+  c1a.removeSessionC1Many2Many(c1b);
+
+  // removeCompositesRole on a session-origin role must remove, not add:
+  // the bug routes it to sessionOriginState.addCompositesRole, leaving c1b in place.
+  expect(c1a.SessionC1Many2Manies).toEqual([c1c]);
 });

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/session/strategy.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/session/strategy.ts
@@ -373,7 +373,7 @@ export abstract class Strategy implements IStrategy {
 
     switch (roleType.origin) {
       case Origin.Session:
-        this.session.sessionOriginState.addCompositesRole(
+        this.session.sessionOriginState.removeCompositesRole(
           this.object,
           roleType,
           value


### PR DESCRIPTION
First cherry-pick from the `bugfix-review` branch — a **pipeline smoke test** validating the `cherry-pick → branch → PR → CI` loop before batching the remaining fixes.

- Original: **#87 / BUG-07**
- Cherry-picked (`-x`) from `ab8d42661a` (author preserved)
- `CHANGELOG.md` conflict resolved by **union** (kept both the existing CI entry and this fix's entry)

**Fix:** `Strategy.removeCompositesRole` routed the `Origin.Session` case to `sessionOriginState.addCompositesRole`, re-adding the item instead of removing it. It now calls `removeCompositesRole`, matching the `Origin.Database` case. Covered by a new `runtime/strategy.spec.ts` case.
