### PR TITLE
fix(base): integrate batch 2 — employment FromDate, person overview, prod app-init [BUG-01/21, #100]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,68 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- The base app's Person overview pulled the wrong object: `onPreSharedPull` fetched `p.Organisation` by the
+  Person's `scoped.id`, so no object came back and the overview's `object` (the Person) was null — e.g. the
+  breadcrumb `{{ object?.FirstName }}` rendered blank. It now pulls `p.Person`. (The dynamic panels were
+  unaffected because they drive off `scoped.id` directly.)
+- The extranet app's `MainComponent` leaked its `router.events` subscription: unlike the sibling
+  toggle/open/close side-nav subscriptions it was neither stored nor unsubscribed, so it survived component
+  teardown. It is now kept in a `routerSubscription` field and unsubscribed in `ngOnDestroy`.
+- The intranet `DisplayService.description()` read the `nameByObjectType` map instead of
+  `descriptionByObjectType`, so the dynamic summary panel showed an object's name as both its name and its
+  description. It now reads `descriptionByObjectType`, falling back to `nameByObjectType` when no description
+  role is configured for a type (the map is not yet populated, so behaviour is unchanged until it is).
+- The purchase-invoice summary panel's "ship to" and "Bill to End Customer" cards both navigated to the
+  `BilledFrom` party on click (copied from the "Billed from" card) instead of the party each card shows. They
+  now navigate to `ShipToCustomer` and `BillToEndCustomer` respectively.
+- The intranet proposal (quote) list declared `origin` and `destination` columns that were never populated —
+  a Proposal has no such roles, and they were absent from the row interface, the row-builder, and the Proposal
+  sorter — so they rendered permanently blank (and their `sort: true` was dead). Both columns are removed.
+- The intranet non-unified-part list's `type` column was always blank: the column is defined (and sortable),
+  but the row-builder never set a `type` key. It now populates `type` from `v.ProductTypeName` (the role the
+  column already sorts by, alongside the sibling `brand`/`model`/`kind` derived-name columns).
+- The intranet purchase-order list's `customerReference` column showed the order's `Description` instead of
+  its `CustomerReference`. The row-builder read `v.Description`; it now reads `v.CustomerReference` (the role
+  the column is named for and the list already sorts by).
+- The intranet product-characteristic list never sorted: it fetched `sorterService.sorter(m.Brand)`, and the
+  matching sorter — whose values are `SerialisedItemCharacteristicType` roles — was registered under the wrong
+  composite key `m.SerialisedItemCharacteristic` while the list pulls `SerialisedItemCharacteristicType`. The
+  sorter is now registered under `m.SerialisedItemCharacteristicType` and the list fetches it, so the name /
+  active columns sort. (No other component fetched the old key.)
+- The intranet serialised-item list never sorted: its pull fetched `sorterService.sorter(m.Brand)` — a
+  composite with no entry in the sorter service, so `sorter(...)` returned undefined and no sorting was
+  applied — even though the pull and result are `SerialisedItem`. It now fetches `sorter(m.SerialisedItem)`,
+  so the id / name / categories / availability columns sort.
+- The intranet ProductCategory list could not be sorted: its sorter was a copy of the Catalogue sorter, so
+  its keys pointed at the foreign `m.Catalogue.*` / `m.Scope.*` roleTypes (which a `ProductCategory` pull has
+  no business sorting by) rather than ProductCategory's own roles. It now sorts by `m.ProductCategory.Name`.
+  (Sorting the `scope` / parent columns would need derived `<Composite>Name` roles on ProductCategory — a
+  dotnet-domain change tracked separately.)
+- The intranet WorkRequirement list's `priority` column sorted by the requirement number, not the priority.
+  Its sort key was `m.WorkRequirement.SortableRequirementNumber` — the same roleType the `number` column uses
+  — so sorting by priority reproduced the number order. It now sorts by `m.WorkRequirement.PriorityName`
+  (mirroring how the `state` column uses `RequirementStateName`).
+- The party `DisplayPhone` workspace derivation prefixed its output with a spurious `", "`. It joined the
+  telecommunications-number display names with `.reduce((acc, cur) => acc + ', ' + cur, '')` seeded with an
+  empty string, so the seed contributed a leading separator (e.g. `", Office, Mobile"`). It now uses
+  `.join(', ')`.
+- The purchase-order-item `TotalIncVat` workspace derivation computed unit VAT on the gross base price
+  instead of the net unit price — the order-side sibling of the purchase-invoice-item fix. `unitVat` was
+  `unitBasePrice * vatRate`, so the line's discounts and surcharges (accumulated into
+  `unitDiscount`/`unitSurcharge` just above) were excluded from the VAT base, and `TotalIncVat` was left
+  inconsistent with the sibling `UnitVat` rule. It now applies the rate to
+  `unitBasePrice - unitDiscount + unitSurcharge`.
+- The purchase-invoice-item `TotalIncVat` workspace derivation computed unit VAT on the gross base price
+  instead of the net unit price. `unitVat` was `unitBasePrice * vatRate`, so the line's discounts and
+  surcharges — already accumulated into `unitDiscount`/`unitSurcharge` just above — were excluded from the VAT
+  base, overstating VAT on discounted lines and understating it on surcharged ones (and leaving `TotalIncVat`
+  inconsistent with the sibling `UnitVat` rule, which already applied the rate to the net price). It now
+  applies the rate to `unitBasePrice - unitDiscount + unitSurcharge`.
+- The extranet work-task create + edit forms bound the FullfillContactMechanism select's options to
+  PartyContactMechanisms instead of ContactMechanisms. `onPostPull` assigned the pulled
+  `CurrentPartyContactMechanisms` (a PartyContactMechanism collection) straight to
+  `contactMechanisms: ContactMechanism[]`; it now maps each to its `.ContactMechanism`, so the picker offers
+  the contact mechanisms the `FullfillContactMechanism` role expects.
 - The employment form no longer overwrites an existing employment's FromDate on edit. `onPostPull` set
   `this.object.FromDate = new Date()` unconditionally, so opening an employment to edit it reset its start
   date to today (persisted on save). The default is now guarded by `this.createRequest`, so only a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,28 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- The base application's **production** bootstrap no longer crashes. The `environment.prod.ts`
+  `APP_INITIALIZER` factory (`appInitFactory`) takes four parameters and assigns
+  `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but its `deps`
+  listed only `[WorkspaceService, HttpClient]` — so Angular injected `undefined` for the third and fourth
+  arguments and the initializer threw a `TypeError` during bootstrap. This is production-only: the dev
+  `environment.ts` already lists all four deps (and the e2e harness serves the dev configuration, so it
+  never exercised the prod file). `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`, matching the factory's parameters.
+- The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
+  domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
+  price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so
+  `SalesInvoiceStateRule` correctly derived `NotPaid` instead of the asserted `PartiallyPaid`. The test-data
+  builders now floor the random unit price at `2`, and a deterministic regression test pins the minimal price
+  so the "one unit short of full payment" boundary is always covered.
+- Test-population organisation builders now generate unique `Organisation.Name` values by construction.
+  `OrganisationBuilderExtensions.WithDefaults`, `WithManufacturerDefaults` and `WithInternalOrganisationDefaults`
+  used Bogus `Company.CompanyName()`, which is not unique, so a population occasionally produced two organisations
+  with the same name — invisible in allors3 core (no name-uniqueness rule) but an intermittent `DerivationException`
+  ("Company with this name already exists") in downstream apps that enforce it. Each generated name now carries a
+  monotonic `Interlocked.Increment` suffix, removing the collisions at the source. (Bogus' `faker.UniqueIndex`
+  only advances inside the `Faker<T>.Generate()` pipeline, which these builders do not use, so a dedicated counter
+  is required.)
 - Reassigning a session-origin one-to-many role to a new association now detaches it from the old one.
   `SessionOriginState.addCompositesRoleOne2Many` set the role's association back-pointer to the role itself
   instead of the association, so the "remove from previous association" step targeted the wrong object and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,119 @@ under a dated version heading.
   corrupted the file, failing a random matrix job. A new `dotnet/Directory.Build.targets` clears the
   `CloudBuildVersionVars` item before the target runs, skipping the emission. Assembly version stamping
   is unaffected, and `cloudBuild.setVersionVariables: false` does **not** gate this MSBuild-side write.
+- The employment form no longer overwrites an existing employment's FromDate on edit. `onPostPull` set
+  `this.object.FromDate = new Date()` unconditionally, so opening an employment to edit it reset its start
+  date to today (persisted on save). The default is now guarded by `this.createRequest`, so only a new
+  employment gets today's date; a loaded one keeps its own.
+- The purchase-invoice create and edit forms had several mis-wired "add new …" inline cards and
+  contact-added handlers, now corrected: the ShipToCustomer add-person card ran
+  `billedFromContactPersonAdded` (now `shipToCustomerContactPersonAdded`); the ShipToEndCustomer
+  add-customer card ran `billToEndCustomerAdded` (now `shipToEndCustomerAdded`); the BillToEndCustomer
+  add-customer card was shown by `*ngIf="addShipToCustomer"` instead of `addBillToEndCustomer`; and two
+  contact-added handlers linked the new `OrganisationContactRelationship` to the wrong organisation —
+  `billToEndCustomerContactPersonAdded` used `ShipToEndCustomer` (now `BillToEndCustomer`) and
+  `shipToCustomerContactPersonAdded` used `BilledFrom` (now `ShipToCustomer`). Each defect was present on
+  both the create and edit forms.
+- Editing a CustomerShipment or PurchaseReturn no longer silently clears its `ShipToAddress` and
+  `ShipToContactPerson` on load. `onPostPull` called `updateShipToParty` without first setting
+  `previousShipToparty`, so the `ShipToParty !== previousShipToparty` guard inside it was true on the initial
+  load and nulled `ShipToAddress` + `ShipToContactPerson` — which then persisted on save (silent data loss on
+  every edit). `onPostPull` now initializes `previousShipToparty` to the loaded `ShipToParty`, so a load is no
+  longer treated as a party change. (The customershipment instance was an unflagged sibling of the reported
+  purchasereturn defect.)
+- The email-communication form's "add a To email" inline card saved the new address to `FromEmail` instead
+  of `ToEmail` (`toEmailAdded`), overwriting the From address and never setting the recipient. It now assigns
+  `ToEmail`. (The sibling `fromEmailAdded` was already correct.)
+- The bill-to-end-customer autocomplete on the sales-invoice (create + edit) and sales-order (edit) forms now
+  fires `billToEndCustomerSelected` instead of `billToCustomerSelected`. The autocomplete binds the
+  `BillToEndCustomer` role correctly, but its `(changed)` handler ran the bill-to-*customer* side-effect
+  (`updateBillToCustomer`), so selecting a bill-to-end-customer loaded the wrong party's contacts and
+  contact-mechanisms into the dependent dropdowns. It now runs `updateBillToEndCustomer`.
+- The UnifiedGood edit form no longer drops product categories on save — the same alias + splice-during-
+  iteration defect as the NonUnifiedGood/NonUnifiedPart edit forms. `onPostPull` set `selectedCategories` to
+  the *same array reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while
+  `splice`-ing the aliased `originalCategories`, skipping every other `ProductCategory`, which the second
+  loop then `removeProduct`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`),
+  so all categories are preserved.
+- The work-effort / purchase-order-item assignment form no longer crashes on open. `onPostPull` filtered the
+  available purchase orders using `this.workEffort.TakenBy` before `workEffort` was assigned (it was set only
+  afterwards), throwing a `TypeError` whenever a candidate order existed. `workEffort` is now established
+  before the filter runs.
+- The customer-shipment create + edit forms now populate the ship-from contact dropdown with the ship-from
+  party's contacts instead of overwriting the ship-to contact options. `updateShipFromParty` assigned the
+  ship-from party's `CurrentContacts` to `shipToContacts` (leaving the declared `shipFromContacts` unused),
+  so on load — where `updateShipToParty` runs first and `updateShipFromParty` overwrites — the ship-to
+  contact dropdown was clobbered with the ship-from party's contacts. It now assigns `shipFromContacts`.
+- The purchase-return create + edit forms had the identical `updateShipFromParty` defect: the ship-from
+  party's `CurrentContacts` were assigned to `shipToContacts` (leaving the declared `shipFromContacts`
+  unused), so the ship-from contact picker stayed empty and the ship-to contact options were overwritten
+  with the ship-from party's contacts. Both forms now assign `shipFromContacts`.
+- The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
+  iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
+  reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the
+  aliased `originalCategories` inside the loop, skipping every other `PartCategory`, which the second loop
+  then `removePart`-ed. `selectedCategories` is now an independent copy (`[...originalCategories]`), so all
+  part categories are preserved.
+- The PositionTypeRate form no longer nulls kept PositionType assignments on save. `onPostPull` set
+  `originalPositionTypes` to the *same array reference* as `selectedPositionTypes`; `save()` then iterated
+  `selectedPositionTypes` while `splice`-ing the aliased `originalPositionTypes`, skipping every other
+  PositionType, which the second loop then set to `PositionTypeRate = null`. Editing a rate with two or more
+  assigned position types and saving unassigned roughly half of them. `originalPositionTypes` is now an
+  independent copy (`[...(selectedPositionTypes ?? [])]`), so all assignments are preserved.
+- The purchase-invoice create + edit forms no longer clear the wrong assigned ship-to address when the
+  ShipToCustomer changes. `updateShipToCustomer`'s change-guard nulled `AssignedShipToEndCustomerAddress`
+  (the *end*-customer's field, correctly owned by `updateShipToEndCustomer`) instead of the ship-to-customer's
+  own `AssignedShipToCustomerAddress` — so changing the ShipToCustomer left its stale address in place (saved
+  against the new customer) while wiping the end-customer's chosen address. It now nulls
+  `AssignedShipToCustomerAddress`, matching the adjacent `ShipToCustomerContactPerson` clear.
+- The supplier-offering form's `currencySelected` no longer throws when a currency is picked before a
+  supplier. Its condition optional-chained `this.object.Supplier?.PreferredCurrency`, but the body assigned
+  `this.object.Supplier.PreferredCurrency` unguarded, so with no supplier selected (the `== null` branch
+  true) it raised a `TypeError`. The assignment is now guarded by `this.object.Supplier`.
+- Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
+  (latent; both hooks are empty today).
+- SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`
+  statement, so databases named after reserved T-SQL keywords (e.g. `Identity`) provision correctly.
+- The NonUnifiedGood edit form no longer drops product categories on save. `onPostPull` assigned the same
+  array reference to both `selectedCategories` and `originalCategories`, so `save()` iterated
+  `selectedCategories` while `splice`-ing the aliased `originalCategories` inside that loop — a
+  splice-during-iteration that skipped every other category, which the second loop then `removeProduct`-ed
+  from the good. Editing a good with two or more categories and saving dropped roughly half of them.
+  `selectedCategories` is now an independent copy (`[...originalCategories]`, with the source `?? []`-guarded
+  for the spread), so all categories are preserved.
+- Effects watching composites roles (or derived list roles) no longer rerun on every unrelated session
+  write. Those signals rebuild their list on every recompute, and the default reference-equality comparer
+  counted each fresh array as a change. `ISignalFactory.Computed` now accepts an optional
+  `IEqualityComparer<T>` (mirroring `State`), and the adapter passes element-wise comparers for composites
+  and derived role signals, restoring the value cutoff.
+- Effects no longer run between the record merges of a single pull, push response or reset. Every merged
+  record bumped the session graph revision — and flushed effects — individually, so an effect reading roles
+  of two pulled objects observed the first object updated while the second still held its stale values
+  (and large pulls paid one full propagation per record). Multi-record operations now hold the revision and
+  bump once at the end (`Session.HoldGraph`/`ReleaseGraph`), so effects observe only the fully merged state.
+- Effects no longer observe torn state or run twice per change. The effect scheduler flushed as soon as
+  the first effect was enqueued, while the propagation walk was still marking the remaining subscribers —
+  an effect reading two computeds derived from the same signal ran once with one fresh and one stale value,
+  then again after the walk finished. `Propagation.Propagate` now holds every touched scheduler for the
+  duration of the walk and releases (flushes) them only after all reachable nodes are marked, so each
+  change produces exactly one consistent effect run.
+- A role write performed inside an effect no longer re-runs that effect forever. `Session.TouchGraph`
+  bumped the graph revision by reading the revision signal through its tracked getter, so the writing
+  effect subscribed itself to the session-wide revision — always recorded one version behind the bump —
+  and was re-scheduled after every flush. The bump now comes from an untracked backing counter, so
+  writers never become subscribers of the revision they bump.
+- Disposing a parent effect scope while a nested child scope was the active scope no longer leaves the
+  signals engine's active scope pointing at the disposed parent. `EffectScopeNode.Dispose` only restored the
+  active scope when it was exactly the disposed node, but disposal recurses into child scopes, so the child's
+  restore re-targeted its already-disposed (and already unlinked) parent — and effects created afterwards
+  registered under that disposed scope, where no outer scope could ever dispose them. `Dispose` now restores
+  the active scope whenever it lies anywhere in the disposed subtree, so it lands on the disposed scope's
+  outer scope.
+- The apps-intranet application's **production** bootstrap no longer crashes — the same `environment.prod.ts`
+  `APP_INITIALIZER` defect as the base app. The four-parameter `appInitFactory` had only
+  `deps: [WorkspaceService, HttpClient]`, so `createService`/`editService` were injected as `undefined` and
+  the initializer threw a `TypeError` at bootstrap. `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`. Production-only: the dev `environment.ts` was already correct.
 - The base application's **production** bootstrap no longer crashes. The `environment.prod.ts`
   `APP_INITIALIZER` factory (`appInitFactory`) takes four parameters and assigns
   `createService.createControlByObjectTypeTag` / `editService.editControlByObjectTypeTag`, but its `deps`

--- a/typescript/e2e/Base/Tests/Base/Generic/OverviewPagesTest.cs
+++ b/typescript/e2e/Base/Tests/Base/Generic/OverviewPagesTest.cs
@@ -120,7 +120,7 @@ namespace Tests.E2E.Generic
                                 var rows = objectRelation.Locator("tr[data-allors-id]");
                                 for (var j = 0; j < await rows.CountAsync(); j++)
                                 {
-                                    var row = rows.Nth(i);
+                                    var row = rows.Nth(j);
 
                                     await row.ClickAsync();
 

--- a/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
+++ b/typescript/e2e/Base/Tests/Custom/Objects/PersonTest.cs
@@ -228,5 +228,55 @@ namespace Tests.E2E.Objects
             // throws); without the fix the table is empty and the console-error TearDown trips.
             ClassicAssert.Contains(employment.Strategy.ObjectId.ToString(), objectIds);
         }
+
+        [Test]
+        public async Task EditEmploymentPreservesFromDate()
+        {
+            // Build a dedicated employment with a known FromDate (well in the past, not today), so editing
+            // it must not silently reset FromDate. Self-contained: independent of population/order.
+            var person = new People(this.Transaction).FindBy(this.M.Person.FirstName, "John");
+            var employer = new OrganisationBuilder(this.Transaction).WithName("Employer For FromDate E2E").Build();
+            var fromDate = this.Transaction.Now().AddDays(-30);
+
+            var employment = new EmploymentBuilder(this.Transaction)
+                .WithEmployee(person)
+                .WithEmployer(employer)
+                .WithFromDate(fromDate)
+                .Build();
+
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
+            var @class = this.M.Person;
+
+            var overview = this.Application.GetOverview(@class);
+            var url = overview.RouteInfo.FullPath.Replace(":id", $"{person.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var personOverview = new PersonOverviewPageComponent(this.AppRoot);
+
+            await personOverview.ViewEmployment.Locator.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var edit = personOverview.EditEmployment;
+            await edit.Table.DefaultAction(employment);
+            await this.Page.WaitForAngular();
+
+            var form = new EmploymentFormComponent(this.OverlayContainer);
+
+            // The form's onPostPull is the suspect; dirty an unrelated field (ThroughDate) so SAVE enables
+            // even after the fix (which no longer touches FromDate on load).
+            await form.ThroughDateDatepicker.SetAsync(this.Transaction.Now());
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.OverlayContainer);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            ClassicAssert.AreEqual(fromDate.Date, employment.FromDate.Date, "FromDate was overwritten on edit");
+        }
     }
 }

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/employment/form/employment-form.component.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/employment/form/employment-form.component.ts
@@ -68,6 +68,8 @@ export class EmploymentFormComponent extends AllorsFormComponent<Employment> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.object.FromDate = new Date();
+    if (this.createRequest) {
+      this.object.FromDate = new Date();
+    }
   }
 }

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/person/overview/person-overview-page.component.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/app/domain/person/overview/person-overview-page.component.ts
@@ -59,7 +59,7 @@ export class PersonOverviewPageComponent extends AllorsOverviewPageComponent {
     } = this;
 
     pulls.push(
-      p.Organisation({
+      p.Person({
         name: prefix,
         objectId: this.scoped.id,
       })

--- a/typescript/modules/apps/base/workspace/angular-material/application-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/base/workspace/angular-material/application-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],


### PR DESCRIPTION
**Batch 2 of the bugfix-review integration** — scope `base` (the `apps/base` Angular app + its e2e). Cherry-picked (`-x`, original authors preserved) from `bugfix-review`, oldest-first; CHANGELOG auto-unioned.

| Fix | Ref | Commit |
|-----|----|--------|
| add missing CreateService/EditDialogService to **prod** APP_INITIALIZER deps | #100 | `becf8607a4` |
| `[BUG-01]` preserve employment FromDate on edit (only default on create) | #120 | `a60faf5f59` |
| `[BUG-21]` test: iterate rows by inner loop var in `OverviewPagesTest` | #138 | `6725aafde1` |
| `[BUG-01]` pull `Person` (not `Organisation`) in person overview | #133 | `84124b6dbc` |

⚠️ **Coverage note:** the relevant verification is `CiTypescriptE2EAngularBaseTest` (e2e), which is **not** in the required-checks gate — the 11 required checks don't exercise app/UI fixes. The prod-config fix (#100) isn't CI-covered at all (verified correct by inspection).

Claude review brief follows.
