### PR TITLE
fix(apps-intranet): batch 4a — edit/create form data preservation [#104-107, 117, 119]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,10 @@ under a dated version heading.
   party's `CurrentContacts` were assigned to `shipToContacts` (leaving the declared `shipFromContacts`
   unused), so the ship-from contact picker stayed empty and the ship-to contact options were overwritten
   with the ship-from party's contacts. Both forms now assign `shipFromContacts`.
+- The base-price form's create-time defaults are no longer applied on edit. `onPostPull` unconditionally set
+  `FromDate = new Date()` and `PricedBy = internalOrganisation`, so editing an existing BasePrice reset its
+  effective-from date to today and its priced-by (persisted on save). Both are now guarded by
+  `this.createRequest`, so a loaded BasePrice keeps its own values.
 - The NonUnifiedPart edit form no longer drops part categories on save — the same alias + splice-during-
   iteration defect as the NonUnifiedGood edit form. `onPostPull` set `selectedCategories` to the *same array
   reference* as `originalCategories`; `onSave()` then iterated `selectedCategories` while `splice`-ing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,11 @@ under a dated version heading.
   true) it raised a `TypeError`. The assignment is now guarded by `this.object.Supplier`.
 - Apps `Setup.v.cs` dispatched `BaseOnPreSetup` from `OnPrePrepare` instead of `BaseOnPrePrepare`
   (latent; both hooks are empty today).
+- The UnifiedGood create form showed its manual ProductNumber input based on `settings.UseGlobalProductNumber`,
+  but the bound `ProductNumber` is created (and added to the good) based on `settings.UseProductNumberCounter`.
+  With the settings disagreeing, the field could be hidden while an empty product-number identification was
+  attached, or shown bound to `undefined`. The input is now gated on `!settings.UseProductNumberCounter`,
+  matching its creation.
 - SQL Server `AllowSnapshotIsolation` now brackets the database name in its `ALTER DATABASE`
   statement, so databases named after reserved T-SQL keywords (e.g. `Identity`) provision correctly.
 - The NonUnifiedGood edit form no longer drops product categories on save. `onPostPull` assigned the same

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedGoodTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedGoodTest.cs
@@ -99,5 +99,87 @@ namespace Tests.E2E.Objects
             ClassicAssert.AreEqual("Dit is een test description", nonUnifiedGood.Description);
         }
 
+        [Test]
+        public async Task EditNonUnifiedGoodPreservesCategories()
+        {
+            var good = new NonUnifiedGoods(this.Transaction).Extent()
+                .First(v => v.ProductCategoriesWhereProduct.Count() >= 2);
+            var originalCategories = good.ProductCategoriesWhereProduct.ToArray();
+
+            var @class = this.M.NonUnifiedGood;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new NonunifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new NonunifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.DescriptionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            var after = good.ProductCategoriesWhereProduct.ToArray();
+            foreach (var category in originalCategories)
+            {
+                ClassicAssert.Contains(category, after, $"category '{category.Name}' was dropped on save");
+            }
+
+            ClassicAssert.AreEqual(originalCategories.Length, after.Length);
+        }
+
+        [Test]
+        public async Task EditNonUnifiedGoodWithoutCategoriesDoesNotThrow()
+        {
+            // A freshly-created good has no product categories; editing+saving it must not throw.
+            var part = new NonUnifiedParts(this.Transaction).Extent().First();
+
+            var @class = this.M.NonUnifiedGood;
+
+            var list = this.Application.GetList(@class);
+            await this.Page.GotoAsync(list.RouteInfo.FullPath);
+            await this.Page.WaitForAngular();
+
+            var factory = new FactoryFabComponent(this.AppRoot);
+            await factory.Create(@class);
+            await this.Page.WaitForAngular();
+
+            var createForm = new NonunifiedgoodCreateFormComponent(this.OverlayContainer);
+            await createForm.NameInput.SetValueAsync("CategorylessGood");
+            await createForm.PartAutocomplete.SelectAsync(part.DisplayName);
+            await new Button(createForm, "text=SAVE").ClickAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+            var good = new NonUnifiedGoods(this.Transaction).Extent().First(v => v.Name == "CategorylessGood");
+            ClassicAssert.IsEmpty(good.ProductCategoriesWhereProduct);
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new NonunifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new NonunifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.DescriptionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+            ClassicAssert.IsEmpty(good.ProductCategoriesWhereProduct);
+        }
+
     }
 }

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedPartTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/NonUnifiedPartTest.cs
@@ -114,5 +114,41 @@ namespace Tests.E2E.Objects
             ClassicAssert.AreEqual("4202 21", nonUnifiedPart.HsCode);
         }
 
+        [Test]
+        public async Task EditNonUnifiedPartPreservesCategories()
+        {
+            var part = new NonUnifiedParts(this.Transaction).Extent()
+                .First(v => v.PartCategoriesWherePart.Count() >= 2);
+            var originalCategories = part.PartCategoriesWherePart.ToArray();
+
+            var @class = this.M.NonUnifiedPart;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{part.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new NonunifiedpartOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new NonunifiedpartEditFormComponent(this.AppRoot);
+            await editForm.NameInput.SetValueAsync("Edited NonUnifiedPart");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            var after = part.PartCategoriesWherePart.ToArray();
+            foreach (var category in originalCategories)
+            {
+                ClassicAssert.Contains(category, after, $"part category '{category.Name}' was dropped on save");
+            }
+
+            ClassicAssert.AreEqual(originalCategories.Length, after.Length);
+        }
+
     }
 }

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/UnifiedGoodTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/UnifiedGoodTest.cs
@@ -98,5 +98,41 @@ namespace Tests.E2E.Objects
             ClassicAssert.AreEqual(productType, unifiedGood.ProductType);
         }
 
+        [Test]
+        public async Task EditUnifiedGoodPreservesCategories()
+        {
+            var good = new UnifiedGoods(this.Transaction).Extent()
+                .First(v => v.ProductCategoriesWhereProduct.Count() >= 2);
+            var originalCategories = good.ProductCategoriesWhereProduct.ToArray();
+
+            var @class = this.M.UnifiedGood;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{good.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new UnifiedgoodOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new UnifiedgoodEditFormComponent(this.AppRoot);
+            await editForm.NameInput.SetValueAsync("Edited UnifiedGood");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            var after = good.ProductCategoriesWhereProduct.ToArray();
+            foreach (var category in originalCategories)
+            {
+                ClassicAssert.Contains(category, after, $"category '{category.Name}' was dropped on save");
+            }
+
+            ClassicAssert.AreEqual(originalCategories.Length, after.Length);
+        }
+
     }
 }

--- a/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
@@ -422,6 +422,11 @@ namespace Tests
 
             new PartCategoryBuilder(this.Transaction).WithDefaults().Build();
 
+            var e2ePartCategoryA = new PartCategoryBuilder(this.Transaction).WithName("E2E Part Category A").Build();
+            var e2ePartCategoryB = new PartCategoryBuilder(this.Transaction).WithName("E2E Part Category B").Build();
+            e2ePartCategoryA.AddPart(good_2.Part);
+            e2ePartCategoryB.AddPart(good_2.Part);
+
             this.Transaction.Derive();
 
             new IndustryClassificationBuilder(this.Transaction).WithDefaults().Build();

--- a/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
@@ -314,6 +314,7 @@ namespace Tests
                 .WithName("Best selling gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Meest verkochte gizmo's").WithLocale(dutchLocale).Build())
                 .WithProduct(good_3)
+                .WithProduct(good_4)
                 .Build();
 
             var productCategory_2 = new ProductCategoryBuilder(this.Transaction)
@@ -321,6 +322,7 @@ namespace Tests
                 .WithName("Big Gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Grote Gizmo's").WithLocale(dutchLocale).Build())
                 .WithProduct(good_3)
+                .WithProduct(good_4)
                 .Build();
 
             var productCategory_3 = new ProductCategoryBuilder(this.Transaction)

--- a/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/IntranetPopulation.cs
@@ -313,12 +313,14 @@ namespace Tests
                 .WithInternalOrganisation(allors)
                 .WithName("Best selling gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Meest verkochte gizmo's").WithLocale(dutchLocale).Build())
+                .WithProduct(good_3)
                 .Build();
 
             var productCategory_2 = new ProductCategoryBuilder(this.Transaction)
                 .WithInternalOrganisation(allors)
                 .WithName("Big Gizmo's")
                 .WithLocalisedName(new LocalisedTextBuilder(this.Transaction).WithText("Grote Gizmo's").WithLocale(dutchLocale).Build())
+                .WithProduct(good_3)
                 .Build();
 
             var productCategory_3 = new ProductCategoryBuilder(this.Transaction)

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/baseprice/form/baseprice-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/baseprice/form/baseprice-form.component.ts
@@ -67,7 +67,9 @@ export class BasepriceFormComponent extends AllorsFormComponent<BasePrice> {
     this.internalOrganisation =
       this.fetcher.getInternalOrganisation(pullResult);
 
-    this.object.FromDate = new Date();
-    this.object.PricedBy = this.internalOrganisation;
+    if (this.createRequest) {
+      this.object.FromDate = new Date();
+      this.object.PricedBy = this.internalOrganisation;
+    }
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedgood/edit/nonunifiedgood-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedgood/edit/nonunifiedgood-edit-form.component.ts
@@ -124,8 +124,8 @@ export class NonUnifiedGoodEditFormComponent extends AllorsFormComponent<NonUnif
     this.onPostPullInitialize(pullResult);
 
     this.originalCategories =
-      pullResult.collection<ProductCategory>('OriginalCategories');
-    this.selectedCategories = this.originalCategories;
+      pullResult.collection<ProductCategory>('OriginalCategories') ?? [];
+    this.selectedCategories = [...this.originalCategories];
 
     this.categories = pullResult.collection<ProductCategory>(
       this.m.ProductCategory

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/edit/nonunifiedpart-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/edit/nonunifiedpart-edit-form.component.ts
@@ -148,7 +148,7 @@ export class NonUnifiedPartEditFormComponent extends AllorsFormComponent<NonUnif
 
     this.originalCategories =
       pullResult.collection<PartCategory>('OriginalCategories') ?? [];
-    this.selectedCategories = this.originalCategories;
+    this.selectedCategories = [...this.originalCategories];
 
     this.inventoryItemKinds = pullResult.collection<InventoryItemKind>(
       this.m.InventoryItemKind

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/positiontyperate/form/positiontyperate-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/positiontyperate/form/positiontyperate-form.component.ts
@@ -92,7 +92,7 @@ export class PositionTypeRateFormComponent extends AllorsFormComponent<PositionT
     this.selectedPositionTypes = this.positionTypes?.filter(
       (v) => v.PositionTypeRate === this.object
     );
-    this.originalPositionTypes = this.selectedPositionTypes;
+    this.originalPositionTypes = [...(this.selectedPositionTypes ?? [])];
 
     if (this.createRequest) {
       this.object.Frequency = hour;

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/create/unifiedgood-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/create/unifiedgood-create-form.component.html
@@ -2,7 +2,7 @@
   <div class="row pt-3">
     <a-mat-input
       class="col-md"
-      *ngIf="!settings.UseGlobalProductNumber"
+      *ngIf="!settings.UseProductNumberCounter"
       [object]="productNumber"
       [roleType]="m.ProductNumber.Identification"
     ></a-mat-input>

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/edit/unifiedgood-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/unifiedgood/edit/unifiedgood-edit-form.component.ts
@@ -161,7 +161,7 @@ export class UnifiedGoodEditFormComponent extends AllorsFormComponent<UnifiedGoo
 
     this.originalCategories =
       pullResult.collection<ProductCategory>('OriginalCategories') ?? [];
-    this.selectedCategories = this.originalCategories;
+    this.selectedCategories = [...this.originalCategories];
 
     this.inventoryItemKinds = pullResult.collection<InventoryItemKind>(
       this.m.InventoryItemKind


### PR DESCRIPTION
**Batch 4a** of the bugfix-review integration — `apps-intranet` edit/create form data preservation. Cherry-picked (`-x`, original authors); CHANGELOG auto-unioned via the new driver.

| Fix | Ref | Commit |
|-----|-----|--------|
| keep product categories editing NonUnifiedGood | #104 | `1fe4e8abde` |
| keep part categories editing NonUnifiedPart | #105 | `bbba760062` |
| keep product categories editing UnifiedGood | #106 | `e8275cb3d3` |
| keep PositionType assignments editing PositionTypeRate | #107 | `388b700008` |
| gate UnifiedGood ProductNumber on `UseProductNumberCounter` `[BUG-30]` | #117 | `e57f158382` |
| only default BasePrice FromDate/PricedBy on create `[BUG-D1]` | #119 | `41af81b1bb` |

Exercised by the required `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` (+ added e2e tests for #104/#105/#106). Claude review brief follows.
