### PR TITLE
fix(apps-intranet): batch 4b — shipping ship-to/ship-from [#109-112, 118, 137]

### DIFF
--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
@@ -7,6 +7,7 @@ namespace Tests.E2E.Objects
 {
     using System.Linq;
     using Allors.Database.Domain;
+    using Allors.Database.Domain.TestPopulation;
     using Allors.E2E.Angular;
     using Allors.E2E.Angular.Html;
     using Allors.E2E.Angular.Material.Factory;
@@ -22,8 +23,21 @@ namespace Tests.E2E.Objects
         [Test]
         public async Task EditCustomerShipmentPreservesShipToContactPerson()
         {
-            var shipment = new CustomerShipments(this.Transaction).Extent()
-                .First(v => v.ExistShipToContactPerson);
+            // Build a dedicated shipment with a guaranteed ShipToContactPerson, independent of the shared
+            // population (whose single WithDefaults shipment takes its contact from a random customer that
+            // may be a B2C person with no CurrentContacts). Repoint ShipTo to a B2B customer that has a
+            // contact — done post-build via direct role assignment, not on the builder.
+            var internalOrganisation = new Organisations(this.Transaction).FindBy(this.M.Organisation.Name, "Allors BV");
+            var customer = internalOrganisation.ActiveCustomers.OfType<Organisation>().First(v => v.CurrentContacts.Any());
+
+            var shipment = new CustomerShipmentBuilder(this.Transaction).WithDefaults(internalOrganisation).Build();
+            this.Transaction.Derive();
+
+            shipment.ShipToParty = customer;
+            shipment.ShipToContactPerson = customer.CurrentContacts.First();
+            this.Transaction.Derive();
+            this.Transaction.Commit();
+
             var shipToContactPerson = shipment.ShipToContactPerson;
 
             var @class = this.M.CustomerShipment;

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/CustomerShipmentTest.cs
@@ -1,0 +1,52 @@
+// <copyright file="CustomerShipmentTest.cs" company="Allors bvba">
+// Copyright (c) Allors bvba. All rights reserved.
+// Licensed under the LGPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Tests.E2E.Objects
+{
+    using System.Linq;
+    using Allors.Database.Domain;
+    using Allors.E2E.Angular;
+    using Allors.E2E.Angular.Html;
+    using Allors.E2E.Angular.Material.Factory;
+    using Allors.E2E.Test;
+    using NUnit.Framework;
+    using Task = System.Threading.Tasks.Task;
+
+    public class CustomerShipmentTest : Test
+    {
+        [SetUp]
+        public async Task Setup() => await this.LoginAsync("jane@example.com");
+
+        [Test]
+        public async Task EditCustomerShipmentPreservesShipToContactPerson()
+        {
+            var shipment = new CustomerShipments(this.Transaction).Extent()
+                .First(v => v.ExistShipToContactPerson);
+            var shipToContactPerson = shipment.ShipToContactPerson;
+
+            var @class = this.M.CustomerShipment;
+
+            var url = this.Application.GetOverview(@class).RouteInfo.FullPath.Replace(":id", $"{shipment.Strategy.ObjectId}");
+            await this.Page.GotoAsync(url);
+            await this.Page.WaitForAngular();
+
+            var overview = new CustomershipmentOverviewPageComponent(this.AppRoot);
+            await overview.AllorsMaterialDynamicViewDetailPanelComponent.ClickAsync();
+            await this.Page.WaitForAngular();
+
+            var editForm = new CustomershipmentEditFormComponent(this.AppRoot);
+            await editForm.HandlingInstructionTextarea.SetAsync("touched to enable save");
+            await this.Page.WaitForAngular();
+
+            var saveComponent = new SaveComponent(this.AppRoot);
+            await saveComponent.SaveAsync();
+            await this.Page.WaitForAngular();
+
+            this.Transaction.Rollback();
+
+            ClassicAssert.AreEqual(shipToContactPerson, shipment.ShipToContactPerson, "ShipToContactPerson was cleared on edit/save");
+        }
+    }
+}

--- a/typescript/e2e/AppsIntranet/Tests/Custom/Domain/PurchaseReturnTest.cs
+++ b/typescript/e2e/AppsIntranet/Tests/Custom/Domain/PurchaseReturnTest.cs
@@ -55,6 +55,11 @@ namespace Tests.E2E.Objects
         {
             var before = new PurchaseReturns(this.Transaction).Extent().ToArray();
 
+            var shipToParty = new Organisations(this.Transaction)
+                .Extent()
+                .First(v => v.Name == "Allors BV")
+                .ActiveSuppliers.First();
+
             var @class = this.M.Shipment;
 
             var list = this.Application.GetList(@class);
@@ -67,6 +72,9 @@ namespace Tests.E2E.Objects
 
             var form = new PurchasereturnCreateFormComponent(this.OverlayContainer);
 
+            await form.ShipToPartyAutocomplete.SelectAsync(shipToParty.DisplayName);
+            await this.Page.WaitForAngular();
+
             var saveComponent = new Button(form, "text=SAVE");
             await saveComponent.ClickAsync();
 
@@ -78,7 +86,9 @@ namespace Tests.E2E.Objects
 
             ClassicAssert.AreEqual(before.Length + 1, after.Length);
 
-            //var productType = after.Except(before).First();
+            var purchaseReturn = after.Except(before).First();
+
+            ClassicAssert.AreEqual(shipToParty, purchaseReturn.ShipToParty);
         }
     }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/create/customershipment-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/create/customershipment-create-form.component.ts
@@ -261,7 +261,7 @@ export class CustomerShipmentCreateFormComponent extends AllorsFormComponent<Cus
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
@@ -266,7 +266,7 @@ export class CustomerShipmentEditFormComponent extends AllorsFormComponent<Custo
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(m.Party.CurrentContacts);
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/customershipment/edit/customershipment-edit-form.component.ts
@@ -130,6 +130,7 @@ export class CustomerShipmentEditFormComponent extends AllorsFormComponent<Custo
     );
 
     if (this.object.ShipToParty) {
+      this.previousShipToparty = this.object.ShipToParty;
       this.updateShipToParty(this.object.ShipToParty);
     }
 

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
@@ -458,7 +458,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
 
     this.allors.context.pull(pulls).subscribe((loaded) => {
       if (this.object.ShipToCustomer !== this.previousShipToCustomer) {
-        this.object.AssignedShipToEndCustomerAddress = null;
+        this.object.AssignedShipToCustomerAddress = null;
         this.object.ShipToCustomerContactPerson = null;
         this.previousShipToCustomer = this.object.ShipToCustomer;
       }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
@@ -479,7 +479,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
 
     this.allors.context.pull(pulls).subscribe((loaded) => {
       if (this.object.ShipToCustomer !== this.previousShipToCustomer) {
-        this.object.AssignedShipToEndCustomerAddress = null;
+        this.object.AssignedShipToCustomerAddress = null;
         this.object.ShipToCustomerContactPerson = null;
         this.previousShipToCustomer = this.object.ShipToCustomer;
       }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/create/purchasereturn-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/create/purchasereturn-create-form.component.ts
@@ -218,7 +218,9 @@ export class PurchaseReturnCreateFormComponent extends AllorsFormComponent<Purch
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(
+        m.Party.CurrentContacts
+      );
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
@@ -260,7 +260,9 @@ export class PurchaseReturnEditFormComponent extends AllorsFormComponent<Purchas
         ?.map(
           (v: PartyContactMechanism) => v.ContactMechanism
         ) as PostalAddress[];
-      this.shipToContacts = loaded.collection<Person>(m.Party.CurrentContacts);
+      this.shipFromContacts = loaded.collection<Person>(
+        m.Party.CurrentContacts
+      );
     });
   }
 }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchasereturn/edit/purchasereturn-edit-form.component.ts
@@ -123,6 +123,7 @@ export class PurchaseReturnEditFormComponent extends AllorsFormComponent<Purchas
     );
 
     if (this.object.ShipToParty) {
+      this.previousShipToparty = this.object.ShipToParty;
       this.updateShipToParty(this.object.ShipToParty);
     }
 


### PR DESCRIPTION
**Batch 4b** — `apps-intranet` shipping: ship-to / ship-from address & contact handling on customershipment / purchasereturn / purchaseinvoice forms. Cherry-picked (`-x`); CHANGELOG auto-unioned.

| Fix | Ref | Commit |
|-----|-----|--------|
| shipFromContacts in customershipment updateShipFromParty | #109 | `1b2cbfc647` |
| stop clearing ShipTo address/contact on load `[BUG-16/D3]` | #110 | `d7d8fe64ea` |
| bind ship-from contacts in purchasereturn `[BUG-17/32]` | #111 | `e373fc124d` |
| clear ShipToCustomer's own address on change `[BUG-15/27]` | #112 | `e8abdc22ed` |
| test: self-contained CustomerShipment e2e | #118 | `fa40a74afd` |
| test: optional field in CreatePurchaseReturnMaximal `[BUG-19]` | #137 | `e4615d340f` |

Gated by the required `CiTypescriptWorkspacesE2EAngularAppsIntranetTest` (+ added e2e tests). Claude review brief follows.
