### PR TITLE
fix: integrate batch 3 — apps-extranet + singletons (+ CHANGELOG union driver)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 
 *.csproj text merge=union
 *.sln    text merge=union
+CHANGELOG.md merge=union
 
 yarn.lock merge=ours
 package-lock.json merge=ours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ under a dated version heading.
   re-triggers downstream cost derivations.
 
 ### Added
+### Fixed
+
+- Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
+  (latent; both hooks are empty today).
+- SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`
+  statement, so databases named after reserved T-SQL keywords (e.g. `Identity`) provision correctly.
 
 - `WorkRequirement.WorkEffortPurpose` (enumeration Refurbishment / Maintenance / Repair): defaults to
   **Repair** on init, is copied onto the `WorkTask` created by `CreateWorkTask`, and is mirrored into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,11 @@ under a dated version heading.
   `environment.ts` already lists all four deps (and the e2e harness serves the dev configuration, so it
   never exercised the prod file). `deps` now also lists `AllorsMaterialCreateService` and
   `AllorsMaterialEditDialogService`, matching the factory's parameters.
+- The apps-extranet application's **production** bootstrap no longer crashes — the same `environment.prod.ts`
+  `APP_INITIALIZER` defect as the base and intranet apps. The four-parameter `appInitFactory` had only
+  `deps: [WorkspaceService, HttpClient]`, so `createService`/`editService` were injected as `undefined` and
+  the initializer threw a `TypeError` at bootstrap. `deps` now also lists `AllorsMaterialCreateService` and
+  `AllorsMaterialEditDialogService`. Production-only: the dev `environment.ts` was already correct.
 - The `SalesInvoiceStateRuleTests.ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePartiallyPaid`
   domain test no longer flakes (~1% of CI runs). `SalesInvoiceItemBuilder.WithDefaults()` drew a random unit
   price in `[1, 100]`; when it rolled `1` the test's `TotalIncVat - 1` partial payment was `0`, so

--- a/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
+++ b/dotnet/Apps/Database/Domain.Tests/Invoice/Salesinvoicetests.cs
@@ -2090,6 +2090,39 @@ namespace Allors.Database.Domain.Tests
         }
 
         [Fact]
+        public void ChangedSalesInvoiceItemAmountPaidAtMinimalUnitPriceDeriveSalesInvoiceItemStatePartiallyPaid()
+        {
+            // Regression for a flaky CI failure: WithDefaults() draws a random unit price; a price of 1 made the
+            // `TotalIncVat - 1` payment 0, deriving NotPaid. Pin the minimal sensible price (qty 1 from defaults)
+            // so the boundary (one unit short of full payment) is covered deterministically instead of ~1% of the time.
+            var invoice = new SalesInvoiceBuilder(this.Transaction).WithDefaultsWithoutItems(this.InternalOrganisation).Build();
+
+            this.Transaction.Derive();
+
+            var invoiceItem = new SalesInvoiceItemBuilder(this.Transaction).WithDefaults().Build();
+            invoiceItem.AssignedUnitPrice = 2M;
+            invoice.AddSalesInvoiceItem(invoiceItem);
+            this.Transaction.Derive();
+
+            invoice.Send();
+            this.Transaction.Derive();
+
+            var partialAmount = invoiceItem.TotalIncVat - 1;
+            new ReceiptBuilder(this.Transaction)
+                .WithAmount(partialAmount)
+                .WithEffectiveDate(this.Transaction.Now())
+                .WithPaymentApplication(new PaymentApplicationBuilder(this.Transaction)
+                                            .WithAmountApplied(partialAmount)
+                                            .WithInvoiceItem(invoiceItem)
+                                            .Build())
+                .Build();
+
+            this.Transaction.Derive();
+
+            Assert.Equal(invoiceItem.SalesInvoiceItemState, new SalesInvoiceItemStates(this.Transaction).PartiallyPaid);
+        }
+
+        [Fact]
         public void ChangedSalesInvoiceItemAmountPaidDeriveSalesInvoiceItemStatePaid()
         {
             var invoice = new SalesInvoiceBuilder(this.Transaction).WithDefaultsWithoutItems(this.InternalOrganisation).Build();

--- a/dotnet/Apps/Database/TestPopulation.Tests/SetupConfigurationTests.cs
+++ b/dotnet/Apps/Database/TestPopulation.Tests/SetupConfigurationTests.cs
@@ -5,7 +5,9 @@
 
 namespace Allors.Database.Domain.Tests
 {
+    using System.Collections.Generic;
     using System.Linq;
+    using Allors.Database.Domain.TestPopulation;
     using Xunit;
 
     public class SetupConfigurationTests : DomainTest, IClassFixture<Fixture>
@@ -19,6 +21,23 @@ namespace Allors.Database.Domain.Tests
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "dutchInternalOrganisation");
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "Ned. Belastingdienst");
             Assert.Contains(internalOrganisations.Select(v => v.DisplayName).ToArray(), v => v == "Federale OverheidsDienst FINANCIËN");
+        }
+
+        [Fact]
+        public void OrganisationDefaultsGenerateUniqueNames()
+        {
+            const int countPerMethod = 500;
+            var faker = this.Transaction.Faker();
+            var names = new List<string>(countPerMethod * 3);
+
+            for (var i = 0; i < countPerMethod; i++)
+            {
+                names.Add(new OrganisationBuilder(this.Transaction).WithDefaults().Build().Name);
+                names.Add(new OrganisationBuilder(this.Transaction).WithManufacturerDefaults(faker).Build().Name);
+                names.Add(new OrganisationBuilder(this.Transaction).WithInternalOrganisationDefaults().Build().Name);
+            }
+
+            Assert.Equal(names.Count, names.Distinct().Count());
         }
     }
 }

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Invoice/SalesInvoiceItemBuilderExtensions.cs
@@ -29,7 +29,10 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithInvoiceItemType(faker.Random.ListItem(otherInvoiceItemTypes))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                // Floor 2, not 1: several invoice tests form a partial payment as `TotalIncVat - 1`,
+                // which must stay > 0. A unit price of 1 makes it 0, so the derivation yields NotPaid
+                // instead of PartiallyPaid and flakes those tests (this Faker is unseeded/random).
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -53,7 +56,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -73,7 +76,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }
@@ -98,7 +101,7 @@ namespace Allors.Database.Domain.TestPopulation
                 .WithNextSerialisedItemAvailability(faker.Random.ListItem(@this.Transaction.Extent<SerialisedItemAvailability>()))
                 .WithMessage(faker.Lorem.Sentence())
                 .WithQuantity(1)
-                .WithAssignedUnitPrice(faker.Random.UInt(1, 100));
+                .WithAssignedUnitPrice(faker.Random.UInt(2, 100));
 
             return @this;
         }

--- a/dotnet/Apps/Database/TestPopulation/Apps/Builders/Relation/OrganisationBuilderExtensions.cs
+++ b/dotnet/Apps/Database/TestPopulation/Apps/Builders/Relation/OrganisationBuilderExtensions.cs
@@ -6,12 +6,18 @@
 namespace Allors.Database.Domain.TestPopulation
 {
     using System.Linq;
+    using System.Threading;
     using Bogus;
     using Meta;
     using LegalForm = LegalForm;
 
     public static partial class OrganisationBuilderExtensions
     {
+        // Monotonic suffix that makes generated organisation names unique by construction.
+        // Bogus' faker.UniqueIndex/IndexGlobal only advance inside the Faker<T>.Generate() pipeline,
+        // which these builders do not use, so a dedicated counter is required.
+        private static int uniqueNameIndex;
+
         public static OrganisationBuilder WithDefaults(this OrganisationBuilder @this)
         {
             var m = @this.Transaction.Database.Services.Get<MetaPopulation>();
@@ -19,7 +25,7 @@ namespace Allors.Database.Domain.TestPopulation
 
             var euCountry = new Countries(@this.Transaction).FindBy(m.Country.IsoCode, faker.PickRandom(Countries.EuMemberStates));
 
-            @this.WithName(faker.Company.CompanyName())
+            @this.WithName($"{faker.Company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithEuListingState(euCountry)
                 .WithLegalForm(faker.Random.ListItem(@this.Transaction.Extent<LegalForm>()))
                 .WithLocale(faker.Random.ListItem(@this.Transaction.GetSingleton().Locales.ToArray()))
@@ -33,7 +39,7 @@ namespace Allors.Database.Domain.TestPopulation
         {
             var company = faker.Company;
 
-            @this.WithName(company.CompanyName())
+            @this.WithName($"{company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithIsManufacturer(true);
 
             return @this;
@@ -47,7 +53,7 @@ namespace Allors.Database.Domain.TestPopulation
             var company = faker.Company;
             var euCountry = new Countries(@this.Transaction).FindBy(m.Country.IsoCode, faker.PickRandom(Countries.EuMemberStates));
 
-            @this.WithName(company.CompanyName())
+            @this.WithName($"{company.CompanyName()} {Interlocked.Increment(ref uniqueNameIndex)}")
                 .WithEuListingState(euCountry)
                 .WithLegalForm(faker.Random.ListItem(@this.Transaction.Extent<LegalForm>()))
                 .WithLocale(faker.Random.ListItem(@this.Transaction.GetSingleton().Locales.ToArray()))

--- a/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Initialization.cs
+++ b/dotnet/System/Database/Adapters/Allors.Database.Adapters.Sql.SqlClient/Schema/Initialization.cs
@@ -71,7 +71,7 @@ namespace Allors.Database.Adapters.Sql.SqlClient
             {
                 var cmdText = $@"
 IF ((SELECT SNAPSHOT_ISOLATION_STATE FROM SYS.DATABASES WHERE NAME = '{connection.Database}') = 0)
-alter Database {connection.Database}
+alter Database [{connection.Database}]
 set allow_snapshot_isolation on";
                 using var command = new SqlCommand(cmdText, connection);
                 command.ExecuteNonQuery();

--- a/typescript/e2e/Scaffold/ComponentModels/AssociationComponentModel.cs
+++ b/typescript/e2e/Scaffold/ComponentModels/AssociationComponentModel.cs
@@ -53,15 +53,19 @@ namespace Scaffold
             {
             }
 
-            public override ComponentModel? Build(IElement element) =>
-                TypeByTag.ContainsKey(element.TagName.ToLowerInvariant())
+            public override ComponentModel? Build(IElement element)
+            {
+                var tag = element.TagName.ToLowerInvariant();
+                return TypeByTag.ContainsKey(tag) &&
+                       element.GetAttribute("[associationType]") != null
                     ? new AssociationComponentModel(element)
                     : base.Build(element);
+            }
         }
 
         public override bool Equals(object? obj)
         {
-            if (obj is RoleComponentModel that)
+            if (obj is AssociationComponentModel that)
             {
                 return string.Equals(this.Property, that.Property) &&
                        string.Equals(this.Type, that.Type) &&

--- a/typescript/e2e/Scaffold/ComponentModels/RoleComponentModel.cs
+++ b/typescript/e2e/Scaffold/ComponentModels/RoleComponentModel.cs
@@ -86,10 +86,15 @@ namespace Scaffold
             {
             }
 
-            public override ComponentModel? Build(IElement element) =>
-                TypeByTag.ContainsKey(element.TagName.ToLowerInvariant())
+            public override ComponentModel? Build(IElement element)
+            {
+                var tag = element.TagName.ToLowerInvariant();
+                return TypeByTag.ContainsKey(tag) &&
+                       (tag != "a-mat-autocomplete" ||
+                        element.GetAttribute("[roleType]") != null)
                     ? new RoleComponentModel(element)
                     : base.Build(element);
+            }
         }
 
         public override bool Equals(object? obj)

--- a/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/app/main/main.component.ts
+++ b/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/app/main/main.component.ts
@@ -29,6 +29,7 @@ export class MainComponent implements OnInit, OnDestroy {
 
   sideMenuItems: SideMenuItem[] = [];
 
+  private routerSubscription: Subscription;
   private toggleSubscription: Subscription;
   private openSubscription: Subscription;
   private closeSubscription: Subscription;
@@ -75,7 +76,7 @@ export class MainComponent implements OnInit, OnDestroy {
     });
 
     this.router.onSameUrlNavigation = 'reload';
-    this.router.events
+    this.routerSubscription = this.router.events
       .pipe(filter((v) => v instanceof NavigationEnd))
       .subscribe(() => {
         if (this.sidenav) {
@@ -97,6 +98,7 @@ export class MainComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.routerSubscription.unsubscribe();
     this.toggleSubscription.unsubscribe();
     this.openSubscription.unsubscribe();
     this.closeSubscription.unsubscribe();

--- a/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/apps-extranet/workspace/angular-material-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],

--- a/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/create/worktask-create-form.component.ts
+++ b/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/create/worktask-create-form.component.ts
@@ -3,6 +3,7 @@ import { Component, Self } from '@angular/core';
 import {
   Person,
   ContactMechanism,
+  PartyContactMechanism,
   WorkTask,
 } from '@allors/default/workspace/domain';
 import {
@@ -89,8 +90,9 @@ export class WorkTaskCreateFormComponent extends AllorsFormComponent<WorkTask> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.contactMechanisms =
-      pullResult.collection<ContactMechanism>('contactmechanisms');
+    this.contactMechanisms = pullResult
+      .collection<PartyContactMechanism>('contactmechanisms')
+      ?.map((v) => v.ContactMechanism);
     this.contacts = pullResult.collection<Person>('contacts');
   }
 }

--- a/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/edit/worktask-edit-form.component.ts
+++ b/typescript/modules/libs/apps-extranet/workspace/angular-material/src/lib/domain/worktask/edit/worktask-edit-form.component.ts
@@ -10,6 +10,7 @@ import { IPullResult, Pull } from '@allors/system/workspace/domain';
 import { NgForm } from '@angular/forms';
 import {
   ContactMechanism,
+  PartyContactMechanism,
   Person,
   WorkTask,
 } from '@allors/default/workspace/domain';
@@ -97,8 +98,9 @@ export class WorkTaskEditFormComponent extends AllorsFormComponent<WorkTask> {
 
     this.onPostPullInitialize(pullResult);
 
-    this.contactMechanisms =
-      pullResult.collection<ContactMechanism>('contactmechanisms');
+    this.contactMechanisms = pullResult
+      .collection<PartyContactMechanism>('contactmechanisms')
+      ?.map((v) => v.ContactMechanism);
     this.contacts = pullResult.collection<Person>('contacts');
   }
 }


### PR DESCRIPTION
**Batch 3 of the bugfix-review integration.** First commit adds `CHANGELOG.md merge=union` to `.gitattributes` (consistent with the existing `*.csproj`/`*.sln` union entries) — this ends the recurring CHANGELOG cherry-pick/rebase conflicts; **already proven** here (all 7 cherry-picks auto-merged the changelog with zero conflicts). Then 7 fixes cherry-picked (`-x`, oldest-first, original authors).

| Fix | Ref | Commit |
|-----|-----|--------|
| chore: `CHANGELOG.md merge=union` | — | `56d98af4ec` |
| testpopulation: unique org names by construction | #95 | `4c8a63e011` |
| invoice: de-flake partial-payment test (unit-price floor 2) | #96 | `dc2929dcfc` |
| adapters: bracket DB name for snapshot isolation | — | `bd3abc2677` |
| apps-extranet: prod APP_INITIALIZER deps | #103 | `81e84d5242` |
| apps-extranet: bind `FullfillContactMechanism` options `[BUG-05/06]` | #121 | `c03a5ed021` |
| apps-extranet: unsubscribe MainComponent router.events `[BUG-08]` | #136 | `54ede1bec1` |
| e2e: distinguish role vs association autocompletes `[BUG-18]` | #139 | `a4da2eb985` |

⚠️ **Coverage:** `apps-extranet` has **no e2e required check**, so #103/#121/#136 are verified by inspection only (the `adapters` SQL fix and the two test/test-infra fixes *are* covered by required dotnet checks). Claude review brief follows.
