### PR TITLE
chore(e2e): bump Microsoft.Playwright from 1.59.0 to 1.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ under a dated version heading.
 
 ### Changed
 
+- Updated the e2e test projects' `Microsoft.Playwright` dependency from 1.59.0 to 1.61.0.
 - The part weighted-average cost is now maintained by a dedicated `PartWeightedAverageRule` that only
   recomputes when stock is received, instead of `PartQuantitiesRule` re-reading a part's entire
   inventory-transaction history on every inventory transaction. Consumption transactions (e.g. parts

--- a/typescript/e2e/AppsIntranet/E2E/Allors.E2E.csproj
+++ b/typescript/e2e/AppsIntranet/E2E/Allors.E2E.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
   </ItemGroup>
 
 

--- a/typescript/e2e/AppsIntranet/Tests/Tests.csproj
+++ b/typescript/e2e/AppsIntranet/Tests/Tests.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
 		<PackageReference Include="NUnit" Version="4.6.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 	</ItemGroup>

--- a/typescript/e2e/Base/E2E/Allors.E2E.csproj
+++ b/typescript/e2e/Base/E2E/Allors.E2E.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/typescript/e2e/Base/Tests/Tests.csproj
+++ b/typescript/e2e/Base/Tests/Tests.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
 		<PackageReference Include="NUnit" Version="4.6.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary

Bumps the `Microsoft.Playwright` package reference from **1.59.0** to **1.61.0** across the four e2e test projects:

- `typescript/e2e/AppsIntranet/E2E/Allors.E2E.csproj`
- `typescript/e2e/AppsIntranet/Tests/Tests.csproj`
- `typescript/e2e/Base/E2E/Allors.E2E.csproj`
- `typescript/e2e/Base/Tests/Tests.csproj`

`CHANGELOG.md` updated under `[Unreleased] → Changed`.

## Notes

Dependency-only change; no production or library code touched.