### PR TITLE
fix(apps-intranet): batch 4d — lists, sorters & display (12 fixes)

### DIFF
--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/display.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/display.service.ts
@@ -541,7 +541,10 @@ export class AppDisplayService implements DisplayService {
   }
 
   description(objectType: Composite): RoleType {
-    return this.nameByObjectType.get(objectType);
+    return (
+      this.descriptionByObjectType.get(objectType) ??
+      this.nameByObjectType.get(objectType)
+    );
   }
 
   primary(objectType: Composite): RoleType[] {

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
@@ -180,9 +180,7 @@ export class AppSorterService implements SorterService {
     define(
       m.ProductCategory,
       new Sorter({
-        name: m.Catalogue.Name,
-        description: m.Catalogue.Description,
-        scope: m.Scope.Name,
+        name: m.ProductCategory.Name,
       })
     );
 
@@ -334,7 +332,7 @@ export class AppSorterService implements SorterService {
       new Sorter({
         number: [m.WorkRequirement.SortableRequirementNumber],
         state: [m.WorkRequirement.RequirementStateName],
-        priority: [m.WorkRequirement.SortableRequirementNumber],
+        priority: [m.WorkRequirement.PriorityName],
         equipment: [m.WorkRequirement.FixedAssetName],
         location: [m.WorkRequirement.Location],
         lastModifiedDate: m.WorkRequirement.LastModifiedDate,

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/app/services/sorter.service.ts
@@ -276,7 +276,7 @@ export class AppSorterService implements SorterService {
     );
 
     define(
-      m.SerialisedItemCharacteristic,
+      m.SerialisedItemCharacteristicType,
       new Sorter({
         name: m.SerialisedItemCharacteristicType.Name,
         uom: m.UnitOfMeasure.Name,

--- a/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/environments/environment.prod.ts
+++ b/typescript/modules/apps/apps-intranet/workspace/angular-material-app/src/environments/environment.prod.ts
@@ -46,7 +46,12 @@ export const environment = {
     {
       provide: APP_INITIALIZER,
       useFactory: appInitFactory,
-      deps: [WorkspaceService, HttpClient],
+      deps: [
+        WorkspaceService,
+        HttpClient,
+        AllorsMaterialCreateService,
+        AllorsMaterialEditDialogService,
+      ],
       multi: true,
     },
   ],

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/emailcommunication/form/emailcommunication-form.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/emailcommunication/form/emailcommunication-form.component.ts
@@ -254,7 +254,7 @@ export class EmailCommunicationFormComponent extends AllorsFormComponent<EmailCo
     const emailAddress = partyContactMechanism.ContactMechanism as EmailAddress;
 
     this.toEmails.push(emailAddress);
-    this.object.FromEmail = emailAddress;
+    this.object.ToEmail = emailAddress;
   }
 
   public fromPartyAdded(fromParty: Person): void {

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/list/nonunifiedpart-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/nonunifiedpart/list/nonunifiedpart-list-page.component.ts
@@ -283,6 +283,7 @@ export class NonUnifiedPartListPageComponent implements OnInit, OnDestroy {
             object: v,
             name: v.Name,
             partNo: v.ProductNumber,
+            type: v.ProductTypeName,
             qoh: v.QuantityOnHand,
             localQoh:
               facilitySearchId &&

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/proposal/list/proposal-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/proposal/list/proposal-list-page.component.ts
@@ -101,8 +101,6 @@ export class ProposalListPageComponent
         { name: 'number', sort: true },
         { name: 'to' },
         { name: 'state' },
-        { name: 'origin', sort: true },
-        { name: 'destination', sort: true },
         { name: 'description', sort: true },
         { name: 'validThroughDate', sort: true },
         { name: 'lastModifiedDate', sort: true },

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/summary/purchaseinvoice-summary-panel.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseinvoice/summary/purchaseinvoice-summary-panel.component.html
@@ -30,7 +30,7 @@
       *ngIf="
         invoice.ShipToCustomer && invoice.ShipToCustomer !== invoice.BilledTo
       "
-      (click)="navigation.overview(invoice.BilledFrom)"
+      (click)="navigation.overview(invoice.ShipToCustomer)"
       style="cursor: pointer"
     >
       <div style="color: grey">ship to</div>
@@ -41,7 +41,7 @@
 
     <div
       *ngIf="invoice.BillToEndCustomer"
-      (click)="navigation.overview(invoice.BilledFrom)"
+      (click)="navigation.overview(invoice.BillToEndCustomer)"
       style="cursor: pointer"
     >
       <div style="color: grey">Bill to End Customer</div>

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseorder/list/purchaseorder-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/purchaseorder/list/purchaseorder-list-page.component.ts
@@ -244,7 +244,7 @@ export class PurchaseOrderListPageComponent implements OnInit, OnDestroy {
                 v.PurchaseOrderShipmentState &&
                 v.PurchaseOrderShipmentState.Name
               }`,
-              customerReference: `${v.Description || ''}`,
+              customerReference: `${v.CustomerReference || ''}`,
               invoice: v.PurchaseInvoicesWherePurchaseOrder?.map(
                 (w) => w.InvoiceNumber
               ).join(', '),

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/create/salesinvoice-create-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/create/salesinvoice-create-form.component.html
@@ -423,7 +423,7 @@
           [roleType]="m.SalesInvoice.BillToEndCustomer"
           [filter]="customersFilter.create(allors.context)"
           display="DisplayName"
-          (changed)="billToCustomerSelected($event)"
+          (changed)="billToEndCustomerSelected($event)"
           label="Bill to end customer"
         ></a-mat-autocomplete>
         <button

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/edit/salesinvoice-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesinvoice/edit/salesinvoice-edit-form.component.html
@@ -430,7 +430,7 @@
               [roleType]="m.SalesInvoice.BillToEndCustomer"
               [filter]="customersFilter.create(allors.context)"
               display="DisplayName"
-              (changed)="billToCustomerSelected($event)"
+              (changed)="billToEndCustomerSelected($event)"
               label="Bill to end customer"
             ></a-mat-autocomplete>
             <button

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesorder/edit/salesorder-edit-form.component.html
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/salesorder/edit/salesorder-edit-form.component.html
@@ -494,7 +494,7 @@
               [roleType]="m.SalesOrder.BillToEndCustomer"
               [filter]="customersFilter.create(allors.context)"
               display="DisplayName"
-              (changed)="billToCustomerSelected($event)"
+              (changed)="billToEndCustomerSelected($event)"
               label="Bill to end customer"
             ></a-mat-autocomplete>
             <button

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditem/list/serialiseditem-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditem/list/serialiseditem-list-page.component.ts
@@ -138,7 +138,7 @@ export class SerialisedItemListPageComponent implements OnInit, OnDestroy {
               pull.SerialisedItem({
                 predicate: this.filter.definition.predicate,
                 sorting: sort
-                  ? this.sorterService.sorter(m.Brand)?.create(sort)
+                  ? this.sorterService.sorter(m.SerialisedItem)?.create(sort)
                   : null,
                 arguments: this.filter.parameters(filterFields),
                 skip: pageEvent.pageIndex * pageEvent.pageSize,

--- a/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditemcharacteristictype/list/serialiseditemcharacteristic-list-page.component.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/angular-material/src/lib/domain/serialiseditemcharacteristictype/list/serialiseditemcharacteristic-list-page.component.ts
@@ -136,7 +136,9 @@ export class SerialisedItemCharacteristicListPageComponent
               pull.SerialisedItemCharacteristicType({
                 predicate: this.filter.definition.predicate,
                 sorting: sort
-                  ? this.sorterService.sorter(m.Brand)?.create(sort)
+                  ? this.sorterService
+                      .sorter(m.SerialisedItemCharacteristicType)
+                      ?.create(sort)
                   : null,
                 include: {
                   UnitOfMeasure: x,

--- a/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/party-display-phone.rule.ts
+++ b/typescript/modules/libs/apps-intranet/workspace/derivations/src/lib/rules/party-display-phone.rule.ts
@@ -40,7 +40,7 @@ export class PartyDisplayPhoneRule implements IRule<Party> {
             v.ContactMechanism as TelecommunicationsNumber;
           return telecommunicationsNumber.DisplayName;
         })
-        .reduce((acc: string, cur: string) => acc + ', ' + cur, '');
+        .join(', ');
     }
 
     return '';


### PR DESCRIPTION
**Batch 4d** — `apps-intranet` lists / sorters / display (largest but lowest-risk: read-side, wiring, config). 12 fixes cherry-picked (`-x`); CHANGELOG auto-unioned.

Wrong-field/handler/type/target corrections + formatting + column populate/drop:
- `#101` prod APP_INITIALIZER deps (verified pattern) · `#108` bill-to-end-customer autocomplete → `billToEndCustomerSelected` · `#114` added To-email → `ToEmail` (was FromEmail) `[BUG-08/09]`
- `#125` DisplayPhone `.join(', ')` (was reduce with leading separator) `[BUG-16]`
- `#127` ProductCategory/WorkRequirement sorter role types `[BUG-02/10]` · `#128` serialised-item sorts by SerialisedItem (not Brand) `[BUG-06]` · `#129` product-characteristic sorts by its own type `[BUG-07/15]`
- `#130` PO list shows CustomerReference (not Description) `[BUG-03]` · `#131` populate non-unified-part type column `[BUG-11]` · `#132` drop proposal list's empty columns `[BUG-12]`
- `#134` PI summary cards navigate to their own party (not BilledFrom) `[BUG-13]` · `#135` DisplayService.description() reads descriptionByObjectType `[BUG-09]`

Gated by required intranet e2e. Claude review brief follows.
