### PR TITLE
fix(workspace): integrate batch 1 — session-origin roles, revocations, binary [BUG-03/04/05/06/11/12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- Binary unit values are no longer double base64-encoded when pulled. `unitFromJson` returned `btoa(value)` for
+  a `Binary` unit, but the wire value is already base64 and the push path (`unitToJson`) sends it through
+  unchanged, so the round-trip produced a doubly-encoded value. It now returns the value as-is, matching the
+  other units.
 - Missing-revocation detection now checks the cached revocations instead of the permissions.
   `ResponseContext.checkForMissingRevocations` tested `database.permissions` rather than
   `database.revocationById`, so it flagged the wrong ids as missing (cached revocations were re-requested and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- Removing an item from a session-origin one-to-many role now removes it.
+  `SessionOriginState.removeCompositesRoleOne2Many` used `ranges.add` instead of `ranges.remove`, so the item
+  was left in place; it now calls `ranges.remove`, matching the many-to-many case.
 - Removing an item from a session-origin many-valued role now removes it. `Strategy.removeCompositesRole`
   routed the `Origin.Session` case to `sessionOriginState.addCompositesRole`, so the item was re-added instead
   of removed; it now calls `removeCompositesRole`, matching the `Origin.Database` case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- Reassigning a session-origin one-to-many role to a new association now detaches it from the old one.
+  `SessionOriginState.addCompositesRoleOne2Many` set the role's association back-pointer to the role itself
+  instead of the association, so the "remove from previous association" step targeted the wrong object and the
+  role stayed in both associations (violating the one-to-many). It now stores the association.
 - Binary unit values are no longer double base64-encoded when pulled. `unitFromJson` returned `btoa(value)` for
   a `Binary` unit, but the wire value is already base64 and the push path (`unitToJson`) sends it through
   unchanged, so the round-trip produced a doubly-encoded value. It now returns the value as-is, matching the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- Missing-revocation detection now checks the cached revocations instead of the permissions.
+  `ResponseContext.checkForMissingRevocations` tested `database.permissions` rather than
+  `database.revocationById`, so it flagged the wrong ids as missing (cached revocations were re-requested and
+  genuinely missing ones were not). It now checks `revocationById`, matching `checkForMissingGrants`.
 - Removing an item from a session-origin one-to-many role now removes it.
   `SessionOriginState.removeCompositesRoleOne2Many` used `ranges.add` instead of `ranges.remove`, so the item
   was left in place; it now calls `ranges.remove`, matching the many-to-many case.

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/database/security/response-context.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/database/security/response-context.spec.ts
@@ -1,0 +1,17 @@
+import { ResponseContext } from '@allors/system/workspace/adapters-json';
+
+test('checkForMissingRevocations flags ids absent from revocationById', () => {
+  const database = {
+    ranges: { enumerate: (value: number[]) => value },
+    grantById: new Map<number, unknown>(),
+    revocationById: new Map<number, unknown>([[1, {}]]), // revocation 1 is cached
+    permissions: new Set<number>([2]), // decoy: id 2 is a permission, not a revocation
+  } as any;
+
+  const context = new ResponseContext(database);
+  context.checkForMissingRevocations([1, 2] as any);
+
+  // Only 2 is an uncached revocation; 1 is already in revocationById. The bug checked
+  // `permissions` instead, so it would flag 1 (absent from permissions) and miss 2.
+  expect([...context.missingRevocationIds]).toEqual([2]);
+});

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/procedure.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/procedure.spec.ts
@@ -50,7 +50,7 @@ test('testUnitSamplesWithValues', async () => {
 
   const unitSample = result.object<UnitSample>(m.UnitSample);
 
-  expect(unitSample.AllorsBinary).toEqual('QVFJRA==');
+  expect(unitSample.AllorsBinary).toEqual('AQID');
   expect(unitSample.AllorsBoolean).toBeTruthy();
   expect(new Date(unitSample.AllorsDateTime)).toEqual(
     new Date('Tue Mar 27 1973 00:00:00 GMT+0000')

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/push.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/push.spec.ts
@@ -138,13 +138,13 @@ test('pushShouldUpdateId', async () => {
   person.FirstName = 'Johny';
   person.LastName = 'Doey';
 
-  expect(person.id < 0);
+  expect(person.id).toBeLessThan(0);
 
   const pushResult = await session.push();
 
   expect(pushResult.hasErrors).toBeFalsy();
 
-  expect(person.id > 0);
+  expect(person.id).toBeGreaterThan(0);
 });
 
 test('pushShouldNotUpdateVersion', async () => {

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/security.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/security.spec.ts
@@ -89,7 +89,7 @@ test('deniedPermissions', async () => {
         expect(denied.strategy.canWrite(roleType)).toBeFalsy();
       } else {
         expect(denied.strategy.canRead(roleType)).toBeTruthy();
-        expect(denied.strategy.canRead(roleType)).toBeTruthy();
+        expect(denied.strategy.canWrite(roleType)).toBeTruthy();
       }
     }
   }

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
@@ -120,3 +120,21 @@ test('removeCompositesRoleSession', async () => {
   // the bug routes it to sessionOriginState.addCompositesRole, leaving c1b in place.
   expect(c1a.SessionC1Many2Manies).toEqual([c1c]);
 });
+
+test('removeCompositesRoleSessionOne2Many', async () => {
+  const { workspace, m } = fixture;
+  const session = workspace.createSession();
+
+  const c1a = session.create<C1>(m.C1);
+  const c1b = session.create<C1>(m.C1);
+  const c1c = session.create<C1>(m.C1);
+
+  c1a.addSessionC1One2Many(c1b);
+  c1a.addSessionC1One2Many(c1c);
+
+  c1a.removeSessionC1One2Many(c1b);
+
+  // removeCompositesRoleOne2Many must remove the role from the association:
+  // the bug used ranges.add, leaving c1b in place.
+  expect(c1a.SessionC1One2Manies).toEqual([c1c]);
+});

--- a/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json-tests/src/lib/runtime/strategy.spec.ts
@@ -138,3 +138,21 @@ test('removeCompositesRoleSessionOne2Many', async () => {
   // the bug used ranges.add, leaving c1b in place.
   expect(c1a.SessionC1One2Manies).toEqual([c1c]);
 });
+
+test('addCompositesRoleSessionOne2ManyReassigns', async () => {
+  const { workspace, m } = fixture;
+  const session = workspace.createSession();
+
+  const c1a = session.create<C1>(m.C1);
+  const c1d = session.create<C1>(m.C1);
+  const c1b = session.create<C1>(m.C1);
+
+  c1a.addSessionC1One2Many(c1b);
+  c1d.addSessionC1One2Many(c1b);
+
+  // One2Many: reassigning the role to a new association must detach it from the
+  // old one. The bug set the role's association to itself, so the detach targeted
+  // the wrong object and c1b stayed in c1a.
+  expect(c1a.SessionC1One2Manies).toEqual([]);
+  expect(c1d.SessionC1One2Manies).toEqual([c1b]);
+});

--- a/typescript/modules/libs/system/workspace/adapters-json/src/index.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/database/database-connection';
+export * from './lib/database/security/response-context';
 
 export * from './lib/json/from-json';
 export * from './lib/json/to-json';

--- a/typescript/modules/libs/system/workspace/adapters-json/src/lib/database/security/response-context.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/lib/database/security/response-context.ts
@@ -23,7 +23,7 @@ export class ResponseContext {
 
   checkForMissingRevocations(value: IRange<number>): IRange<number> {
     for (const id of this.database.ranges.enumerate(value)) {
-      if (!this.database.permissions.has(id)) {
+      if (!this.database.revocationById.has(id)) {
         this.missingRevocationIds.add(id);
       }
     }

--- a/typescript/modules/libs/system/workspace/adapters-json/src/lib/json/from-json.ts
+++ b/typescript/modules/libs/system/workspace/adapters-json/src/lib/json/from-json.ts
@@ -20,7 +20,7 @@ export function unitFromJson(tag: string, value: unknown): IUnit {
 
     case UnitTags.Binary:
       if (typeof value === 'string') {
-        return btoa(value);
+        return value;
       }
       break;
 

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
@@ -342,7 +342,7 @@ export class SessionOriginState {
 
     // A ----> R
     let roleIds = this.getCompositesRole(association, roleType);
-    roleIds = this.ranges.add(roleIds, role);
+    roleIds = this.ranges.remove(roleIds, role);
     this.propertyByObjectByPropertyType.set(association, roleType, roleIds);
   }
 

--- a/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
+++ b/typescript/modules/libs/system/workspace/adapters/src/lib/session/originstate/session-origin-state.ts
@@ -282,7 +282,7 @@ export class SessionOriginState {
     }
 
     // A <---- R
-    this.propertyByObjectByPropertyType.set(role, associationType, role);
+    this.propertyByObjectByPropertyType.set(role, associationType, association);
 
     // A ----> R
     let roleIds = this.getCompositesRole(association, roleType);


### PR DESCRIPTION
**Batch 1 of the bugfix-review integration** — scope `workspace`. Cherry-picked (`-x`, original authors preserved) from `bugfix-review`, oldest-first; CHANGELOG conflicts resolved by union.

| Fix | PR | Commit |
|-----|----|--------|
| `[BUG-05]` remove session-origin one-to-many role item instead of adding | #90 | `ff0554f40b` |
| `[BUG-03]` check `revocationById` in `checkForMissingRevocations` | #91 | `8dbc7e06eb` |
| `[BUG-04]` stop double base64-encoding Binary units on pull | #92 | `abe9d2f145` |
| `[BUG-11]` test: assert id changes in `pushShouldUpdateId` | #93 | `5cbfbb7669` |
| `[BUG-06]` store association on session one-to-many role back-pointer | #89 | `66c218b6ef` |
| `[BUG-12]` test: assert `canWrite` in `deniedPermissions` | #94 | `dcd884c71d` |

All under `libs/system/workspace` (+ `adapters-json-tests`). Exercised by the now-green required check `CiTypescriptWorkspaceAdaptersJsonTest`.

A Claude review brief follows in a comment.
