### PR TITLE
fix(apps-intranet): batch 4c — purchasing: VAT-on-net, add-card wiring, workeffort, currency [#113/115/116/123/124]

### DIFF
--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.html
@@ -283,7 +283,7 @@
           <person-inline
             (cancelled)="addShipToCustomerContactPerson = false"
             (saved)="
-              billedFromContactPersonAdded($event);
+              shipToCustomerContactPersonAdded($event);
               addShipToCustomerContactPerson = false
             "
           >
@@ -318,7 +318,7 @@
       </div>
     </div>
     <div class="col-md-12">
-      <mat-card *ngIf="addShipToCustomer">
+      <mat-card *ngIf="addBillToEndCustomer">
         <mat-card-header>Add a new customer</mat-card-header>
         <mat-card-content>
           <party-party
@@ -471,7 +471,7 @@
         <mat-card-content>
           <party-party
             (saved)="
-              billToEndCustomerAdded($event); addShipToEndCustomer = false
+              shipToEndCustomerAdded($event); addShipToEndCustomer = false
             "
             (cancelled)="addShipToEndCustomer = false"
           >

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/create/purchaseinvoice-create-form.component.ts
@@ -260,7 +260,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .BilledFrom as Organisation;
+      .ShipToCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.shipToCustomerContacts.push(person);
@@ -273,7 +273,7 @@ export class PurchaseInvoiceCreateFormComponent extends AllorsFormComponent<Purc
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .ShipToEndCustomer as Organisation;
+      .BillToEndCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.billToEndCustomerContacts.push(person);

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.html
@@ -294,7 +294,7 @@
               <person-inline
                 (cancelled)="addShipToCustomerContactPerson = false"
                 (saved)="
-                  billedFromContactPersonAdded($event);
+                  shipToCustomerContactPersonAdded($event);
                   addShipToCustomerContactPerson = false
                 "
               >
@@ -329,7 +329,7 @@
           </div>
         </div>
         <div class="col-md-12">
-          <mat-card *ngIf="addShipToCustomer">
+          <mat-card *ngIf="addBillToEndCustomer">
             <mat-card-header>Add a new customer</mat-card-header>
             <mat-card-content>
               <party-party
@@ -489,7 +489,7 @@
             <mat-card-content>
               <party-party
                 (saved)="
-                  billToEndCustomerAdded($event); addShipToEndCustomer = false
+                  shipToEndCustomerAdded($event); addShipToEndCustomer = false
                 "
                 (cancelled)="addShipToEndCustomer = false"
               >

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/edit/purchaseinvoice-edit-form.component.ts
@@ -287,7 +287,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .BilledFrom as Organisation;
+      .ShipToCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.shipToCustomerContacts.push(person);
@@ -300,7 +300,7 @@ export class PurchaseInvoiceEditFormComponent extends AllorsFormComponent<Purcha
         this.m.OrganisationContactRelationship
       );
     organisationContactRelationship.Organisation = this.object
-      .ShipToEndCustomer as Organisation;
+      .BillToEndCustomer as Organisation;
     organisationContactRelationship.Contact = person;
 
     this.billToEndCustomerContacts.push(person);

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/supplieroffering/form/supplieroffering-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/supplieroffering/form/supplieroffering-form.component.ts
@@ -145,7 +145,10 @@ export class SupplierOfferingFormComponent extends AllorsFormComponent<SupplierO
   }
 
   public currencySelected(currency: IObject) {
-    if (this.supplierIsNew || this.object.Supplier?.PreferredCurrency == null) {
+    if (
+      this.object.Supplier &&
+      (this.supplierIsNew || this.object.Supplier.PreferredCurrency == null)
+    ) {
       this.object.Supplier.PreferredCurrency = currency as Currency;
     }
   }

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/workeffortpoiassignment/form/workeffortpoiassignment-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/workeffortpoiassignment/form/workeffortpoiassignment-form.component.ts
@@ -86,6 +86,16 @@ export class WorkEffortPurchaseOrderItemAssignmentFormComponent extends AllorsFo
       ? pullResult.object('_object')
       : this.context.create(this.createRequest.objectType);
 
+    if (this.createRequest) {
+      this.workEffort = pullResult.object<WorkEffort>(this.m.WorkEffort);
+
+      this.object.Assignment = this.workEffort;
+      this.object.Quantity = 1;
+    } else {
+      this.selectedPurchaseOrder = this.object.PurchaseOrder;
+      this.workEffort = this.object.Assignment;
+    }
+
     const purchaseOrders = pullResult.collection<PurchaseOrder>(
       this.m.PurchaseOrder
     );
@@ -100,15 +110,7 @@ export class WorkEffortPurchaseOrderItemAssignmentFormComponent extends AllorsFo
       )
     );
 
-    if (this.createRequest) {
-      this.workEffort = pullResult.object<WorkEffort>(this.m.WorkEffort);
-
-      this.object.Assignment = this.workEffort;
-      this.object.Quantity = 1;
-    } else {
-      this.selectedPurchaseOrder = this.object.PurchaseOrder;
-      this.workEffort = this.object.Assignment;
-
+    if (this.editRequest) {
       this.purchaseOrders.push(this.selectedPurchaseOrder);
       this.purchaseOrderSelected(this.selectedPurchaseOrder);
     }

--- a/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-invoice-item-total-inc-vat.rule.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-invoice-item-total-inc-vat.rule.ts
@@ -64,7 +64,10 @@ export class PurchaseInvoiceItemTotalIncVatRule
             ? (unitBasePrice * parseFloat(v.Percentage)) / 100
             : parseFloat(v.Amount ?? '0');
       });
-      unitVat = (unitBasePrice * parseFloat(vatRate?.Rate ?? '0')) / 100;
+      unitVat =
+        ((unitBasePrice - unitDiscount + unitSurcharge) *
+          parseFloat(vatRate?.Rate ?? '0')) /
+        100;
     }
 
     const unitPrice = unitBasePrice - unitDiscount + unitSurcharge;

--- a/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-order-item-total-inc-vat.rule.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/purchase-order-item-total-inc-vat.rule.ts
@@ -65,7 +65,10 @@ export class PurchaseOrderItemTotalIncVatRule
             : parseFloat(v.Amount ?? '0');
       });
 
-      unitVat = (unitBasePrice * parseFloat(vatRate?.Rate ?? '0')) / 100;
+      unitVat =
+        ((unitBasePrice - unitDiscount + unitSurcharge) *
+          parseFloat(vatRate?.Rate ?? '0')) /
+        100;
     }
 
     const unitPrice = unitBasePrice - unitDiscount + unitSurcharge;


### PR DESCRIPTION
**Batch 4c** — `apps-intranet` purchasing/VAT (highest-attention batch: financial logic + the multi-bug #113). Cherry-picked (`-x`); CHANGELOG auto-unioned.

| Fix | Ref | Commit |
|-----|-----|--------|
| establish workEffort before the purchaseOrders filter `[BUG-22]` | #115 | `091ec20557` |
| purchaseinvoice add-card wiring + contact-org party `[BUG-13/14/25/26/28/31 + D4/D5]` | #113 | `cc666f8014` |
| guard currencySelected vs missing Supplier `[BUG-29]` | #116 | `ffd3971178` |
| purchase-invoice-item VAT on **net** unit price `[BUG-04]` | #123 | `026c7717a0` |
| purchase-order-item VAT on **net** unit price `[BUG-05]` | #124 | `5119245611`→`49ed2c7e99` |

⚠️ Touches the purchaseinvoice forms that **#250 (4b)** also edits — different lines, should auto-merge, but the second of {4b,4c} to merge may need a trivial rebase. Gated by required intranet e2e. Claude review brief follows.
